### PR TITLE
Initial travis-ci integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,13 +25,13 @@ matrix:
     include:
         # pep8 check (only once, i.e. "os: linux")
         - os: linux
-          env: PYTHON_VERSION=3.5 MAIN_CMD='pep8 --first --count'
+          env: PYTHON_VERSION=3.5 MAIN_CMD='pep8 --count'
                SETUP_CMD='jwst' TEST_CMD='pep8 --version'
                CONDA_DEPENDENCIES=$CONDA_JWST_DEPENDENCIES
 
     allow_failures:
         # pep8 will fail for numerous reasons. Ignore it.
-        - env: PYTHON_VERSION=3.5 MAIN_CMD='pep8 --first --count'
+        - env: PYTHON_VERSION=3.5 MAIN_CMD='pep8 --count'
                SETUP_CMD='jwst' TEST_CMD='pep8 --version'
                CONDA_DEPENDENCIES=$CONDA_JWST_DEPENDENCIES
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,45 @@
+language: c
+
+os:
+    - linux
+    - osx
+
+sudo: false
+
+env:
+    # CONDA_JWST_DEPENDENCIES is used because CONDA_DEPENDENCIES is not truly global.
+    global:
+        - MAIN_CMD='python setup.py'
+        - CONDA_CHANNELS='http://ssb.stsci.edu/conda-dev'
+        - CONDA_DEPENDENCIES='pytest nose stsci-jwst'
+        - CONDA_JWST_DEPENDENCIES='pytest nose stsci-jwst'
+        - PIP_DEPENDENCIES=''
+
+    # SETUP_CMD='test' is unreliable under 2.7; using 'nosetests' for consistency.
+    matrix:
+        - PYTHON_VERSION=2.7 SETUP_CMD='install'
+        - PYTHON_VERSION=2.7 SETUP_CMD='nosetests'
+        - PYTHON_VERSION=3.5 SETUP_CMD='install'
+        - PYTHON_VERSION=3.5 SETUP_CMD='nosetests'
+
+matrix:
+    include:
+        # pep8 check (only once, i.e. "os: linux")
+        - os: linux
+          env: PYTHON_VERSION=3.5 MAIN_CMD='pep8 --first --count'
+               SETUP_CMD='jwst' TEST_CMD='pep8 --version'
+               CONDA_DEPENDENCIES=$CONDA_JWST_DEPENDENCIES
+
+    allow_failures:
+        # pep8 will fail for numerous reasons. Ignore it.
+        - env: PYTHON_VERSION=3.5 MAIN_CMD='pep8 --first --count'
+               SETUP_CMD='jwst' TEST_CMD='pep8 --version'
+               CONDA_DEPENDENCIES=$CONDA_JWST_DEPENDENCIES
+
+install:
+    - git clone git://github.com/astropy/ci-helpers.git
+    - source ci-helpers/travis/setup_conda_$TRAVIS_OS_NAME.sh
+
+script:
+    - $MAIN_CMD $SETUP_CMD
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,16 +11,16 @@ env:
     global:
         - MAIN_CMD='python setup.py'
         - CONDA_CHANNELS='http://ssb.stsci.edu/conda-dev'
-        - CONDA_DEPENDENCIES='pytest nose stsci-jwst'
-        - CONDA_JWST_DEPENDENCIES='pytest nose stsci-jwst'
+        - CONDA_DEPENDENCIES='pytest stsci-jwst'
+        - CONDA_JWST_DEPENDENCIES='pytest stsci-jwst'
         - PIP_DEPENDENCIES=''
 
     # SETUP_CMD='test' is unreliable under 2.7; using 'nosetests' for consistency.
     matrix:
         - PYTHON_VERSION=2.7 SETUP_CMD='install'
-        - PYTHON_VERSION=2.7 SETUP_CMD='nosetests'
+        - PYTHON_VERSION=2.7 SETUP_CMD='test'
         - PYTHON_VERSION=3.5 SETUP_CMD='install'
-        - PYTHON_VERSION=3.5 SETUP_CMD='nosetests'
+        - PYTHON_VERSION=3.5 SETUP_CMD='test'
 
 matrix:
     include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ env:
         - CONDA_JWST_DEPENDENCIES='pytest stsci-jwst'
         - PIP_DEPENDENCIES=''
 
-    # SETUP_CMD='test' is unreliable under 2.7; using 'nosetests' for consistency.
     matrix:
         - PYTHON_VERSION=2.7 SETUP_CMD='install'
         - PYTHON_VERSION=2.7 SETUP_CMD='test'

--- a/README.md
+++ b/README.md
@@ -9,3 +9,8 @@ TODO
 # Using (etc...)
 
 TODO
+
+# Project Status
+
+[![Build Status](https://travis-ci.org/stsci-jwst/jwst.svg?branch=master)](https://travis-ci.org/stsci-jwst/jwst)
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,14 @@
+[pep8]
+# E101 - mix of tabs and spaces
+# W191 - use of tabs
+# W291 - trailing whitespace
+# W292 - no newline at end of file
+# W293 - trailing whitespace
+# W391 - blank line at end of file
+# E111 - 4 spaces per indentation level
+# E112 - 4 spaces per indentation level
+# E113 - 4 spaces per indentation level
+# E901 - SyntaxError or IndentationError
+# E902 - IOError
+select = E101,W191,W291,W292,W293,W391,E111,E112,E113,E901,E902
+exclude = extern,sphinx,*parsetab.py


### PR DESCRIPTION
For OSX and Linux this config does the following... 

1. Checks the package installation
2. Runs unit tests
3. Reports pep8 code violations

I had to tell pep8 to report only the first occurrence of an issue, because there are >13,000 and travis limits output to 10,000 lines.

I've tested this travis configuration extensively on my fork and I believe it's good to go. The only errors I'm seeing are "real ones". :smile: 
