### PR TITLE
Fix relative imports in stpipe

### DIFF
--- a/jwst/stpipe/tests/steps/__init__.py
+++ b/jwst/stpipe/tests/steps/__init__.py
@@ -1,5 +1,5 @@
 from jwst.stpipe import Step
-from .. import datamodels
+from .... import datamodels
 
 class AnotherDummyStep(Step):
     """

--- a/jwst/stpipe/tests/steps/python_pipeline.cfg
+++ b/jwst/stpipe/tests/steps/python_pipeline.cfg
@@ -4,7 +4,7 @@
 # Name is a string set to whatever you want to call your pipeline. It
 # is used to identify the pipeline in the logs.
 name = "TestPipeline"
-class = "jwst_lib.stpipe.tests.test_pipeline.TestPipeline"
+class = "jwst.stpipe.tests.test_pipeline.TestPipeline"
 
 science_filename = "../data/science.fits"
 output_filename = "DUMMY"

--- a/jwst/stpipe/tests/steps/some_other_step.cfg
+++ b/jwst/stpipe/tests/steps/some_other_step.cfg
@@ -1,4 +1,4 @@
-class = "jwst_lib.stpipe.tests.steps.AnotherDummyStep"
+class = "jwst.stpipe.tests.steps.AnotherDummyStep"
 name = "SomeOtherStepOriginal"
 
 par1 = 10.3456789

--- a/jwst/stpipe/tests/test_crds.py
+++ b/jwst/stpipe/tests/test_crds.py
@@ -29,7 +29,7 @@ class CrdsStep(Step):
     reference_file_types = ['flat']
 
     def process(self, input_file):
-        from .. import datamodels
+        from ... import datamodels
 
         with models.open(input_file) as dm:
             self.ref_filename = self.get_reference_file(dm, 'flat')
@@ -46,7 +46,7 @@ def test_crds_step_bad():
     _run_flat_fetch_on_dataset('data/crds_bad.fits')
 
 def _run_flat_fetch_on_dataset(dataset_path):
-    from .. import datamodels
+    from ... import datamodels
     step = CrdsStep()
     with models.ImageModel(join(dirname(__file__), dataset_path))  as input_file:
         step.run(input_file)
@@ -55,7 +55,7 @@ def _run_flat_fetch_on_dataset(dataset_path):
 
 def test_crds_step_override():
     """Run CRDS step with override parameter bypassing CRDS lookup."""
-    from .. import datamodels
+    from ... import datamodels
 
     step = CrdsStep(override_flat=join(dirname(__file__), 'data/flat.fits'))
     with models.ImageModel(join(dirname(__file__), 'data/crds.fits')) as input_file:

--- a/jwst/stpipe/tests/test_pipeline.py
+++ b/jwst/stpipe/tests/test_pipeline.py
@@ -24,7 +24,7 @@ class FlatField(Step):
     # Load the spec from a file
 
     def process(self, science, flat):
-        from .. import datamodels
+        from ... import datamodels
 
         self.log.info("Removing flat field")
         self.log.info("Threshold: {0}".format(self.threshold))
@@ -40,7 +40,7 @@ class Combine(Step):
     """
 
     def process(self, images):
-        from .. import datamodels
+        from ... import datamodels
 
         combined = np.zeros((50, 50))
         for image in images:
@@ -63,7 +63,7 @@ class MultiplyBy2(Step):
     """
 
     def process(self, image):
-        from .. import datamodels
+        from ... import datamodels
 
         with models.ImageModel(image) as dm:
             with models.ImageModel() as dm2:
@@ -89,7 +89,7 @@ class TestPipeline(Pipeline):
     """
 
     def process(self, *args):
-        from .. import datamodels
+        from ... import datamodels
 
         science = models.open(self.science_filename)
         if self.flat_filename is None:
@@ -171,7 +171,7 @@ def test_pipeline_commandline():
 
 def test_pipeline_commandline_class():
     args = [
-        'jwst..stpipe.tests.test_pipeline.TestPipeline',
+        'jwst.stpipe.tests.test_pipeline.TestPipeline',
         '--logcfg={0}'.format(
             abspath(join(dirname(__file__), 'steps', 'log.cfg'))),
         # The file_name parameters are *required*
@@ -194,7 +194,7 @@ def test_pipeline_commandline_invalid_args():
     from io import StringIO
 
     args = [
-        'jwst..stpipe.tests.test_pipeline.TestPipeline',
+        'jwst.stpipe.tests.test_pipeline.TestPipeline',
         # The file_name parameters are *required*, and one of them
         # is missing, so we should get a message to that effect
         # followed by the commandline usage message.

--- a/jwst/stpipe/tests/test_step.py
+++ b/jwst/stpipe/tests/test_step.py
@@ -110,7 +110,7 @@ def test_step_from_commandline_class():
     from .. import Step
 
     args = [
-        'jwst..stpipe.tests.steps.AnotherDummyStep',
+        'jwst.stpipe.tests.steps.AnotherDummyStep',
         '--par1=58', '--par2=hij klm'
         ]
 
@@ -198,7 +198,7 @@ def test_extra_parameter():
 
 def test_crds_override():
     from .steps import AnotherDummyStep
-    from .. import datamodels
+    from ... import datamodels
 
     step = AnotherDummyStep(
         "SomeOtherStepOriginal",
@@ -223,7 +223,7 @@ def test_save_model():
     shutil.copyfile(orig_filename, temp_filename)
 
     args = [
-        'jwst..stpipe.tests.steps.SaveStep',
+        'jwst.stpipe.tests.steps.SaveStep',
         temp_filename
     ]
 


### PR DESCRIPTION
- The depth of the `stpipe` testing sub-package could not resolve `from .. import datamodels`
- Discovered a few more `jwst_` references