### PR TITLE
Add pytest hook for setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,12 +6,21 @@ from setuptools.command.test import test as TestCommand
 from numpy import get_include as np_include
 from glob import glob
 
+NAME='jwst'
+SCRIPTS=glob('scripts/*')
+PACKAGE_DATA={
+    '': ['*.fits',
+        '*.txt',
+        '*.inc',
+        '*.json',
+        '*.cfg']
+}
 
 class PyTest(TestCommand):
 
     def initialize_options(self):
         TestCommand.initialize_options(self)
-        self.pytest_args = []
+        self.pytest_args = [NAME]
 
     def finalize_options(self):
         TestCommand.finalize_options(self)
@@ -49,19 +58,11 @@ else:
 
 
 version = relic.release.get_info()
-relic.release.write_template(version, 'jwst/')
+relic.release.write_template(version, NAME)
 
-SCRIPTS=glob('scripts/*')
-PACKAGE_DATA={
-    '': ['*.fits',
-        '*.txt',
-        '*.inc',
-        '*.json',
-        '*.cfg']
-}
 
 setup(
-    name='jwst',
+    name=NAME,
     version=version.pep386,
     author='OED/SSB, etc',
     author_email='help@stsci.edu',

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,33 @@ import os
 import subprocess
 import sys
 from setuptools import setup, find_packages, Extension
+from setuptools.command.test import test as TestCommand
 from numpy import get_include as np_include
 from glob import glob
+
+
+class PyTest(TestCommand):
+
+    def initialize_options(self):
+        TestCommand.initialize_options(self)
+        self.pytest_args = []
+
+    def finalize_options(self):
+        TestCommand.finalize_options(self)
+        self.test_args = []
+        self.test_suite = True
+
+    def run_tests(self):
+        try:
+            import pytest
+        except ImportError:
+            print('Unable to run tests...')
+            print('To continue, please install "pytest":')
+            print('    pip install pytest')
+            exit(1)
+
+        errno = pytest.main(self.pytest_args)
+        sys.exit(errno)
 
 
 if os.path.exists('relic'):
@@ -26,10 +51,9 @@ else:
 version = relic.release.get_info()
 relic.release.write_template(version, 'jwst/')
 
-
 SCRIPTS=glob('scripts/*')
 PACKAGE_DATA={
-    '': ['*.fits', 
+    '': ['*.fits',
         '*.txt',
         '*.inc',
         '*.json',
@@ -59,5 +83,10 @@ setup(
             include_dirs=[np_include()],
             define_macros=[('NUMPY','1')]),
     ],
+    tests_require=[
+        'pytest'
+    ],
+    cmdclass={
+        'test': PyTest
+    },
 )
-    


### PR DESCRIPTION
Travis is running `python setup.py test` to start its testing. This change tells setuptools to use `pytest` rather than the default, `unittest`.

Misc: fixed whitespace