### PR TITLE
Fixed a couple tests

### DIFF
--- a/jwst/datamodels/tests/test_fits.py
+++ b/jwst/datamodels/tests/test_fits.py
@@ -171,13 +171,13 @@ def test_extra_fits():
 
     with DataModel(path) as dm:
         assert 'BITPIX' not in _header_to_dict(dm.extra_fits.PRIMARY.header)
-        assert _header_to_dict(dm.extra_fits.PRIMARY.header)['CORONMSK'] == 'MASKSWB'
+        assert _header_to_dict(dm.extra_fits.PRIMARY.header)['SCIYSTRT'] == 705
         dm2 = dm.copy()
         dm2.to_fits(TMP_FITS, clobber=True)
 
     with DataModel(TMP_FITS) as dm3:
         assert 'BITPIX' not in _header_to_dict(dm.extra_fits.PRIMARY.header)
-        assert _header_to_dict(dm.extra_fits.PRIMARY.header)['CORONMSK'] == 'MASKSWB'
+        assert _header_to_dict(dm.extra_fits.PRIMARY.header)['SCIYSTRT'] == 705
 
 
 def test_extra_fits_update():
@@ -187,7 +187,7 @@ def test_extra_fits_update():
         with DataModel() as dm2:
             dm2.update(dm)
             assert 'BITPIX' not in _header_to_dict(dm.extra_fits.PRIMARY.header)
-            assert _header_to_dict(dm.extra_fits.PRIMARY.header)['CORONMSK'] == '#TODO'
+            assert _header_to_dict(dm.extra_fits.PRIMARY.header)['SCIYSTRT'] == 705
 '''
 
 def test_hdu_order():

--- a/jwst/stpipe/tests/steps/python_pipeline.cfg
+++ b/jwst/stpipe/tests/steps/python_pipeline.cfg
@@ -7,7 +7,7 @@ name = "TestPipeline"
 class = "jwst.stpipe.tests.test_pipeline.TestPipeline"
 
 science_filename = "../data/science.fits"
-output_filename = "DUMMY"
+output_filename = "DUMMY.fits"
 
 [steps]
   [[flat_field]]


### PR DESCRIPTION
With regards to jwst/datamodels/test/test_fits.py, the CORONMSK keyword is now defined in the core schema and hence no longer appears in the extra_fits portion of the data model (it's part of the main meta attribute). So a new keyword ('SCIYSTRT') was chosen to replace it in this test, because it is not part of the core schema and hence appears in the extra_fits attribute of the data model.

The stpipe test was failing because the datamodels package is now able to handle different file formats (fits and asdf) and hence it needs to know what type of file is desired when specifying an output file name.