### PR TITLE
Updated calwebb_sloper and calwebb_image2

### DIFF
--- a/jwst/pipeline/__init__.py
+++ b/jwst/pipeline/__init__.py
@@ -5,5 +5,6 @@ from .calwebb_dark import DarkPipeline
 from .calwebb_image2 import Image2Pipeline
 from .calwebb_image3 import Image3Pipeline
 from .calwebb_sloper import SloperPipeline
+from .calwebb_sloper_b7 import SloperPipelineB7
 from .calwebb_spec2 import Spec2Pipeline
 from .linear_pipeline import TestLinearPipeline

--- a/jwst/pipeline/calwebb_image2.cfg
+++ b/jwst/pipeline/calwebb_image2.cfg
@@ -6,9 +6,5 @@ class = "jwst.pipeline.Image2Pipeline"
         config_file = assign_wcs.cfg
       [[flat_field]]
         config_file = flat_field.cfg
-      [[persistence]]
-        config_file = persistence.cfg
-      [[emission]]
-        config_file = emission.cfg
       [[photom]]
         config_file = photom.cfg

--- a/jwst/pipeline/calwebb_image2.py
+++ b/jwst/pipeline/calwebb_image2.py
@@ -6,12 +6,10 @@ import os
 # calwebb IMAGE2 step imports
 from ..assign_wcs import assign_wcs_step
 from ..flatfield import flat_field_step
-from ..persistence import persistence_step
-from ..emission import emission_step
 from ..photom import photom_step
 
 
-__version__ = "2.1"
+__version__ = "2.2"
 
 # Define logging
 import logging
@@ -25,15 +23,13 @@ class Image2Pipeline(Pipeline):
                    Level-2a to Level-2b.
 
     Included steps are:
-    assign_wcs, flat_field, persistence, emission, and photom.
+    assign_wcs, flat_field, and photom.
 
     """
 
     # Define alias to steps
     step_defs = {'assign_wcs': assign_wcs_step.AssignWcsStep,
                  'flat_field': flat_field_step.FlatFieldStep,
-                 'persistence': persistence_step.PersistenceStep,
-                 'emission': emission_step.EmissionStep,
                  'photom': photom_step.PhotomStep,
                  }
 
@@ -44,8 +40,6 @@ class Image2Pipeline(Pipeline):
         # work on slope images
         input = self.assign_wcs(input)
         input = self.flat_field(input)
-        input = self.persistence(input)
-        input = self.emission(input)
         input = self.photom(input)
 
         # setup output_file for saving

--- a/jwst/pipeline/calwebb_sloper_b7.cfg
+++ b/jwst/pipeline/calwebb_sloper_b7.cfg
@@ -1,0 +1,29 @@
+name = "SloperPipelineB7"
+class = "jwst.pipeline.SloperPipelineB7"
+save_calibrated_ramp = False
+
+    [steps]
+      [[dq_init]]
+        config_file = dq_init.cfg
+      [[saturation]]
+        config_file = saturation.cfg
+      [[ipc]]
+        skip = True
+      [[superbias]]
+        config_file = superbias.cfg
+      [[refpix]]
+        config_file = refpix.cfg
+      [[rscd]]
+        config_file = rscd.cfg
+      [[lastframe]]
+        config_file = lastframe.cfg
+      [[linearity]]
+        config_file = linearity.cfg
+      [[dark_current]]
+        config_file = dark_current.cfg
+      [[persistence]]
+        config_file = persistence.cfg
+      [[jump]]
+        config_file = jump.cfg
+      [[ramp_fit]]
+        config_file = ramp_fit.cfg

--- a/jwst/pipeline/calwebb_sloper_b7.py
+++ b/jwst/pipeline/calwebb_sloper_b7.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python
+from ..stpipe import Pipeline
+from .. import datamodels
+import os
+
+# step imports
+from ..dq_init import dq_init_step
+from ..saturation import saturation_step
+from ..ipc import ipc_step
+from ..superbias import superbias_step
+from ..refpix import refpix_step
+from ..rscd import rscd_step
+from ..lastframe import lastframe_step
+from ..linearity import linearity_step
+from ..dark_current import dark_current_step
+from ..persistence import persistence_step
+from ..jump import jump_step
+from ..ramp_fitting import ramp_fit_step
+
+
+__version__ = "4.0"
+
+# Define logging
+import logging
+log = logging.getLogger()
+log.setLevel(logging.DEBUG)
+
+class SloperPipelineB7(Pipeline):
+    """
+
+    SloperPipeline: Apply all calibration steps to raw JWST
+    ramps to produce a 2-D slope product. Included steps are:
+    dq_init, saturation, ipc, superbias, refpix, rscd, lastframe,
+    linearity, dark_current, persistence, jump detection, and ramp_fit.
+
+    """
+
+    spec = """
+        save_calibrated_ramp = boolean(default=False)
+    """
+
+    # Define aliases to steps
+    step_defs = {'dq_init': dq_init_step.DQInitStep,
+                 'saturation': saturation_step.SaturationStep,
+                 'ipc': ipc_step.IPCStep,
+                 'superbias': superbias_step.SuperBiasStep,
+                 'refpix': refpix_step.RefPixStep,
+                 'rscd': rscd_step.RSCD_Step,
+                 'lastframe': lastframe_step.LastFrameStep,
+                 'linearity': linearity_step.LinearityStep,
+                 'dark_current': dark_current_step.DarkCurrentStep,
+                 'persistence': persistence_step.PersistenceStep,
+                 'jump': jump_step.JumpStep,
+                 'ramp_fit': ramp_fit_step.RampFitStep,
+                 }
+
+
+    # start the actual processing
+    def process(self, input):
+
+        log.info('Starting calwebb_sloper ...')
+
+        # open the input
+        input = datamodels.open(input)
+
+        # propagate output_dir to steps that might need it
+        self.dark_current.output_dir = self.output_dir
+        self.ramp_fit.output_dir = self.output_dir
+
+        if input.meta.instrument.name == 'MIRI':
+
+            # process MIRI exposures;
+            # the steps are in a different order than NIR
+            log.debug('Processing a MIRI exposure')
+
+            input = self.dq_init(input)
+            input = self.saturation(input)
+            input = self.ipc(input)
+            input = self.linearity(input)
+            input = self.rscd(input)
+            input = self.lastframe(input)
+            input = self.dark_current(input)
+            input = self.refpix(input)
+
+        else:
+
+            # process Near-IR exposures
+            log.debug('Processing a Near-IR exposure')
+
+            input = self.dq_init(input)
+            input = self.saturation(input)
+            input = self.ipc(input)
+            input = self.superbias(input)
+            input = self.refpix(input)
+            input = self.linearity(input)
+            input = self.dark_current(input)
+
+        # apply the persistence step
+        input = self.persistence(input)
+
+        # apply the jump step
+        input = self.jump(input)
+
+        # save the corrected ramp data, if requested
+        if self.save_calibrated_ramp:
+            self.save_model(input, 'ramp')
+
+        # apply the ramp_fit step
+        input = self.ramp_fit(input)
+
+        # setup output_file for saving
+        self.setup_output(input)
+
+        log.info('... ending calwebb_sloper')
+
+        return input
+
+
+    def setup_output(self, input):
+
+        # This routine doesn't actually save the final result to a file,
+        # but just sets up the value of self.output_file appropriately.
+        # The final data model is passed back up to the caller, which can be
+        # either an interactive session or a command-line instance of stpipe.
+        # If it's an interactive session, the data model is simply returned to
+        # the user without saving to a file. If it's a command-line instance
+        # of stpipe, stpipe will save the data model to a file using the name
+        # given in self.output_file.
+
+        # first determine the proper file name suffix to use later
+        if input.meta.cal_step.ramp_fit == 'COMPLETE':
+            suffix = 'rate'
+        else:
+            suffix = 'ramp'
+
+        # Has an output file name already been set?
+        if self.output_file is not None:
+
+            # Check to see if the output_file name is the default set by
+            # stpipe for command-line processing
+            root, ext = os.path.splitext(self.output_file)
+            if root[root.rfind('_') + 1:] == 'SloperPipeline':
+
+                # Remove the step name that stpipe appended to the file name,
+                # as well as the original suffix on the input file name,
+                # and create a new name with the appropriate output suffix
+                root = root[:root.rfind('_')]
+                self.output_file = root[:root.rfind('_') + 1] + suffix + ext
+
+        # If no output name was set, take no action


### PR DESCRIPTION
As documented in Trac #336 ([https://aeon.stsci.edu/ssb/trac/jwst/ticket/336]) the calwebb_sloper pipeline needed to be updated for Build 7, in order to use a different processing order for MIRI data, as well as to move the persistence correction step from calwebb_image2 to calwebb_sloper. So that on-going use of the existing calwebb_sloper pipeline is not disrupted, I've created a new version of it for Build 7, with class name "SloperPipelineB7" and config file "calwebb_sloper_b7.cfg." Before B7 is delivered, this new version of calwebb_sloper will be renamed to take the place of the existing version.

The calwebb_image2 pipeline module has also been updated, to remove the persistence step (moving to calwebb_sloper), and the not-yet-implemented emission step. The emission step will be reinstated in B7.1 when an initial algorithm is implemented for it.