### PR TITLE
Work around for asdf code change

### DIFF
--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -31,7 +31,6 @@ from gwcs.extension import GWCSExtension
 
 jwst_extensions = [GWCSExtension(), JWSTExtension()]
 
-
 class DataModel(properties.ObjectNode):
     """
     Base class of all of the data models.
@@ -164,8 +163,9 @@ class DataModel(properties.ObjectNode):
         # if the input model doesn't have a date set, use the current date/time
         if self.meta.date is None:
             self.meta.date = Time(datetime.datetime.now())
-            self.meta.date.format = 'isot'
-            self.meta.date = self.meta.date.value
+            if hasattr(self.meta.date, 'value'):
+                self.meta.date.format = 'isot'
+                self.meta.date = str(self.meta.date.value)
 
         # if the input is from a file, set the filename attribute
         if isinstance(init, six.string_types):


### PR DESCRIPTION
I am about to deliver a change to asdf which will improve the way that
date tagging is handled. The result of the change is that complex
formats, such as dates, are stored as tagged strings. This is not a
problem, and in fact is an improvement, as that is the format that
both fits and serialized asdf want to see. However, the current
version of asdf stores dates as dates and model_base.py contains a
patch to work around the problem it causes. Because asdf and datamodel
are separatepackages I needed to add some code so that it will work
with both the old and about to be delivered version of asdf, basically
just an if statement.