### PR TITLE
Updated calwebb_sloper for new location of persistence step

### DIFF
--- a/jwst/pipeline/calwebb_sloper_b7.py
+++ b/jwst/pipeline/calwebb_sloper_b7.py
@@ -81,6 +81,7 @@ class SloperPipelineB7(Pipeline):
             input = self.lastframe(input)
             input = self.dark_current(input)
             input = self.refpix(input)
+            input = self.persistence(input)
 
         else:
 
@@ -93,10 +94,8 @@ class SloperPipelineB7(Pipeline):
             input = self.superbias(input)
             input = self.refpix(input)
             input = self.linearity(input)
+            input = self.persistence(input)
             input = self.dark_current(input)
-
-        # apply the persistence step
-        input = self.persistence(input)
 
         # apply the jump step
         input = self.jump(input)


### PR DESCRIPTION
As documented in #90 the persistence correction step needs to be between linearity and dark for NIR exposures, and following dark and refpix for MIRI exposures.