### PR TITLE
Photom updates for new NIRSpec flux cal

### DIFF
--- a/jwst/datamodels/__init__.py
+++ b/jwst/datamodels/__init__.py
@@ -62,7 +62,8 @@ from .multispec import MultiSpecModel
 from .ifucube import IFUCubeModel
 from .pixelarea import PixelAreaModel
 from .photom import PhotomModel, FgsPhotomModel, NircamPhotomModel, NirissPhotomModel
-from .photom import NirspecPhotomModel, MiriImgPhotomModel, MiriMrsPhotomModel
+from .photom import NirspecPhotomModel, NirspecFSPhotomModel
+from .photom import MiriImgPhotomModel, MiriMrsPhotomModel
 from .ramp import RampModel
 from .rampfitoutput import RampFitOutputModel
 from .readnoise import ReadnoiseModel
@@ -86,10 +87,10 @@ __all__ = [
     'ImageModel', 'IPCModel', 'IRS2Model', 'LastFrameModel', 'LinearityModel',
     'MaskModel', 'MIRIRampModel', 'ModelContainer', 'MultiSlitModel',
     'MultiSpecModel', 'IFUCubeModel', 'PhotomModel', 'NircamPhotomModel',
-    'NirissPhotomModel', 'NirspecPhotomModel', 'MiriImgPhotomModel',
-    'MiriMrsPhotomModel', 'RampModel', 'RampFitOutputModel',
-    'ReadnoiseModel', 'ResetModel', 'RSCDModel', 'SaturationModel', 'SpecModel',
-    'StrayLightModel']
+    'NirissPhotomModel', 'NirspecPhotomModel', 'NirspecFSPhotomModel',
+    'MiriImgPhotomModel', 'MiriMrsPhotomModel', 'RampModel',
+    'RampFitOutputModel', 'ReadnoiseModel', 'ResetModel', 'RSCDModel',
+    'SaturationModel', 'SpecModel', 'StrayLightModel']
 
 
 def open(init=None, extensions=None):

--- a/jwst/datamodels/photom.py
+++ b/jwst/datamodels/photom.py
@@ -66,7 +66,7 @@ class NirissPhotomModel(PhotomModel):
 
 class NirspecPhotomModel(PhotomModel):
     """
-    A data model for NIRSpec photom reference files.
+    A data model for NIRSpec imaging, IFU, and MOS photom reference files.
 
     Parameters
     ----------
@@ -82,6 +82,29 @@ class NirspecPhotomModel(PhotomModel):
 
     def __init__(self, init=None, phot_table=None, **kwargs):
         super(NirspecPhotomModel, self).__init__(init=init, **kwargs)
+
+        if phot_table is not None:
+            self.phot_table = phot_table
+
+
+class NirspecFSPhotomModel(PhotomModel):
+    """
+    A data model for NIRSpec Fixed-Slit (FS) photom reference files.
+
+    Parameters
+    ----------
+    init : any
+        Any of the initializers supported by `~jwst.datamodels.DataModel`.
+
+    phot_table : numpy array
+        A table-like object containing row selection criteria made up
+        of instrument mode parameters and photometric conversion
+        factors associated with those modes.
+    """
+    schema_url = "nirspecfs_photom.schema.yaml"
+
+    def __init__(self, init=None, phot_table=None, **kwargs):
+        super(NirspecFSPhotomModel, self).__init__(init=init, **kwargs)
 
         if phot_table is not None:
             self.phot_table = phot_table

--- a/jwst/datamodels/schemas/nirspecfs_photom.schema.yaml
+++ b/jwst/datamodels/schemas/nirspecfs_photom.schema.yaml
@@ -1,4 +1,4 @@
-title: NIRSpec Image, IFU, and MOS photometric flux conversion data model
+title: NIRSpec Fixed-Slit photometric flux conversion data model
 allOf:
 - $ref: photom.schema.yaml
 - type: object
@@ -10,6 +10,8 @@ allOf:
       - name: filter
         datatype: [ascii, 12]
       - name: grating
+        datatype: [ascii, 12]
+      - name: slit
         datatype: [ascii, 12]
       - name: photmjsr
         datatype: float32

--- a/jwst/photom/photom_step.py
+++ b/jwst/photom/photom_step.py
@@ -38,10 +38,18 @@ class PhotomStep(Step):
         area_filename = self.get_reference_file(dm, 'area')
         self.log.info('Using area reference file: %s', area_filename)
 
+        # Check for a valid photom reference file
+        if phot_filename == 'N/A':
+            self.log.warning('No PHOTOM reference file found')
+            self.log.warning('Photom step will be skipped')
+            result = dm.copy()
+            result.meta.cal_step.photom = 'SKIPPED'
+            return result
+
         # Do the correction
         ff_a = photom.DataSet(dm, phot_filename, area_filename)
-
         output_obj = ff_a.do_all()
+
         output_obj.meta.cal_step.photom = 'COMPLETE'
 
         return output_obj


### PR DESCRIPTION
The NIRSpec IDT delivered their first complete set of flux calibration (photom) reference files in their pre-CDP3 package a couple months ago (the real CDP3 is expected "any day now"). All of these reference files use a one-dimensional vector of flux cal conversion factors that are a function of wavelength. The current ref files are dummies, in that all of the conversion factors are set to 1.

The ref files for the MOS and IFU modes are relatively easily accommodated in the existing photom reference file scheme, with the only slight modification being the addition of uncertainty/error/variance values for the wavelength-dependent correction factors. Ref data for both of these modes are dependent only on the combination of filter+grating in use for an exposure. Thus the existing NirspecPhotomModel data model was updated to accommodate a new column of uncertainties for the conversion factors.

The ref files for the Fixed-Slit mode have the same content, but in addition to being dependent on the filter+grating combination for an exposure, they are also slit-dependent, where the slits correspond to one of the five available fixed slits. So a new NirspecFSPhotomModel data model has been created to accommodate these ref files, which have an extra table column for the slit name.

The photom step itself has also been updated. First, the top-level routine has been updated to check for a photom ref file of 'N/A' returned from CRDS, which will be the case for the NIRSpec Imaging mode (the imaging mode will not be flux calibrated). When the top-level photom step sees a result of 'N/A' for the photom ref file, it will issue a warning that the photom step will be skipped.

The lower-level photom module (the one that does all of the real work) has been updated to work on each slit of a MultiSlitModel input, which is necessary to handle exposures in which data for more than one fixed slit have been extracted. The step will now search for a photom table row corresponding to each slit and will then attach a RELSENS table extension containing the flux cal data for each slit.