### PR TITLE
Set default log level to DEBUG

### DIFF
--- a/jwst/extract_2d/extract_2d.py
+++ b/jwst/extract_2d/extract_2d.py
@@ -13,7 +13,7 @@ from ..assign_wcs import nirspec
 
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.INFO)
+log.setLevel(logging.DEBUG)
 
 
 def extract2d(input_model, which_subarray=None):

--- a/jwst/flatfield/flat_field.py
+++ b/jwst/flatfield/flat_field.py
@@ -10,7 +10,7 @@ from .. import datamodels
 from .. datamodels import dqflags
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.INFO)
+log.setLevel(logging.DEBUG)
 
 def do_correction(input_model, flat_model, flat_suffix=None):
     """

--- a/jwst/ipc/ipc_corr.py
+++ b/jwst/ipc/ipc_corr.py
@@ -11,7 +11,7 @@ import numpy as np
 from . import x_irs2
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.INFO)
+log.setLevel(logging.DEBUG)
 
 NumRefPixels = namedtuple("NumRefPixels",
                           ["bottom_rows", "top_rows",

--- a/jwst/saturation/saturation.py
+++ b/jwst/saturation/saturation.py
@@ -8,7 +8,7 @@ import numpy as np
 from . import x_irs2
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.INFO)
+log.setLevel(logging.DEBUG)
 
 HUGE_NUM = 100000.
 


### PR DESCRIPTION
Change the default log level in several pipeline step modules from INFO to DEBUG, so that DEBUG level messages will be passed when requested. If set to INFO in the module, no messages at a level lower than INFO will be passed even when explicitly requested by the user.