### PR TITLE
wcs python 3 tweaks

### DIFF
--- a/jwst/transforms/models.py
+++ b/jwst/transforms/models.py
@@ -506,7 +506,7 @@ class Gwa2Slit(Model):
         self.models = models
         super(Gwa2Slit, self).__init__()
 
-    def evaluate(self, quadrant, slitid,list x, y, z):
+    def evaluate(self, quadrant, slitid,istax, y, z):
         slit = int(slitid_to_slit(np.array([quadrant, slitid]).T)[0])
         return (quadrant, slitid) + self.models[slit](x, y, z)
 

--- a/jwst/transforms/models.py
+++ b/jwst/transforms/models.py
@@ -502,11 +502,11 @@ class Gwa2Slit(Model):
     outputs = ('x_slit', 'y_slit', 'lam', 'quadrant', 'slitid')
 
     def __init__(self, models):
-        self.slits = slit_to_slitid(models.keys())
+        self.slits = slit_to_slitid(list(models.keys()))
         self.models = models
         super(Gwa2Slit, self).__init__()
 
-    def evaluate(self, quadrant, slitid, x, y, z):
+    def evaluate(self, quadrant, slitid,list x, y, z):
         slit = int(slitid_to_slit(np.array([quadrant, slitid]).T)[0])
         return (quadrant, slitid) + self.models[slit](x, y, z)
 
@@ -518,7 +518,7 @@ class Slit2Msa(Model):
 
     def __init__(self, models):
         super(Slit2Msa, self).__init__()
-        self.slits = slit_to_slitid(models.keys())
+        self.slits = slit_to_slitid(list(models.keys()))
         self.models = models
 
     def evaluate(self, quadrant, slitid, x, y, lam):

--- a/jwst/transforms/models.py
+++ b/jwst/transforms/models.py
@@ -506,7 +506,7 @@ class Gwa2Slit(Model):
         self.models = models
         super(Gwa2Slit, self).__init__()
 
-    def evaluate(self, quadrant, slitid,istax, y, z):
+    def evaluate(self, quadrant, slitid, x, y, z):
         slit = int(slitid_to_slit(np.array([quadrant, slitid]).T)[0])
         return (quadrant, slitid) + self.models[slit](x, y, z)
 

--- a/jwst/transforms/tags/jwst_models.py
+++ b/jwst/transforms/tags/jwst_models.py
@@ -144,7 +144,7 @@ class Gwa2SlitType(TransformType):
     def to_tree_transform(cls, model, ctx):
         slits = []
         models = []
-        for s, m in model.models.iteritems():
+        for s, m in model.models.items():
             slits.append(s)
             models.append(m)
         node = {'slits': slits,
@@ -167,7 +167,7 @@ class Slit2MsaType(TransformType):
     def to_tree_transform(cls, model, ctx):
         slits = []
         models = []
-        for s, m in model.models.iteritems():
+        for s, m in model.models.items():
             slits.append(s)
             models.append(m)
         node = {'slits': slits,


### PR DESCRIPTION
Nadia and I were discussing the wcs code and found it failed in a couple of places due to running it in Python 3. First, the dictionary.keys() is now a generator but the code was expecting a list, so added list() around it.  Second, to iterate over a dictionary we need to use dictionary.items() for python 3.

I went through the code in jwst/transforms and jwst/assign_wcs and did not see any other obvious python 3 issues:
- except Exception e:" instead of "except Exception as e", but none found
- print 'here' instead of print('here'), but none found
- integer division, but in all cases the numerator or denominator were float so this should be fine
- str vs byte and encoding, does not seem to affect these packages
- dictionary.iteritems() -> dictionary.items(), two places
- dictionary.keys()  ->  list(dictionary.keys()) as keys() became a generator and one part of the code was expecting a list 

@nden , please review...