### PR TITLE
Rewrite __eq__ method in ObjectNode to avoid infinite recursion

### DIFF
--- a/jwst/datamodels/properties.py
+++ b/jwst/datamodels/properties.py
@@ -159,12 +159,11 @@ class ObjectNode(Node):
         return list(six.iterkeys(self._schema.get('properties', {})))
 
     def __eq__(self, other):
-        if isinstance(other, dict):
-            return self._instance == other
-        elif isinstance(other, ObjectNode):
+        if isinstance(other, ObjectNode):
             return self._instance == other._instance
-        return self == other
-
+        else:
+            return self._instance == other
+        
     def __getattr__(self, attr):
         if attr.startswith('_'):
             raise AttributeError('No attribute {0}'.format(attr))


### PR DESCRIPTION
The __eq__ method, as written, can invoke itself through the line "return self == other", leading to infinite recursion. Although there is a guard against this, it does not always catch this case. I rewrote the code to be simpler and never invoke the == operator on itself.