### PR TITLE
restore inverse

### DIFF
--- a/jwst/transforms/models.py
+++ b/jwst/transforms/models.py
@@ -244,6 +244,9 @@ class DirCos2Unitless(Model):
 
         return x / z, y / z
 
+    def inverse(self):
+        return Unitless2DirCos()
+
 
 class Rotation3DToGWA(Model):
     separable = False


### PR DESCRIPTION
Restore `Dircos2Unitless.inverse` which was unintentionally deleted in #69.