### PR TITLE
Enable connection to CRDS and start running the previously disabled s…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ env:
         - CONDA_DEPENDENCIES='pytest jwst sphinx=1.3.5'
         - CONDA_JWST_DEPENDENCIES='pytest stsci-jwst sphinx=1.3.5'
         - PIP_DEPENDENCIES=''
+        - CRDS_SERVER_URL='https://jwst-crds.stsci.edu'
+        - CRDS_PATH='/tmp/crds_cache'
 
     matrix:
         - PYTHON_VERSION=2.7 SETUP_CMD='install'

--- a/jwst/stpipe/tests/test_crds.py
+++ b/jwst/stpipe/tests/test_crds.py
@@ -35,7 +35,7 @@ class CrdsStep(Step):
             self.ref_filename = self.get_reference_file(dm, 'flat')
         return datamodels.DataModel()
 
-'''
+
 def test_crds_step():
     """Nominal working CrdsStep flat fetch for valid dataset."""
     _run_flat_fetch_on_dataset('data/crds.fits')
@@ -45,7 +45,7 @@ def test_crds_step():
 def test_crds_step_bad():
     """Run CrdsStep on a dataset with invalid FILTER."""
     _run_flat_fetch_on_dataset('data/crds_bad.fits')
-'''
+
 
 def _run_flat_fetch_on_dataset(dataset_path):
     from ... import datamodels
@@ -54,7 +54,7 @@ def _run_flat_fetch_on_dataset(dataset_path):
         step.run(input_file)
     print(step.ref_filename)
     assert basename(step.ref_filename) == "jwst_nircam_flat_0000.fits"
-'''
+
 def test_crds_step_override():
     """Run CRDS step with override parameter bypassing CRDS lookup."""
     from ... import datamodels
@@ -135,7 +135,7 @@ def test_crds_failed_getreferences_reftype():
 #         }
 #     assert_raises(crds.getreferences, header, reftypes=["foo"], context="jwst_9942.pmap")
 
-'''
+
 def test_crds_flatten():
     from jwst.stpipe import crds_client
 

--- a/jwst/stpipe/tests/test_step.py
+++ b/jwst/stpipe/tests/test_step.py
@@ -94,7 +94,6 @@ def test_step_from_commandline_class():
     step.run(1, 2)
 
 
-#@raises(ValueError)
 def test_step_from_commandline_invalid():
     from .. import Step
     args = [
@@ -105,7 +104,6 @@ def test_step_from_commandline_invalid():
         step = Step.from_cmdline(args)
 
 
-#@raises(ValueError)
 def test_step_from_commandline_invalid2():
     from .. import Step
 
@@ -116,7 +114,6 @@ def test_step_from_commandline_invalid2():
         step = Step.from_cmdline(args)
 
 
-#@raises(ValueError)
 def test_step_from_commandline_invalid3():
     from .. import Step
 
@@ -127,7 +124,6 @@ def test_step_from_commandline_invalid3():
         step = Step.from_cmdline(args)
 
 
-#@raises(ValueError)
 def test_step_from_commandline_invalid4():
     from .. import Step
 
@@ -160,7 +156,6 @@ def test_step_with_local_class():
     step.run(np.array([[0, 0]]))
 
 
-#@raises(ValidationError)
 def test_extra_parameter():
     from .steps import AnotherDummyStep
     with pytest.raises(ValidationError):
@@ -186,7 +181,7 @@ def test_omit_ref_file():
     step = OptionalRefTypeStep(override_to_be_ignored_ref_type="")
     step.process()
 
-'''
+
 def test_save_model():
     tempdir = tempfile.mkdtemp()
     orig_filename = join(dirname(__file__), 'data', 'flat.fits')
@@ -199,6 +194,6 @@ def test_save_model():
     ]
 
     Step.from_cmdline(args)
-    fname = join(tempdir, 'flat_processed.fits')
+    fname = join(tempdir, 'flat_FOO_SaveStep.fits')
     assert isfile(fname)
-'''
+


### PR DESCRIPTION
…tpipe tests.

The `stpipe` tests which are using a connection to CRDS were previously disabled. This will allow running step tests that use reference data on Travis.