### PR TITLE
RSCD check for ref table match

### DIFF
--- a/jwst/rscd/rscd_step.py
+++ b/jwst/rscd/rscd_step.py
@@ -1,14 +1,12 @@
 from ..stpipe import Step
 from .. import datamodels
-
-from .. import datamodels  
 from . import rscd_sub
 
 
 class RSCD_Step(Step):
     """
-    RSCD_Step: Performs an RSCD correction by adding a function of time,
-    frame by frame, to a copy of the input science data model.
+    RSCD_Step: Performs an RSCD correction to MIRI data by adding a function
+    of time, frame by frame, to a copy of the input science data model.
     """
 
     reference_file_types = ['rscd']
@@ -34,20 +32,17 @@ class RSCD_Step(Step):
                     result.meta.cal_step.rscd = 'SKIPPED'
                     return result
 
-                # Open the rscd ref file data model
-
+                # Load the rscd ref file data model
                 rscd_model = datamodels.RSCDModel(self.rscd_name)
 
-
-                # Do the rscd correction subtraction
+                # Do the rscd correction
                 result = rscd_sub.do_correction(input_model, rscd_model)
 
-                # Close the reference file and update the step status
+                # Close the reference file
                 rscd_model.close()
-                result.meta.cal_step.rscd = 'COMPLETE'
 
             else:
-                self.log.warning('RSCD Correction is only for MIRI data')
+                self.log.warning('RSCD correction is only for MIRI data')
                 self.log.warning('RSCD step will be skipped')
                 result = input_model.copy()
                 result.meta.cal_step.rscd = 'SKIPPED'

--- a/jwst/rscd/rscd_sub.py
+++ b/jwst/rscd/rscd_sub.py
@@ -10,12 +10,11 @@ from .. import datamodels
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
-
 def do_correction(input_model, rscd_model):
     """
     Short Summary
     -------------
-    Applies rscd correction to science arrays, xxx
+    Applies rscd correction to science arrays
 
     Parameters
     ----------
@@ -23,7 +22,7 @@ def do_correction(input_model, rscd_model):
         science data to be corrected
 
     rscd_model: rscd model object
-        rscd data
+        rscd reference data
 
     Returns
     -------
@@ -34,31 +33,36 @@ def do_correction(input_model, rscd_model):
 
     # Save some data params for easy use later
     sci_nints = input_model.data.shape[0]       # number of integrations
-
     sci_ngroups = input_model.data.shape[1]     # number of groups
-    # could also grab this information from input_model.meta.exposure.nints (ngroups)
-
-
+    frame_time = input_model.meta.exposure.frame_time
 
     log.debug("RSCD correction using: nints=%d, ngroups=%d" %
-          (sci_nints, sci_ngroups))
+              (sci_nints, sci_ngroups))
 
     # Create output as a copy of the input science data model
     output = input_model.copy()
 
-    even,odd = get_rscd_parameters(input_model, rscd_model)
-    frame_time = input_model.meta.exposure.frame_time
+    # Retrieve the reference parameters for this exposure type
+    even, odd = get_rscd_parameters(input_model, rscd_model)
 
+    # Check for valid parameters
+    if even is None:
+        log.warning('RSCD correction will be skipped')
+        output.meta.cal_step.rscd = 'SKIPPED'
+        return output
+
+    # Unpack the returned parameters
+    tau1_even, scale1_even, tau2_even, scale2_even = even
+    tau1_odd, scale1_odd, tau2_odd, scale2_odd = odd
 
     # loop over all integrations except the first
-    tau1_even,scale1_even,tau2_even,scale2_even = even
-    tau1_odd,scale1_odd,tau2_odd,scale2_odd = odd
     for i in range(1, sci_nints):
         dn_last = get_DNaccumulated_last_int(input_model, i, sci_ngroups)
-        
-       # loop over groups in input science data:
+
+        # loop over groups in input science data:
         for j in range(sci_ngroups):
-           # Apply the correction
+
+            # Compute the correction factors for even and odd rows
             T = (j + 1) * frame_time
             tau_even = tau1_even * frame_time
             eterm_even = np.exp(-T / tau_even)
@@ -66,23 +70,26 @@ def do_correction(input_model, rscd_model):
             tau_odd = tau1_odd * frame_time
             eterm_odd = np.exp(-T / tau_odd)
 
-            # The first row is defined in the RSCD correction as odd (python indexed 0)
-            # The second row is the first even row (python index of 1) 
-            correction_odd = dn_last[0::2,:] * scale1_odd * eterm_odd
-            correction_even = dn_last[1::2,:] * scale1_even * eterm_even
+            # Apply the corrections to even and odd rows:
+            # the first row is defined as odd (python index 0)
+            # the second row is the first even row (python index of 1)
+            correction_odd = dn_last[0::2, :] * scale1_odd * eterm_odd
+            correction_even = dn_last[1::2, :] * scale1_even * eterm_even
 
-            output.data[i, j,0::2,:] += correction_odd
-            output.data[i, j,1::2,:] += correction_even
+            output.data[i, j, 0::2, :] += correction_odd
+            output.data[i, j, 1::2, :] += correction_even
+
+    output.meta.cal_step.rscd = 'COMPLETE'
 
     return output
 
+
 def get_rscd_parameters(input_model, rscd_model):
+
     readpatt = input_model.meta.exposure.readpatt
     subarray = input_model.meta.subarray.name
 
-    # Read the correct row in table in the reference file to get the coefficients.
-    #print('rscd_table',type(rscd_model.rscd_table))
-
+    # Load the reference table columns of parameters
     tau1_table = rscd_model.rscd_table['TAU1']
     scale1_table = rscd_model.rscd_table['SCALE1']
     tau2_table = rscd_model.rscd_table['TAU2']
@@ -90,63 +97,74 @@ def get_rscd_parameters(input_model, rscd_model):
     readpatt_table = rscd_model.rscd_table['READPATT']
     subarray_table = rscd_model.rscd_table['SUBARRAY']
     rowtype = rscd_model.rscd_table['rows']
-    
 
-    num_rows = readpatt_table.size
+    # Find the matching table row index for even row parameters:
+    # the match is based on READPATT, SUBARRAY, and row type (even/odd)
+    index = np.asarray(np.where(np.logical_and(readpatt_table == readpatt,
+                       np.logical_and(subarray_table == subarray, rowtype == 'EVEN'))))
 
-    index = np.asarray(np.where(np.logical_and(readpatt_table == readpatt, 
-                                               np.logical_and(subarray_table == subarray,rowtype=='EVEN'))))
+    # Check for no match found
+    if len(index[0]) == 0:
+        log.warning('No matching row found in RSCD reference table for')
+        log.warning('READPATT=%s, SUBARRAY=%s, Row type=EVEN',
+                    readpatt, subarray)
+        return None, None
 
-
+    # Load the params from the matching table row
     tau1_even = tau1_table[index]
-    #print('tau1 even',tau1_even)
-
     tau2_even = tau2_table[index]
-
     scale1_even = scale1_table[index]
     scale2_even = scale2_table[index]
 
-    index2 = np.asarray(np.where(np.logical_and(readpatt_table == readpatt, 
-                                               np.logical_and(subarray_table == subarray,rowtype=='ODD'))))
+    # Find the matching table row index for odd row parameters:
+    index2 = np.asarray(np.where(np.logical_and(readpatt_table == readpatt,
+                        np.logical_and(subarray_table == subarray, rowtype == 'ODD'))))
+
+    # Check for no match found
+    if len(index[0]) == 0:
+        log.warning('No matching row found in RSCD reference table for')
+        log.warning('READPATT=%s, SUBARRAY=%s, Row type=ODD',
+                    readpatt, subarray)
+        return None, None
+
+    # Load the params from the matching table row
     tau1_odd = tau1_table[index2]
     tau2_odd = tau2_table[index2]
-
     scale1_odd = scale1_table[index2]
     scale2_odd = scale2_table[index2]
 
-    even = tau1_even,scale1_even,tau2_even,scale2_even
-    odd = tau1_odd,scale1_odd,tau2_odd,scale2_odd
+    even = tau1_even, scale1_even, tau2_even, scale2_even
+    odd = tau1_odd, scale1_odd, tau2_odd, scale2_odd
 
-    return even,odd
+    return even, odd
 
 
 def get_DNaccumulated_last_int(input_model, i, sci_ngroups):
+
     # Find the accumulated DN from the last integration
     # need to add skipping N frames (frames affected by reset)
     # Add check to make sure we have enough frames left to do a fit
 
     nrows = input_model.data.shape[2]
     ncols = input_model.data.shape[3]
+
     # last frame affected by "last frame" effect - use second to last frame
     # may want to extrapolate to last frame
     # we may want to check if data has saturated
     dn_lastframe = input_model.data[i - 1][sci_ngroups - 2]
 
     dn_accumulated = dn_lastframe.copy() * 0.0
-   # print('nrows,ncols',nrows,ncols)
-   # print(input_model.data.shape)
     for j in range(nrows):
         for k in range(ncols):
             ramp = input_model.data[i, 0:sci_ngroups - 1, j, k]
-
             slope, intercept = ols_fit(ramp)
-            #print('slope & intercept',slope,intercept)
-
             dn_accumulated[j, k] = dn_lastframe[j, k] - intercept
 
     return dn_accumulated
 
+
 def ols_fit(y):
+
     shape = y.shape
     nelem = float(len(y))
 
@@ -156,7 +174,6 @@ def ols_fit(y):
         xshape[i] = 1
     x = x.reshape(xshape)
 
-
     mean_y = y.mean(axis=0)
     mean_x = x[-1] / 2.
     sum_x2 = (x**2).sum(axis=0)
@@ -164,6 +181,5 @@ def ols_fit(y):
     slope = (sum_xy - nelem * mean_x * mean_y) / \
             (sum_x2 - nelem * mean_x**2)
     intercept = mean_y - slope * mean_x
-
 
     return (slope, intercept)


### PR DESCRIPTION
Updated the get_rscd_parameters function in the RSCD step to check that it found a matching entry in the reference table before blindly trying to apply the correction. If a match is not found, a warning is issued and the step is skipped (output is returned as an unchanged copy of the input). The step completion status is set appropriately.

Also some PEP8 clean-up.