### PR TITLE
Make persistence step skip cleanly for now

### DIFF
--- a/jwst/persistence/persistence_step.py
+++ b/jwst/persistence/persistence_step.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 
 from ..stpipe import Step, cmdline
+from .. import datamodels
 from . import persistence
 
 class PersistenceStep(Step):
@@ -10,11 +11,13 @@ class PersistenceStep(Step):
     """
     def process(self, input):
 
-        pers_a = persistence.DataSet(input)
-        output_obj = pers_a.do_all()
+        # Skip all processing for now
+        output_obj = datamodels.open(input).copy()
+        output_obj.meta.cal_step.persistence = 'SKIPPED'
+        self.log.warning('Persistence step is currently a no-op: SKIPPING')
 
-        if output_obj is not None:
-            output_obj.meta.cal_step.persistence = 'SKIPPED' # no-op
+        #pers_a = persistence.DataSet(input)
+        #output_obj = pers_a.do_all()
 
         return output_obj
 


### PR DESCRIPTION
The persistence step used to be part of level-2b processing, so the lower level routines were setup to open and work with things like Image, Cube, and MultiSlit data models, which was causing some sort of problem now that the step is part of level-2a processing, where we're always working with Ramp models. So I updated the top-level step module to just immediately return a copy of the input model and set the step status to skipped (until the persistence step gets fully implemented later during Build 7 development).