### PR TITLE
New 4D QuadModel data model

### DIFF
--- a/jwst/datamodels/__init__.py
+++ b/jwst/datamodels/__init__.py
@@ -65,6 +65,7 @@ from .pixelarea import PixelAreaModel
 from .photom import PhotomModel, FgsPhotomModel, NircamPhotomModel, NirissPhotomModel
 from .photom import NirspecPhotomModel, NirspecFSPhotomModel
 from .photom import MiriImgPhotomModel, MiriMrsPhotomModel
+from .quad import QuadModel
 from .ramp import RampModel
 from .rampfitoutput import RampFitOutputModel
 from .readnoise import ReadnoiseModel
@@ -89,7 +90,7 @@ __all__ = [
     'MaskModel', 'MIRIRampModel', 'ModelContainer', 'MultiSlitModel',
     'MultiSpecModel', 'IFUCubeModel', 'PhotomModel', 'NircamPhotomModel',
     'NirissPhotomModel', 'NirspecPhotomModel', 'NirspecFSPhotomModel',
-    'MiriImgPhotomModel', 'MiriMrsPhotomModel', 'RampModel',
+    'MiriImgPhotomModel', 'MiriMrsPhotomModel', 'QuadModel', 'RampModel',
     'RampFitOutputModel', 'ReadnoiseModel', 'ResetModel', 'RSCDModel',
     'SaturationModel', 'SpecModel', 'StrayLightModel']
 
@@ -178,13 +179,19 @@ def open(init=None, extensions=None):
         new_class = DataModel
     elif len(shape) == 4:
         try:
-            refouthdu = hdulist[fits_header_name('REFOUT')]
+            groupdqhdu = hdulist[fits_header_name('GROUPDQ')]
         except KeyError:
-            from . import ramp
-            new_class = ramp.RampModel
+            from . import quad
+            new_class = quad.QuadModel
         else:
-            from . import miri_ramp
-            new_class = miri_ramp.MIRIRampModel
+            try:
+                refouthdu = hdulist[fits_header_name('REFOUT')]
+            except KeyError:
+                from . import ramp
+                new_class = ramp.RampModel
+            else:
+                from . import miri_ramp
+                new_class = miri_ramp.MIRIRampModel
     elif len(shape) == 3:
         from . import cube
         new_class = cube.CubeModel

--- a/jwst/datamodels/quad.py
+++ b/jwst/datamodels/quad.py
@@ -1,0 +1,43 @@
+from __future__ import absolute_import, unicode_literals, division, print_function
+
+from . import model_base
+
+
+__all__ = ['QuadModel']
+
+
+class QuadModel(model_base.DataModel):
+    """
+    A data model for 4D image arrays.
+
+    Parameters
+    ----------
+    init : any
+        Any of the initializers supported by `~jwst.datamodels.DataModel`.
+
+    data : numpy array
+        The science data.  4-D.
+
+    dq : numpy array
+        The data quality array.  4-D.
+
+    err : numpy array
+        The error array.  4-D
+    """
+    schema_url = "quad.schema.yaml"
+
+    def __init__(self, init=None, data=None, dq=None, err=None, **kwargs):
+        super(QuadModel, self).__init__(init=init, **kwargs)
+
+        if data is not None:
+            self.data = data
+
+        if dq is not None:
+            self.dq = dq
+
+        if err is not None:
+            self.err = err
+
+        # Implicitly create arrays
+        self.dq = self.dq
+        self.err = self.err

--- a/jwst/datamodels/schemas/quad.schema.yaml
+++ b/jwst/datamodels/schemas/quad.schema.yaml
@@ -1,0 +1,21 @@
+allOf:
+- $ref: core.schema.yaml
+- type: object
+  properties:
+    data:
+      title: The science data
+      fits_hdu: SCI
+      default: 0.0
+      ndim: 4
+      datatype: float32
+    dq:
+      title: Data quality array
+      fits_hdu: DQ
+      default: 0
+      datatype: uint32
+    err:
+      title: Error array
+      fits_hdu: ERR
+      default: 0.0
+      datatype: float32
+$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/tests/test_models.py
+++ b/jwst/datamodels/tests/test_models.py
@@ -19,7 +19,7 @@ import numpy as np
 from numpy.testing.decorators import knownfailureif
 from numpy.testing import assert_array_equal
 
-from .. import DataModel, ImageModel, RampModel, MultiSlitModel, open
+from .. import DataModel, ImageModel, QuadModel, MultiSlitModel, open
 from .. import schema
 
 
@@ -146,7 +146,7 @@ def test_open():
         pass
 
     with open(FITS_FILE) as dm:
-        assert isinstance(dm, RampModel)
+        assert isinstance(dm, QuadModel)
 
 
 def test_copy():
@@ -167,7 +167,7 @@ def test_copy():
 
 
 def test_section():
-    with RampModel((5, 35, 40, 32)) as dm:
+    with QuadModel((5, 35, 40, 32)) as dm:
         section = dm.get_section('data')[3:4, 1:3]
         assert section.shape == (1, 2, 40, 32)
 


### PR DESCRIPTION
Level-3 coronagraphic processing requires the use of a data model that is 4-dimensional, but unlike the existing 4D RampModel, only has standard SCI, DQ, ERR arrays as attributes.

In addition to adding the new QuadModel, I updated the portion of the datamodels __init__ that tries to figure out the type of data model to return when calling the generic datamodels.open. The additional logic is intended to distinguish a simple 4D QuadModel from the more complicated 4D RampModel (or MiriRampModel), which have additional specialized data arrays, like GROUPDQ and REFOUT.