### PR TITLE
Fix logic in datamodels init for QuadModel

### DIFF
--- a/jwst/datamodels/__init__.py
+++ b/jwst/datamodels/__init__.py
@@ -178,24 +178,31 @@ def open(init=None, extensions=None):
     if len(shape) == 0:
         new_class = DataModel
     elif len(shape) == 4:
+        # It's a RampModel, MIRIRampModel, or QuadModel
         try:
-            groupdqhdu = hdulist[fits_header_name('GROUPDQ')]
+            dqhdu = hdulist[fits_header_name('DQ')]
         except KeyError:
-            from . import quad
-            new_class = quad.QuadModel
-        else:
+            # It's a RampModel or MIRIRampModel
             try:
                 refouthdu = hdulist[fits_header_name('REFOUT')]
             except KeyError:
+                # It's a RampModel
                 from . import ramp
                 new_class = ramp.RampModel
             else:
+                # It's a MIRIRampModel
                 from . import miri_ramp
                 new_class = miri_ramp.MIRIRampModel
+        else:
+            # It's a QuadModel
+            from . import quad
+            new_class = quad.QuadModel
     elif len(shape) == 3:
+        # It's a CubeModel
         from . import cube
         new_class = cube.CubeModel
     elif len(shape) == 2:
+        # It's an ImageModel
         from . import image
         new_class = image.ImageModel
     else:


### PR DESCRIPTION
Initial logic to test for RampModel vs. QuadModel was flawed. Raw (_uncal.fits) RampModel products only contain a SCI extension, with no accompanying ERR, GROUPDQ, or PIXELDQ arrays. Hence a test for the presence of GROUPDQ will always fail for a raw product, causing it to assume it's a QuadModel. As of now, QuadModels are always used for more advanced stages of products, which means they'll always contain populated ERR and DQ arrays (even if they're just zero-filled), so changed the test to look for DQ.

This was causing many of the regression tests to fail, at least the ones that use _uncal.fits products as input.

Really need to come up with a way for input products to identify the type of data model that they are in order to avoid having to make guesses like this.