### PR TITLE
Update coron StackRefs step inputs

### DIFF
--- a/jwst/coron/stack_refs.py
+++ b/jwst/coron/stack_refs.py
@@ -12,32 +12,42 @@ import logging
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
-def make_cube(input_table):
+def make_cube(input_models):
     """
-    make_cube: Stack individual coronagraphic PSF reference images into a
-    jwst.datamodels.CubeModel, for use in LOCI/KLIP processing.
+    make_cube: Stack all of the integrations from multiple PSF
+    reference exposures into a single CubeModel, for use in the
+    coronagraphic alignment and PSF-subtraction steps.
     """
 
     # Get the number of input images
-    num_refs = len(input_table.input_filenames)
+    num_refs = len(input_models)
 
-    # Get the size of the first input image
-    img = datamodels.ImageModel(input_table.input_filenames[0])
-    nrows, ncols = img.data.shape
-    img.close()
+    # Loop over all the inputs to find the total number of integrations
+    nrows_ref, ncols_ref = input_models[0].shape[-2:]
+    nints = 0
+    for i in range(num_refs):
+        nints += input_models[i].shape[0]
+        nrows, ncols = input_models[i].shape[-2:]
+        if (nrows != nrows_ref) or (ncols != ncols_ref):
+            raise ValueError('All PSF exposures must have the same x/y dimensions!')
 
-    # Create an empty cube array of the appropriate dimensions
-    cube = np.zeros((num_refs, nrows, ncols), dtype=np.float32)
+    # Create empty output data arrays of the appropriate dimensions
+    outdata = np.zeros((nints, nrows, ncols), dtype=np.float32)
+    outerr = outdata.copy()
+    outdq = np.zeros((nints, nrows, ncols), dtype=np.uint32)
 
-    # Loop over the input images, copying only the science data array
-    # into the cube
-    for i, name in enumerate(input_table.input_filenames):
-        log.info('Adding member %s', name)
-        img = datamodels.ImageModel(name)
-        cube[i] = img.data
-        img.close()
+    # Loop over the input images, copying the data arrays
+    # into the output arrays
+    nint = 0
+    for i in range(num_refs):
+        log.info(' Adding psf member %d to output stack', i+1)
+        for j in range(input_models[i].shape[0]):
+            outdata[nint] = input_models[i].data[j]
+            outerr[nint] = input_models[i].err[j]
+            outdq[nint] = input_models[i].dq[j]
+            nint += 1
 
     # Create the ouput Cube model
-    output_model = datamodels.CubeModel(data=cube)
+    output_model = datamodels.CubeModel(data=outdata, err=outerr, dq=outdq)
 
     return output_model

--- a/jwst/coron/stack_refs_step.py
+++ b/jwst/coron/stack_refs_step.py
@@ -2,14 +2,14 @@
 
 from ..stpipe import Step, cmdline
 
-import json
+from .. import datamodels
 from . import stack_refs
 
 class StackRefsStep(Step):
 
     """
-    StackRefsStep: Stack multiple PSF reference images into a CubeModel, for
-    use by subsequent coronagraphic processing tasks.
+    StackRefsStep: Stack multiple PSF reference exposures into a
+    single CubeModel, for use by subsequent coronagraphic steps.
     """
 
     spec = """
@@ -17,42 +17,13 @@ class StackRefsStep(Step):
 
     def process(self, input):
 
-        # Load the input list of PSF reference images
-        input_table = LoadPsfRefs(input)
+        # Open the inputs
+        with datamodels.open(input) as input_models:
 
-        # Call the stacking routine
-        cube_model = stack_refs.make_cube(input_table)
+            # Call the stacking routine
+            output_model = stack_refs.make_cube(input_models)
 
-        #result.meta.cal_step.psfcube = 'COMPLETE'
-
-        return cube_model
-
-
-class LoadPsfRefs(object):
-    """Class to handle reading a coronagraphic asn table and loading the
-       input and output member info into a table model.
-    """
-
-    def __init__(self, input):
-        self.input = input # keep a record of original input name for later
-
-        if isinstance(input, str):
-            self.asn_table = json.load(open(input, 'r'))
-        else:
-            raise TypeError
-
-        # Extract some values for ease of use
-        self.input_filenames = self.get_inputs()
-        self.output_filename = self.get_output()
-
-    def get_inputs(self, product=0):
-        members = []
-        for p in self.asn_table['products'][product]['members']:
-            members.append(p['expname'])
-        return members
-
-    def get_output(self, product=0):
-        return self.asn_table['products'][product]['name']
+        return output_model
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
As part of the on-ongoing development of the calwebb_coron3 pipeline, the stack ref psfs step had to be updated to accommodate a new form of input and the ability to work over all integrations within an exposure. The previous version of the step read the ASN table to find the list of input psf exposure names. The upper-level pipeline module now handles this and sends a ModelContainer as input to this step. So now all the step needs to do is actually stack the data in the input models. Furthermore, the operation of copying the input data to an output cube was updated to copy all of the multiple integrations that will be in the input model exposures. Previously the step had assumed the input would contain a single image (ImageModel). Now they are CubeModels that in turn get stacked into an even larger output CubeModel.