### PR TITLE
R_BADSHU vs. R_BADSHR badshutter reference file keyword

### DIFF
--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -1061,7 +1061,7 @@ properties:
               name:
                 title: NIRSpec bad shutter reference file name
                 type: string
-                fits_keyword: R_BADSHR
+                fits_keyword: R_BADSHU
           dark:
             title: Dark reference file information
             type: object

--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -1061,7 +1061,7 @@ properties:
               name:
                 title: NIRSpec bad shutter reference file name
                 type: string
-                fits_keyword: R_BADSHU
+                fits_keyword: R_MSAOPE
           dark:
             title: Dark reference file information
             type: object


### PR DESCRIPTION
Reference file keywords are generated in stpipe based on the CRDS type name using a standard rule.  The new badshutter keyword needs to be R_BADSHU to correspond to the truncation rule.