### PR TITLE
First round of updates to CALCORON3

### DIFF
--- a/jwst/coron/align_refs_step.py
+++ b/jwst/coron/align_refs_step.py
@@ -30,7 +30,7 @@ class AlignRefsStep(Step):
                 self.log.warning('No PSFMASK reference file found')
                 self.log.warning('Align_refs step will be skipped')
                 return None
- 
+
             # Open the psf mask reference file
             mask_model = datamodels.ImageModel(self.mask_name)
 
@@ -42,9 +42,9 @@ class AlignRefsStep(Step):
                                                     mask_model)
             mask_model.close()
             psf_model.close()
-            
+
         return result
 
 
 if __name__ == '__main__':
-    cmdline.step_script(StackRefsStep)
+    cmdline.step_script(AlignRefsStep)

--- a/jwst/coron/imageregistration.py
+++ b/jwst/coron/imageregistration.py
@@ -224,21 +224,14 @@ def align_models(reference, target, mask):
         # the science ("reference") image in this integration, and apply
         # the shifts to the PSF images
         d, shifts = align_array(reference.data[k], target.data, mask.data)
+        output_model.data[k] = d
 
         # Apply the same shifts to the PSF error arrays, if they exist
         if target.err is not None:
-            e = fourier_imshift(target.err, -shifts)
-        else:
-            e = None
-
-        # Copy the shifted model data into the output model
-        output_model.data[k] = d
-        output_model.err[k] = e
-        output_model.dq[k] = None
+            output_model.err[k] = fourier_imshift(target.err, -shifts)
 
         # TODO: in the future we need to add shifts and other info (such as
         # slice ID from the reference image to which target was aligned)
         # to output cube metadata (or property).
 
     return output_model
-

--- a/jwst/coron/klip_step.py
+++ b/jwst/coron/klip_step.py
@@ -1,10 +1,7 @@
 #! /usr/bin/env python
 
-import os
-
-from ..stpipe import Step, cmdline
+from ..stpipe import Step
 from .. import datamodels
-
 from . import klip
 
 class KlipStep(Step):
@@ -22,24 +19,20 @@ class KlipStep(Step):
 
     def process(self, target, psfrefs):
 
-        with datamodels.CubeModel(target) as target_model:
+        with datamodels.open(target) as target_model:
 
             # Retrieve the parameter values
             truncate = self.truncate
             self.log.info('KL transform truncation = %d', truncate)
 
             # Get the PSF reference images
-            refs_model = datamodels.QuadModel(psfrefs)
+            refs_model = datamodels.open(psfrefs)
 
             # Call the KLIP routine
-            (target, psf) = klip.klip(target_model, refs_model, truncate)
+            (psf_sub, psf_fit) = klip.klip(target_model, refs_model, truncate)
 
-            refs_model.close()
+        # Update the step completion status
+        psf_sub.meta.cal_step.klip = 'COMPLETE'
 
-        result.meta.cal_step.klip = 'COMPLETE'
-
-        return (target, psf)
-
-
-if __name__ == '__main__':
-    cmdline.step_script(KlipStep)
+        #return psf_sub, psf_fit
+        return psf_sub

--- a/jwst/coron/stack_refs.py
+++ b/jwst/coron/stack_refs.py
@@ -40,7 +40,7 @@ def make_cube(input_models):
     # into the output arrays
     nint = 0
     for i in range(num_refs):
-        log.info(' Adding psf member %d to output stack', i+1)
+        log.info(' Adding psf member %d to output stack', i + 1)
         for j in range(input_models[i].shape[0]):
             outdata[nint] = input_models[i].data[j]
             outerr[nint] = input_models[i].err[j]


### PR DESCRIPTION
Made several updates and bug fixes to get the baseline version of calwebb_coron3 running. The basic pipeline structure and data flow now work end-to-end. A few updates are still needed to some of the individual steps, such as adding the capability in align_refs to store the computed image shifts somewhere, and adding a switch to outlier_detection to tell it to do its work in native detector space, rather than resampling and blotting all the images back and forth.