### PR TITLE
Add version check

### DIFF
--- a/jwst/cal_ver_steps.py
+++ b/jwst/cal_ver_steps.py
@@ -1,0 +1,157 @@
+""" Module for generating CAL_VER related version reports/reference file for all
+JWST calibration processing steps.
+
+"""
+
+import os, sys, inspect
+import imp
+import json
+ 
+from datetime import datetime as dtime
+
+from verhawk.scanner import Scanner
+
+from . import version
+from . import steps  # REQUIRED: in order to load all packages for inspect
+
+from . import __name__ as jwst_pkg_name
+from . import __file__ as jwst_pkg_file
+
+__version__ = "0.7.0.dev"
+
+STDOUT = sys.stdout
+
+class StepVersions(object):
+    def __init__(self, author, **pars):
+        """
+        Parameters
+        ==========
+        author : str
+            Name of user generating this reference file [Required]
+                    
+        descrip : str, optional
+            Basic description of this generated report. Default string will be 
+            generated if no user-supplied string is provided.
+        
+        history : str, optional
+            Single line to provide info on when this file was created. Default
+            string based on current date task was run will be used if no 
+            user-supplied string is provided.
+            
+        verbose : bool, optional
+            Specify whether or not to generate additional diagnostic 
+            messages during operation. [Default: False}
+            
+        """
+        # Initialize output reference file information based on user input
+        descrip = pars.get('pars', "JWST calibration processing step version reference file")
+        history = pars.get('history', "Created by cal_ver_steps version {}".format(__version__))
+        self.verbose = pars.get('verbose', False)
+
+#        useafter = pars.get('useafter', None)
+#        if useafter is None:
+        useafter = dtime.isoformat(dtime.today())#"%Y-%m-%dT%H:%M:%S"
+        
+        self.output = {'reftype': "CALVER",
+                      'instrument': "SYSTEM",
+                      'descrip': descrip, 
+#                      'useafter': useafter, 
+                      'author': author, 
+                      'history': history, 
+                      'CAL_VER': version.__version__,
+                      'versions': {}
+                  }
+        self.versions = {}
+        
+        # Use verhawk to extract all the version information from the package
+        self.pkg_name = jwst_pkg_name
+
+        try:
+            with open(os.devnull, 'w') as devnull:
+                sys.stdout = devnull
+            jwst_pkg = imp.load_source(jwst_pkg_name,jwst_pkg_file)
+            sys.stdout = STDOUT
+
+            pvers = Scanner(jwst_pkg,recursive=True)
+            pvers.scan()
+            self.pkg_versions = pvers.versions
+
+        except ImportError as e:
+            print(e, file=sys.stderr)
+            exit(1)
+                    
+        # Identify which sub-packages are defined in this environment as 
+        # included in the 'steps' module
+        self.modules = inspect.getmembers(jwst_pkg,inspect.ismodule)
+
+        # Look for all modules within each sub-package which MAY contain a 
+        # processing step
+        self.steps = {}
+        for m in self.modules:
+            mod_name = "{}.{}".format(self.pkg_name,m[0])
+            self.steps[mod_name] = inspect.getmembers(m[1],inspect.ismodule)
+            
+    def scan(self):
+        for s in self.steps:
+            for mod in self.steps[s]:
+                step_name = mod[0]
+                step_module = mod[1]
+                classname = None
+                step_version = self.pkg_versions[s]
+                if '_step' in step_name:
+                    # Return all classes defined by step
+                    classnames = inspect.getmembers(step_module,inspect.isclass)
+
+                    # Extract actual processing step associated with this module
+                    for c in classnames:
+                        if c[0].endswith('Step') and c[0] != 'Step':
+                            # store results
+                            self.versions.update({c[0]:step_version})
+                            if self.verbose:
+                                print("Found Step class {} in {}".format(c[0],s))
+
+        # Use this new information to update output versions
+        self.output['versions'].update(self.versions)
+        
+    def as_json(self):
+        """ Return json string for output version information.
+        """
+        return json.dumps(self.output, sort_keys=True)
+   
+    def write_json(self,filename, clobber=False):
+        """ Writes results out to json file. 
+
+        Parameters
+        ==========
+        filename : str
+            Filename for output file.  If it does not end in .json, method will 
+            append '.json' to end of filename automatically.
+            
+        clobber : bool
+            Specify whether or not this method should over-write a previous 
+            output file. If True, it will delete previous file.
+            If False, it will raise an IOError exception when trying to overwrite
+            a file.
+            
+        """
+        json_out = self.as_json()
+
+        if not filename.endswith('.json'):
+            filename += '.json'
+            
+        if clobber:
+            try:
+                os.remove(filename)
+            except:
+                pass
+            if self.verbose:
+                print('Removing previous version of {}'.format(filename))
+        else:
+            if os.path.exists(filename):
+                raise IOError("previous version of {} found, clobber not set".format(filename))
+
+        with open(filename,'w') as outfile:
+            outfile.write(json.dumps(json_out,indent=4,sort_keys=True))
+        if self.verbose:
+            print("Versions written to {}".format(filename))
+

--- a/jwst/cal_ver_steps.py
+++ b/jwst/cal_ver_steps.py
@@ -30,16 +30,16 @@ class StepVersions(object):
             Name of user generating this reference file [Required]
                     
         descrip : str, optional
-            Basic description of this generated report. Default string will be 
+            Basic description of this generated report. Default string will be
             generated if no user-supplied string is provided.
         
         history : str, optional
             Single line to provide info on when this file was created. Default
-            string based on current date task was run will be used if no 
+            string based on current date task was run will be used if no
             user-supplied string is provided.
             
         verbose : bool, optional
-            Specify whether or not to generate additional diagnostic 
+            Specify whether or not to generate additional diagnostic
             messages during operation. [Default: False}
             
         """
@@ -54,10 +54,10 @@ class StepVersions(object):
         
         self.output = {'reftype': "CALVER",
                       'instrument': "SYSTEM",
-                      'descrip': descrip, 
-#                      'useafter': useafter, 
-                      'author': author, 
-                      'history': history, 
+                      'descrip': descrip,
+#                      'useafter': useafter,
+                      'author': author,
+                      'history': history,
                       'CAL_VER': version.__version__,
                       'versions': {}
                   }
@@ -80,11 +80,11 @@ class StepVersions(object):
             print(e, file=sys.stderr)
             exit(1)
                     
-        # Identify which sub-packages are defined in this environment as 
+        # Identify which sub-packages are defined in this environment as
         # included in the 'steps' module
         self.modules = inspect.getmembers(jwst_pkg,inspect.ismodule)
 
-        # Look for all modules within each sub-package which MAY contain a 
+        # Look for all modules within each sub-package which MAY contain a
         # processing step
         self.steps = {}
         for m in self.modules:
@@ -119,16 +119,16 @@ class StepVersions(object):
         return json.dumps(self.output, sort_keys=True)
    
     def write_json(self,filename, clobber=False):
-        """ Writes results out to json file. 
+        """ Writes results out to json file.
 
         Parameters
         ==========
         filename : str
-            Filename for output file.  If it does not end in .json, method will 
+            Filename for output file.  If it does not end in .json, method will
             append '.json' to end of filename automatically.
             
         clobber : bool
-            Specify whether or not this method should over-write a previous 
+            Specify whether or not this method should over-write a previous
             output file. If True, it will delete previous file.
             If False, it will raise an IOError exception when trying to overwrite
             a file.

--- a/scripts/get_cal_vers
+++ b/scripts/get_cal_vers
@@ -1,0 +1,29 @@
+import argparse
+import os
+import sys
+
+from jwst import cal_ver_steps as cvsteps
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('author',
+        help="Name of author/user creating this output file")
+    parser.add_argument('-v', '--verbose',
+        action='store_true',
+        help='Turn on verbose mode')
+    parser.add_argument('-c', '--clobber',
+        action='store_true',
+        help='Specify whether or not to clobber previous output files')
+    parser.add_argument('output',
+        help='Filename for output')
+
+    args = parser.parse_args()
+    print(args)
+    
+    scanner = cvsteps.StepVersions(args.author, verbose=args.verbose)
+    scanner.scan()
+    
+    scanner.write_json(args.output,args.clobber)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This PR adds a new module to report on the versions for all calibration pipeline steps, as well as a new script to enable a command-line interface for generating the version report as a JSON file.  The module has been added to the top level of the JWST package to allow it to inspect all sub-packages for any class that ends in 'Step'.  These versions of the file have already been found to be PEP8 compliant (by checking them with 'pep8' task).  