### PR TITLE
Update keywords to match KWD

### DIFF
--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -94,7 +94,7 @@ properties:
             fits_keyword: SCICAT
           continuation_id:
             title: Continuation of previous program
-            type: string
+            type: integer
             fits_keyword: CONT_ID
       observation:
         title: Observation identifiers
@@ -307,7 +307,7 @@ properties:
           coronagraph:
             title: coronagraph mask used
             type: string
-            enum: [4QPM, LYOT, MASK210R, MASKSWB, MASK335R, MASK430R, MASKLWB, NULL]
+            enum: [4QPM, LYOT, MASK210R, MASKSWB, MASK335R, MASK430R, MASKLWB, NONE]
             fits_keyword: CORONMSK
           msa_state:
             title: State of the MSA
@@ -542,7 +542,7 @@ properties:
             fits_keyword: PATTSTRT
           total_points:
             title: Total number of point in pattern
-            type: integer
+            type: string
             fits_keyword: NUMDTHPT
           pattern_size:
             title: Primary dither pattern size (arcsec)
@@ -755,7 +755,7 @@ properties:
             fits_keyword: PC3_2
           s_region:
             title: spatial extent of the observation
-            type: number
+            type: string
             fits_keyword: S_REGION
           waverange_start:
             title: lower bound of the default wavelength range


### PR DESCRIPTION
The folks in SDP are getting warnings when loading level-1b products, because a few of our keyword definitions in the core schema are out of date with their definitions and therefore how they're writing them in the level-1b products.

In particular:
 CONT_ID: needs to be integer type
 CORONMSK: change the entry 'NULL' in the enum list to 'NONE'
 NUMDTHPT: needs to be string type (I know, it's crazy)
 S_REGION: needs to be string type