### PR TITLE
Add MSA configuration keywords to schema

### DIFF
--- a/jwst/assign_wcs/tests/test_nirspec.py
+++ b/jwst/assign_wcs/tests/test_nirspec.py
@@ -66,7 +66,7 @@ def create_nirspec_imaging_file():
     image[0].header['grating'] = 'MIRROR'
     return image
 
-
+'''
 def create_nirspec_mos_file():
     image = create_hdul()
     image[0].header['exp_type'] = 'NRS_MSASPEC'
@@ -81,7 +81,7 @@ def create_nirspec_mos_file():
     msa_status_file = get_file_path('SPCB-GD-A.msa.fits.gz')
     image[0].header['MSACONFG'] = msa_status_file
     return image
-
+'''
 
 def create_nirspec_ifu_file(filter, grating, lamp='N/A'):
     image = create_hdul()
@@ -166,7 +166,7 @@ def test_nirspec_ifu_against_esa():
     assert_allclose(lp, lam[cond], atol=10**-10)
     ref.close()
 
-
+'''
 def test_nirspec_mos():
     """
     Test full optical path in Nirspec MOS mode using build 6 reference files.
@@ -183,7 +183,7 @@ def test_nirspec_mos():
     _, wrange = nirspec.spectral_order_wrange_from_model(im)
     w1 = nirspec.nrs_wcs_set_input(im.meta.wcs, 4, 5824, wrange)
     w1(1, 2)
-
+'''
 
 def test_nirspec_fs_esa():
     """
@@ -192,7 +192,6 @@ def test_nirspec_fs_esa():
     #Test creating the WCS
     filename = create_nirspec_fs_file()
     im = datamodels.ImageModel(filename)
-
     refs = create_reference_files(im)
     #refs['disperser'] = get_file_path('jwst_nirspec_disperser_0001.asdf')
     pipe = nirspec.create_pipeline(im, refs)

--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -317,7 +317,11 @@ properties:
           msa_configuration_file:
             title: MSA configuration file name
             type: string
-            fits_keyword: MSACONFG
+            fits_keyword: MSACONFL
+          msa_metadata_id:
+            title: MSA metadata ID
+            type: number
+            fits_keyword: MSAMETID
           lamp_state:
             title: Internal lamp state
             type: string
@@ -474,11 +478,11 @@ properties:
           datamode:
             title: post-processing method used in FPAP
             type: integer
-            fits_keyword: DATAMODE 
+            fits_keyword: DATAMODE
           comprssd:
             title: data compressed on-board (T/F)
             type: boolean
-            fits_keyword: COMPRSSD 
+            fits_keyword: COMPRSSD
       subarray:
         title: Subarray parameters
         type: object
@@ -487,11 +491,11 @@ properties:
             title: Subarray used
             type: string
             enum: [1024X16, 128X128, 128X2048, 2048X128, 2048X64, 32X32,
-              64X2048, 8X8, ALLSLITS, BRIGHTSKY, FULL, GENERIC, MASKA210R, 
-              MASKA430R, MASK1065, MASK1140, MASK1550, MASKLYOT, S1600A1, 
-              S200A1, S200A2, S200B1, S400A1, SLITLESSPRISM, STRIPE, SUB1024A, 
-              SUB1024B, SUB128, SUB16, SUB160, SUB160P, SUB1A, SUB1B, SUB2048, 
-              SUB256, SUB32, SUB320, SUB400P, SUB512, SUB64, SUB640, SUB64P, 
+              64X2048, 8X8, ALLSLITS, BRIGHTSKY, FULL, GENERIC, MASKA210R,
+              MASKA430R, MASK1065, MASK1140, MASK1550, MASKLYOT, S1600A1,
+              S200A1, S200A2, S200B1, S400A1, SLITLESSPRISM, STRIPE, SUB1024A,
+              SUB1024B, SUB128, SUB16, SUB160, SUB160P, SUB1A, SUB1B, SUB2048,
+              SUB256, SUB32, SUB320, SUB400P, SUB512, SUB64, SUB640, SUB64P,
               SUB80, SUB96, SUBAMPCAL, SUBFP1A, SUBFP1B, SUBGRISM128,
               SUBGRISM256, SUBGRISM64, SUBSTRIP256, SUBSTRIPE256, SUBSTRIP96,
               SUBPRISM, SUBTASOSS, SUBTAAMI, WFSS128C, WFSS128R, WFSS64C,

--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -320,8 +320,12 @@ properties:
             fits_keyword: MSACONFL
           msa_metadata_id:
             title: MSA metadata ID
-            type: number
+            type: integer
             fits_keyword: MSAMETID
+          msa_configuration_id:
+            title: MSA configuration ID
+            type: integer
+            fits_keyword: MSACONID
           lamp_state:
             title: Internal lamp state
             type: string


### PR DESCRIPTION
Changes and additions to the core schema to keep in sync with DMS.

Two keywords will be added to the primary header:

MSACONFL - (string) stores the name of the configuration file with open shutter information 
MSAMETID - (number) identifier for the row in the metadata file which is relevant for this exposure.

Another keyword (MSACONID) is not going to be used by the pipeline code so it's not being added to the schema.