### PR TITLE
Fix for CALVER output json double-encoding.

### DIFF
--- a/jwst/cal_ver_steps.py
+++ b/jwst/cal_ver_steps.py
@@ -116,7 +116,7 @@ class StepVersions(object):
     def as_json(self):
         """ Return json string for output version information.
         """
-        return json.dumps(self.output, sort_keys=True)
+        return json.dumps(self.output, indent=4, sort_keys=True)
    
     def write_json(self,filename, clobber=False):
         """ Writes results out to json file.
@@ -151,7 +151,7 @@ class StepVersions(object):
                 raise IOError("previous version of {} found, clobber not set".format(filename))
 
         with open(filename,'w') as outfile:
-            outfile.write(json.dumps(json_out,indent=4,sort_keys=True))
+            outfile.write(json_out)
         if self.verbose:
             print("Versions written to {}".format(filename))
 


### PR DESCRIPTION
I noticed that the latest CALVER reference file contained a quoted string instead of simple JSON.   I think it's being "double-json-dumped" so this is my untested proposed fix.   Warren should look it over and perhaps just do his own tested branch and pull request,  I can't vouch that this even runs.   The end result should be pretty printed JSON in the CALVER file... which looks like readable Javascript source code defining data.  Nadia's WCS references are good examples of what it should look like,  e.g. the Contents pane of this CRDS page:  https://jwst-crds.stsci.edu/browse/jwst_miri_wcsregions_0001.json