### PR TITLE
improve domain calculation

### DIFF
--- a/jwst/assign_wcs/tests/test_nirspec.py
+++ b/jwst/assign_wcs/tests/test_nirspec.py
@@ -214,7 +214,7 @@ def test_nirspec_fs_esa():
     y = y + cor[1]
     x = x + cor[0]
     ra, dec, lp = w1(x, y)
-    assert_allclose(lp * 10**-6, lam[cond], atol=10**-10)
+    assert_allclose(lp, lam[cond], atol=10**-10)
     ref.close()
 
 


### PR DESCRIPTION
My best guess of how this should be done.
NRS2 is still way off, looks like it's x/y flipped.

Also this reverts the change of units from meters to microns for the IFU as it broke the IFU pipeline. Currently output wavelengths are still reported in meters.