### PR TITLE
Retrieve bintable column names from table instead of datamodels schema

### DIFF
--- a/jwst/datamodels/tests/test_storage.py
+++ b/jwst/datamodels/tests/test_storage.py
@@ -13,4 +13,4 @@ def test_gentle_asarray():
 
     y = util.gentle_asarray(x, new_dtype)
 
-    assert y['bar'][0] == 1.0
+    assert y['BAR'][0] == 1.0

--- a/jwst/datamodels/util.py
+++ b/jwst/datamodels/util.py
@@ -70,6 +70,10 @@ def gentle_asarray(a, dtype):
                     "Wrong number of columns.  Expected {0}, got {1}".format(
                         len(out_dtype), len(in_dtype)))
             new_dtype = []
+            # We cannot change the names in the dtype record because
+            # they are separately stored in the table _coldefs attribute
+            if hasattr(in_dtype, 'names') and hasattr(out_dtype, 'names'):
+                out_dtype.names = in_dtype.names
             for i in range(len(out_dtype.fields)):
                 in_type = in_dtype[i]
                 out_type = out_dtype[i]


### PR DESCRIPTION
While the bintable code makes some attempt to make column access independent of the column name case, the code is layered on numpy records, where access is case dependent. In practice, you must supply column names in the correct case. The function gentle_asarray coerces the type of data read from a model into the type given in the schema. However, in the case of numpy records, the field name is a part of the datatype. This leads to erroneious results if the case of the column name mentioned in the schema disagress with the case of the name in the binary table. The fix replaces the column names read from the schema with the column names from binary table.
