### PR TITLE
Keyword schema updates

### DIFF
--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -216,16 +216,16 @@ properties:
             title: Target Dec uncertainty
             type: number
             fits_keyword: TARGUDEC
-          proposer_ra:
-            title: Proposer specified RA for the target
+          proper_motion_ra:
+            title: Target proper motion in RA
             type: number
             fits_keyword: PROP_RA
-          proposer_dec:
-            title: Proposer specified Dec for the target
+          proper_motion_dec:
+            title: Target proper motion in Dec
             type: number
             fits_keyword: PROP_DEC
-          proposer_epoch:
-            title: Proposer specified epoch for RA and Dec
+          proper_motion_epoch:
+            title: Target proper motion epoch
             type: string
             fits_keyword: PROPEPOC
       instrument:

--- a/jwst/datamodels/schemas/multislit.schema.yaml
+++ b/jwst/datamodels/schemas/multislit.schema.yaml
@@ -56,26 +56,36 @@ allOf:
             default: 0
             fits_keyword: SLTSIZE2
             fits_hdu: SCI
+          slitlet_id:
+            title: Slitlet ID
+            type: integer
+            default: 0
+            fits_keyword: SLITID
+            fits_hdu: SCI
           source_id:
             title: Source ID
             type: integer
             default: 0
             fits_keyword: SOURCEID
             fits_hdu: SCI
-          background:
-            title: Background (T/F)
-            type: boolean
-            fits_keyword: BACKGRND
-            fits_hdu: SCI
-          shutter_state:
-            title: Shutter state
+          source_name:
+            title: Source name
             type: string
-            fits_keyword: SHUTTER
+            fits_keyword: SRCNAME
             fits_hdu: SCI
-          slitlet_id:
-            title: Slitlet ID
+          source_alias:
+            title: Source alias
+            type: string
+            fits_keyword: SRCALIAS
+            fits_hdu: SCI
+          catalog_id:
+            title: Catalog ID
             type: integer
-            default: 0
-            fits_keyword: SLITID
+            fits_keyword: CATLOGID
+            fits_hdu: SCI
+          stellarity:
+            title: Source stellarity
+            type: number
+            fits_keyword: STLARITY
             fits_hdu: SCI
 $schema: http://stsci.edu/schemas/fits-schema/fits-schema


### PR DESCRIPTION
Updated labels for the proper motion related keywords in the core schema. Added keywords to the mutlislit schema for storing source info from the NIRSpec MSA configuration file for each extracted slitlet. Will be needed for #212.