### PR TITLE
added dms2sca

### DIFF
--- a/jwst/assign_wcs/nirspec.py
+++ b/jwst/assign_wcs/nirspec.py
@@ -90,7 +90,7 @@ def imaging(input_model, reference_files):
 
     # Create coordinate frames in the NIRSPEC WCS pipeline
     # "detector", "gwa", "msa", "oteip", "v2v3", "world"
-    det, gwa, msa_frame, oteip, v2v3, world = create_imaging_frames()
+    det, sca, gwa, msa_frame, oteip, v2v3, world = create_imaging_frames()
     if input_model.meta.instrument.filter != 'OPAQUE':
         # MSA to OTEIP transform
         msa2ote = msa_to_oteip(reference_files)
@@ -103,14 +103,16 @@ def imaging(input_model, reference_files):
         # V2, V3 to wprld (RA, DEC) transform
         v23_to_sky = pointing.fitswcs_transform_from_model(input_model)
 
-        imaging_pipeline = [(det, det2gwa),
+        imaging_pipeline = [(det, dms2detector),
+                            (sca, det2gwa),
                             (gwa, gwa2msa),
                             (msa_frame, msa2oteip),
                             (oteip, oteip2v23),
                             (v2v3, v23_to_sky),
                             (world, None)]
     else:
-        imaging_pipeline = [(det, det2gwa),
+        imaging_pipeline = [(det, dms2detector),
+                            (sca, det2gwa),
                             (gwa, gwa2msa),
                             (msa_frame, None)]
 
@@ -140,7 +142,7 @@ def ifu(input_model, reference_files):
     # SLIT to MSA transform
     slit2msa = ifuslit_to_msa(slits, reference_files)
 
-    det, gwa, slit_frame, msa_frame, oteip, v2v3, world = create_frames()
+    det, sca, gwa, slit_frame, msa_frame, oteip, v2v3, world = create_frames()
     if input_model.meta.instrument.filter != 'OPAQUE':
         # MSA to OTEIP transform
         msa2oteip = ifu_msa_to_oteip(reference_files)
@@ -149,9 +151,10 @@ def ifu(input_model, reference_files):
         oteip2v23 = oteip_to_v23(reference_files)
 
         # Create coordinate frames in the NIRSPEC WCS pipeline"
-        # "detector", "gwa", "slit_frame", "msa_frame", "oteip", "v2v3"
+        # "detector", "gwa", "slit_frame", "msa_frame", "oteip", "v2v3", "world"
 
-        pipeline = [(det, det2gwa.rename('detector2gwa')),
+        pipeline = [(det, dms2detector),
+                    (sca, det2gwa.rename('detector2gwa')),
                     (gwa, gwa2slit.rename('gwa2slit')),
                     (slit_frame, (Mapping((0, 1, 2, 3, 4)) | slit2msa).rename('slit2msa')),
                     (msa_frame, msa2oteip.rename('msa2oteip')),
@@ -159,7 +162,8 @@ def ifu(input_model, reference_files):
                     (v2v3, None)]
     else:
 
-        pipeline = [(det, det2gwa.rename('detector2gwa')),
+        pipeline = [(det, dms2detector),
+                    (sca, det2gwa.rename('detector2gwa')),
                     (gwa, gwa2slit.rename('gwa2slit')),
                     (slit_frame, (Mapping((0, 1, 2, 3, 4)) | slit2msa).rename('slit2msa')),
                     (msa_frame, None)]
@@ -191,6 +195,8 @@ def slits_wcs(input_model, reference_files):
     input_model.meta.wcsinfo.waverange_end = wrange[1]
     input_model.meta.wcsinfo.spectral_order = sporder
 
+    # DMS to SCA transform
+    dms2detector = dms_to_sca(input_model)
     # DETECTOR to GWA transform
     det2gwa = Identity(2) & detector_to_gwa(reference_files, input_model.meta.instrument.detector, disperser)
     #det2gwa = detector_to_gwa(reference_files, input_model.meta.instrument.detector, disperser)
@@ -203,7 +209,7 @@ def slits_wcs(input_model, reference_files):
 
     # Create coordinate frames in the NIRSPEC WCS pipeline"
     # "detector", "gwa", "slit_frame", "msa_frame", "oteip", "v2v3", "world"
-    det, gwa, slit_frame, msa_frame, oteip, v2v3, world = create_frames()
+    det, sca, gwa, slit_frame, msa_frame, oteip, v2v3, world = create_frames()
     if input_model.meta.instrument.filter != 'OPAQUE':
         # MSA to OTEIP transform
         msa2oteip = msa_to_oteip(reference_files)
@@ -212,18 +218,19 @@ def slits_wcs(input_model, reference_files):
         oteip2v23 = oteip_to_v23(reference_files)
 
         # V2, V3 to wprld (RA, DEC ,LAMBDA) transform
-        v23_to_sky = pointing.fitswcs_transform_from_model(input_model)
-        v23_to_world = v23_to_sky & Identity(1)
+        #v23_to_sky = pointing.fitswcs_transform_from_model(input_model)
+        #v23_to_world = v23_to_sky & Identity(1)
 
-        msa_pipeline = [(det, det2gwa),
+        msa_pipeline = [(det, dms2detector),
+                        (sca, det2gwa),
                         (gwa, gwa2slit),
                         (slit_frame, Mapping((0, 1, 2, 3, 4)) | slit2msa),
                         (msa_frame, msa2oteip),
                         (oteip, oteip2v23),
-                        (v2v3, v23_to_world),
-                        (world, None)]
+                        (v2v3, None)]
     else:
-        msa_pipeline = [(det, det2gwa),
+        msa_pipeline = [(det, dms2detector),
+                        (sca, det2gwa),
                         (gwa, gwa2slit),
                         (slit_frame, Mapping((0, 1, 2, 3, 4)) | slit2msa),
                         (msa_frame, None)]
@@ -516,8 +523,28 @@ def detector_to_gwa(reference_files, detector, disperser):
                disperser['theta_z'], disperser['tilt_y']]
     rotation = Rotation3DToGWA(angles, axes_order="xyzy", name='rotaton')
     u2dircos = Unitless2DirCos(name='unitless2directional_cosines')
-    model = (fpa | camera | u2dircos | rotation)
+    model = (models.Shift(-1) & models.Shift(-1) | fpa | camera | u2dircos | rotation)
     return model
+
+
+def dms_to_sca(input_model):
+    """
+    Transforms from SCA to DMS coordinates.
+    """
+    detector = input_model.meta.instrument.detector
+    xstart = input_model.meta.subarray.xstart
+    ystart = input_model.meta.subarray.ystart
+    if xstart is None:
+        xstart = 1
+    if ystart is None:
+        ystart = 1
+    # The SCA coordinates are in full frame
+    subarray2full = models.Shift(xstart) & models.Shift(ystart)
+    if detector == 'NRS2':
+        model = models.Shift(-2048) & models.Shift(-2048) | models.Scale(-1) & models.Scale(-1)
+    elif detector == 'NRS1':
+        model = models.Identity(2)
+    return subarray2full | model
 
 
 def compute_domain(slit2detector, wavelength_range, slit_ymin=-.5, slit_ymax=.5):
@@ -554,6 +581,7 @@ def compute_domain(slit2detector, wavelength_range, slit_ymin=-.5, slit_ymax=.5)
     # add 2 px margin
     y0 = int(y_range.min()) - 2
     y1 = int(y_range.max()) + 2
+
     domain = [{'lower': x0, 'upper': x1}, {'lower': y0, 'upper': y1}]
     return domain
 
@@ -674,6 +702,7 @@ def ifu_msa_to_oteip(reference_files):
     fore_transform = msa2fore_mapping | fore & Identity(1)
     return msa2fore_mapping | ifu_fore_transform | fore_transform
 
+
 def msa_to_oteip(reference_files):
     """
     Transform from the MSA frame to the OTEIP frame.
@@ -727,6 +756,7 @@ def create_frames():
     "detector", "gwa", "slit_frame", "msa_frame", "oteip", "v2v3", "world".
     """
     det = cf.Frame2D(name='detector', axes_order=(0, 1))
+    sca = cf.Frame2D(name='sca', axes_order=(0, 1))
     gwa = cf.Frame2D(name="gwa", axes_order=(0, 1), unit=(u.rad, u.rad),
                       axes_names=('alpha_in', 'beta_in'))
     msa_spatial = cf.Frame2D(name='msa_spatial', axes_order=(0, 1), unit=(u.m, u.m),
@@ -745,7 +775,7 @@ def create_frames():
                                axes_names=('X_OTEIP', 'Y_OTEIP'))
     oteip = cf.CompositeFrame([oteip_spatial, spec], name='oteip')
     world = cf.CompositeFrame([sky, spec], name='world')
-    return det, gwa, slit_frame, msa_frame, oteip, v2v3, world
+    return det, sca, gwa, slit_frame, msa_frame, oteip, v2v3, world
 
 
 def create_imaging_frames():
@@ -755,6 +785,7 @@ def create_imaging_frames():
     "detector", "gwa", "msa_frame", "oteip", "v2v3", "world".
     """
     det = cf.Frame2D(name='detector', axes_order=(0, 1))
+    sca = cf.Frame2D(name='sca', axes_order=(0, 1))
     gwa = cf.Frame2D(name="gwa", axes_order=(0, 1), unit=(u.rad, u.rad),
                       axes_names=('alpha_in', 'beta_in'))
     msa = cf.Frame2D(name='msa', axes_order=(0, 1), unit=(u.m, u.m),
@@ -764,7 +795,7 @@ def create_imaging_frames():
     oteip = cf.Frame2D(name='oteip', axes_order=(0, 1), unit=(u.arcsec, u.arcsec),
                                axes_names=('x_oteip', 'y_oteip'))
     world = cf.CelestialFrame(name='world', axes_order=(0, 1), reference_frame=coord.ICRS())
-    return det, gwa, msa, oteip, v2v3, world
+    return det, sca, gwa, msa, oteip, v2v3, world
 
 
 def get_slit_location_model(slitdata):
@@ -811,7 +842,7 @@ def gwa_to_ymsa(msa2gwa_model):
     return poly_model
 
 
-def nrs_wcs_set_input(wcsobj, quadrant, slitid, wavelength_range):
+def nrs_wcs_set_input(input_model, quadrant, slitid, wavelength_range=None):
     """
     Returns a WCS object for this slit.
 
@@ -832,16 +863,21 @@ def nrs_wcs_set_input(wcsobj, quadrant, slitid, wavelength_range):
         WCS object for this slit.
     """
     import copy # TODO: Add a copy method to gwcs.WCS
+    wcsobj = input_model.meta.wcs
+    if wavelength_range is None:
+        _, wrange = spectral_order_wrange_from_model(input_model)
+    else:
+        wrange = wavelength_range
     slit = slitid_to_slit(np.array([(quadrant, slitid)]))[0]
     slit_wcs = copy.deepcopy(wcsobj)
-    slit_wcs.set_transform('detector', 'gwa', wcsobj.pipeline[0][1][1:])
+    slit_wcs.set_transform('sca', 'gwa', wcsobj.pipeline[1][1][1:])
     #slit_wcs.set_transform('detector', 'gwa', wcsobj.pipeline[0][1])
-    slit_wcs.set_transform('gwa', 'slit_frame', wcsobj.pipeline[1][1].models[slit])
-    slit_wcs.set_transform('slit_frame', 'msa_frame', wcsobj.pipeline[2][1][1].models[slit] & Identity(1))
+    slit_wcs.set_transform('gwa', 'slit_frame', wcsobj.pipeline[2][1].models[slit])
+    slit_wcs.set_transform('slit_frame', 'msa_frame', wcsobj.pipeline[3][1][1].models[slit] & Identity(1))
 
     slit2detector = slit_wcs.get_transform('slit_frame', 'detector')
 
-    domain = compute_domain(slit2detector, wavelength_range)
+    domain = compute_domain(slit2detector, wrange)
     slit_wcs.domain = domain
     return slit_wcs
 

--- a/jwst/assign_wcs/nirspec.py
+++ b/jwst/assign_wcs/nirspec.py
@@ -533,7 +533,7 @@ def detector_to_gwa(reference_files, detector, disperser):
 
 def dms_to_sca(input_model):
     """
-    Transforms from SCA to DMS coordinates.
+    Transforms from DMS to SCA coordinates.
     """
     detector = input_model.meta.instrument.detector
     xstart = input_model.meta.subarray.xstart

--- a/jwst/assign_wcs/nirspec.py
+++ b/jwst/assign_wcs/nirspec.py
@@ -63,6 +63,8 @@ def imaging(input_model, reference_files):
     # Get the corrected disperser model
     disperser = get_disperser(input_model, reference_files['disperser'])
 
+    # DMS to SCA transform
+    dms2detector = dms_to_sca(input_model)
     # DETECTOR to GWA transform
     det2gwa = detector_to_gwa(reference_files, input_model.meta.instrument.detector, disperser)
 
@@ -133,6 +135,8 @@ def ifu(input_model, reference_files):
     input_model.meta.wcsinfo.waverange_end = wrange[1]
     input_model.meta.wcsinfo.spectral_order = sporder
 
+    # DMS to SCA transform
+    dms2detector = dms_to_sca(input_model)
     # DETECTOR to GWA transform
     det2gwa = Identity(2) & detector_to_gwa(reference_files, input_model.meta.instrument.detector, disperser)
 

--- a/jwst/assign_wcs/tests/test_nirspec.py
+++ b/jwst/assign_wcs/tests/test_nirspec.py
@@ -144,9 +144,8 @@ def test_nirspec_ifu_against_esa():
     pipe = nirspec.create_pipeline(im, refs)
     w = wcs.WCS(pipe)
     im.meta.wcs = w
-    _, wrange = nirspec.spectral_order_wrange_from_model(im)
     # Test evaluating the WCS
-    w0 = nirspec.nrs_wcs_set_input(im.meta.wcs, 0, 0, wrange)
+    w0 = nirspec.nrs_wcs_set_input(im, 0, 0)
 
     ref = fits.open(get_file_path('Trace_IFU_Slice_00_MON-COMBO-IFU-06_8410_jlab85.fits.gz'))
     crpix = np.array([ref[1].header['crpix1'], ref[1].header['crpix2']])
@@ -181,7 +180,7 @@ def test_nirspec_mos():
     im.meta.wcs = w
     # Test evaluating the WCS
     _, wrange = nirspec.spectral_order_wrange_from_model(im)
-    w1 = nirspec.nrs_wcs_set_input(im.meta.wcs, 4, 5824, wrange)
+    w1 = nirspec.nrs_wcs_set_input(im, 4, 5824, wrange)
     w1(1, 2)
 '''
 
@@ -198,8 +197,7 @@ def test_nirspec_fs_esa():
     w = wcs.WCS(pipe)
     im.meta.wcs = w
     # Test evaluating the WCS
-    _, wrange = nirspec.spectral_order_wrange_from_model(im)
-    w1 = nirspec.nrs_wcs_set_input(im.meta.wcs, 5, 1, wrange)
+    w1 = nirspec.nrs_wcs_set_input(im, 5, 1)
 
     ref = fits.open(get_file_path('Trace_SLIT_A_200_1_SLIT-COMBO-016_9791_jlab85_0001.fits.gz'))
     crpix = np.array([ref[1].header['crpix1'], ref[1].header['crpix2']])

--- a/jwst/assign_wcs/tests/test_nirspec.py
+++ b/jwst/assign_wcs/tests/test_nirspec.py
@@ -162,7 +162,7 @@ def test_nirspec_ifu_against_esa():
     x = x + cor[0]
 
     ra, dec, lp = w0(x, y)
-    assert_allclose(lp, lam[cond], atol=10**-10)
+    assert_allclose(lp, lam[cond], atol=10**-13)
     ref.close()
 
 '''
@@ -212,7 +212,7 @@ def test_nirspec_fs_esa():
     y = y + cor[1]
     x = x + cor[0]
     ra, dec, lp = w1(x, y)
-    assert_allclose(lp, lam[cond], atol=10**-10)
+    assert_allclose(lp, lam[cond], atol=10**-13)
     ref.close()
 
 


### PR DESCRIPTION
The NIRSpec model goes to SCA coordinates. This PR adds another frame called "sca". The name "detector" frame now refers to the DMS coordinates. The Transform from DMS to SCA coordinates was added to the pipelines. 
In addition, passing a wavelength_range to `nirspec.nrs_wcs_set_input` is now optional, it retrieves the default range from the model.
This includes the corresponding changes in extract_2d.