### PR TITLE
Schema update for #82

### DIFF
--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -357,7 +357,7 @@ properties:
           gwa_tilt:
             title: GWA TILT (avg/calib) temperature
             type: number
-            fits_keyword: GWA_TILT
+            fits_keyword: GWA_TTIL
       exposure:
         title: Exposure parameters
         type: object


### PR DESCRIPTION
Changed the core schema entry for the NIRSpec GWA tilt sensor temperature from a FITS keyword name of GWA_TILT to GWA_TTIL. Fixes #82.