### PR TITLE
Fix problems uncovered by badly formed test image

### DIFF
--- a/jwst/datamodels/__init__.py
+++ b/jwst/datamodels/__init__.py
@@ -170,7 +170,7 @@ def open(init=None, extensions=None):
 
         shape = ()
         try:
-            hdu = hdulist[fits_header_name('SCI')]
+            hdu = hdulist[(fits_header_name('SCI'), 1)]
         except KeyError:
             pass
         else:

--- a/jwst/datamodels/properties.py
+++ b/jwst/datamodels/properties.py
@@ -27,6 +27,9 @@ def _cast(val, schema):
     val = _unmake_node(val)
     if val is not None:
         if 'datatype' in schema:
+            # Handle lazy array
+            if isinstance(val, ndarray.NDArrayType):
+                val = val._make_array()
             val = util.gentle_asarray(
                 val, ndarray.asdf_datatype_to_numpy_dtype(schema['datatype']))
         if 'ndim' in schema and len(val.shape) != schema['ndim']:

--- a/jwst/datamodels/util.py
+++ b/jwst/datamodels/util.py
@@ -89,9 +89,12 @@ def gentle_asarray(a, dtype):
                 else:
                     return np.asarray(a, dtype=out_dtype)
             return a.view(dtype=np.dtype(new_dtype))
-
-    return np.asarray(a, dtype=out_dtype)
-
+    else:
+        try:
+            a = np.asarray(a, dtype=out_dtype)
+        except:
+            raise ValueError("Can't convert {0!s} to ndarray".fornat(type(a)))
+        return a
 
 def get_short_doc(schema):
     title = schema.get('title', None)


### PR DESCRIPTION
Three potential problems were found and fixed. None should happen with
corectly formatted images.

The first change was to datamodels/__init__.py. There is a test on the
dimesnions of the image in open in order to determine the right class
to use. The change uses an explicit extension version in case there is
more than one SCI extension in an image.

The second change is to _cast in datamodels/properties.py. If the
object to be cast is a NDArrayType, then it is lazy and must first be
instantiated with a call to _make_array before calling gentle_asarray.

The third change is to gentle_asarray in datamodels/util.py. The new
code traps any error when calling numpy.asarray on an object that is
not a numpy.ndarray and reports the object as having a bad type.