### PR TITLE
Updates to level-3 pipelines for change in ASN product names

### DIFF
--- a/jwst/pipeline/calwebb_ami3.py
+++ b/jwst/pipeline/calwebb_ami3.py
@@ -21,20 +21,18 @@ log.setLevel(logging.DEBUG)
 
 class Ami3Pipeline(Pipeline):
     """
-
     Ami3Pipeline: Apply all level-3 calibration steps to an
     association of level-2b AMI exposures. Included steps are:
     ami_analyze (fringe detection)
     ami_average (average results of fringe detection)
     ami_normalize (normalize results by reference target)
-
     """
 
     spec = """
         save_averages = boolean(default=False)
     """
 
-    # Define alias to steps
+    # Define aliases to steps
     step_defs = {'ami_analyze': ami_analyze_step.AmiAnalyzeStep,
                  'ami_average': ami_average_step.AmiAverageStep,
                  'ami_normalize': ami_normalize_step.AmiNormalizeStep
@@ -57,11 +55,11 @@ class Ami3Pipeline(Pipeline):
         for member in prod['members']:
             if member['exptype'].upper() == 'PSF':
                 psf_files.append(member['expname'])
-                log.debug(' psf_file {0} = {1}'.format(len(psf_files),
+                log.info('reference psf file {0} = {1}'.format(len(psf_files),
                           member['expname']))
             if member['exptype'].upper() == 'SCIENCE':
                 targ_files.append(member['expname'])
-                log.debug(' targ_file {0} = {1}'.format(len(targ_files),
+                log.info('target file {0} = {1}'.format(len(targ_files),
                           member['expname']))
 
         # Make sure we found some science target members
@@ -76,30 +74,36 @@ class Ami3Pipeline(Pipeline):
             log.info('ami_normalize step will be skipped')
 
         # Loop over all the images in the assocation
+        psf_files = []
+        targ_files = []
         for member in prod['members']:
             input_file = member['expname']
 
             # Do the LG analysis for this image
-            log.debug(' Do LG processing for member %s', input_file)
+            log.debug('Do LG processing for member %s', input_file)
             result = self.ami_analyze(input_file)
 
             # Save the LG analysis results to a file
             output_file = mk_filename(self.output_dir, input_file, 'lg')
-            self.log.info(' Saving LG results to %s', output_file)
+            self.log.info('Saving LG results to %s', output_file)
             result.save(output_file)
 
-        # Average the PSF image results
+            # Save the result file name for input to ami_average
+            if member['exptype'].upper() == 'PSF':
+                psf_files.append(output_file)
+            if member['exptype'].upper() == 'SCIENCE':
+                targ_files.append(output_file)
+
+        # Average the reference PSF image results
         psf_avg = None
         if len(psf_files) > 0:
-            self.log.debug(' Calling ami_average for PSF results ...')
+            self.log.debug('Calling ami_average for PSF results ...')
             psf_avg = self.ami_average(psf_files)
 
             # Save the results to a file, if requested
             if self.save_averages:
-                output_file = prod['name'].format(product_type='lgavgr')
-                if self.output_dir is not None:
-                    output_file = os.path.join(self.output_dir, output_file)
-                self.log.info(' Saving average PSF results to %s', output_file)
+                output_file = mk_prodname(self.output_dir, prod['name'], 'lgavgr')
+                self.log.info('Saving averaged PSF results to %s', output_file)
                 psf_avg.save(output_file)
 
         # Average the science target image results
@@ -109,10 +113,8 @@ class Ami3Pipeline(Pipeline):
 
             # Save the results to a file, if requested
             if self.save_averages:
-                output_file = prod['name'].format(product_type='lgavgt')
-                if self.output_dir is not None:
-                    output_file = os.path.join(self.output_dir, output_file)
-                self.log.info(' Saving average target results to %s', output_file)
+                output_file = mk_prodname(self.output_dir, prod['name'], 'lgavgt')
+                self.log.info('Saving averaged target results to %s', output_file)
                 targ_avg.save(output_file)
 
         # Now that all LGAVG products have been produced, do normalization of
@@ -122,10 +124,8 @@ class Ami3Pipeline(Pipeline):
             result = self.ami_normalize(targ_avg, psf_avg)
 
             # Save the result
-            output_file = prod['name'].format(product_type='lgnorm')
-            if self.output_dir is not None:
-                output_file = os.path.join(self.output_dir, output_file)
-            self.log.info(' Saving normalized result to %s', output_file)
+            output_file = mk_prodname(self.output_dir, prod['name'], 'lgnorm')
+            self.log.info('Saving normalized result to %s', output_file)
             result.save(output_file)
             result.close()
 
@@ -137,6 +137,29 @@ class Ami3Pipeline(Pipeline):
 
 def mk_filename(output_dir, filename, suffix):
 
+    """
+    Build a file name to use when saving results.
+
+    An existing input file name is used as a template. A user-specified
+    output directory path is prepended to the root of the input file name.
+    The last product type suffix contained in the input file name is
+    replaced with the specified new suffix. Any existing file name
+    extension (e.g. ".fits") is preserved.
+
+    Args:
+        output_dir (str): The output_dir requested by the user
+        filename (str): The input file name, to be reworked
+        suffix (str): The desired file type suffix for the new file name
+
+    Returns:
+        string: The new file name
+
+    Examples:
+        For output_dir='/my/path', filename='jw12345_nrca_cal.fits', and
+        suffix='i2d', the returned file name will be
+        '/my/path/jw12345_nrca_i2d.fits'
+    """
+
     # If the user specified an output_dir, replace any existing
     # path with output_dir
     if output_dir is not None:
@@ -146,3 +169,42 @@ def mk_filename(output_dir, filename, suffix):
     # Now replace the existing suffix with the new one
     base, ext = os.path.splitext(filename)
     return base[:base.rfind('_')] + '_' + suffix + ext
+
+
+def mk_prodname(output_dir, filename, suffix):
+
+    """
+    Build a file name based on an ASN product name template.
+
+    The input ASN product name is used as a template. A user-specified
+    output directory path is prepended to the root of the product name.
+    The input product type suffix is appended to the root of the input
+    product name, preserving any existing file name extension 
+    (e.g. ".fits").
+
+    Args:
+        output_dir (str): The output_dir requested by the user
+        filename (str): The input file name, to be reworked
+        suffix (str): The desired file type suffix for the new file name
+
+    Returns:
+        string: The new file name
+
+    Examples:
+        For output_dir='/my/path', filename='jw12345_nrca_cal.fits', and
+        suffix='i2d', the returned file name will be
+        '/my/path/jw12345_nrca_cal_i2d.fits'
+    """
+
+    # If the user specified an output_dir, replace any existing
+    # path with output_dir
+    if output_dir is not None:
+        dirname, filename = os.path.split(filename)
+        filename = os.path.join(output_dir, filename)
+
+    # Now append the new suffix to the root name, preserving
+    # any existing extension
+    base, ext = os.path.splitext(filename)
+    if len(ext) == 0:
+        ext = ".fits"
+    return base + '_' + suffix + ext

--- a/jwst/pipeline/calwebb_coron3.py
+++ b/jwst/pipeline/calwebb_coron3.py
@@ -22,7 +22,6 @@ log.setLevel(logging.DEBUG)
 
 class Coron3Pipeline(Pipeline):
     """
-
     Coron3Pipeline: Apply all level-3 calibration steps to a
     coronagraphic association of exposures. Included steps are:
     stack_refs (assemble reference PSF inputs)
@@ -30,12 +29,12 @@ class Coron3Pipeline(Pipeline):
     klip (PSF subtraction using the KLIP algorithm)
     outlier_detection (flag outliers)
     resample (image combination and resampling)
-
     """
+
     spec = """
     """
 
-    # Define alias to steps
+    # Define aliases to steps
     step_defs = {'stack_refs': stack_refs_step.StackRefsStep,
                  'align_refs': align_refs_step.AlignRefsStep,
                  'klip': klip_step.KlipStep,
@@ -60,11 +59,11 @@ class Coron3Pipeline(Pipeline):
         for member in prod['members']:
             if member['exptype'].upper() == 'PSF':
                 psf_files.append(member['expname'])
-                log.debug(' psf_file {0} = {1}'.format(len(psf_files),
+                log.info('psf file {0} = {1}'.format(len(psf_files),
                           member['expname']))
             if member['exptype'].upper() == 'SCIENCE':
                 targ_files.append(member['expname'])
-                log.debug(' targ_file {0} = {1}'.format(len(targ_files),
+                log.info('target file {0} = {1}'.format(len(targ_files),
                           member['expname']))
 
         # Make sure we found some PSF and target members
@@ -91,9 +90,7 @@ class Coron3Pipeline(Pipeline):
         psf_models.close()
 
         # Save the resulting PSF stack
-        output_file = prod['name'].format(product_type='psfstack')
-        if self.output_dir is not None:
-            output_file = os.path.join(self.output_dir, output_file)
+        output_file = mk_prodname(self.output_dir, prod['name'], 'psfstack')
         log.info('Saving psfstack file %s', output_file)
         psf_stack.save(output_file)
 
@@ -103,7 +100,7 @@ class Coron3Pipeline(Pipeline):
         for target_file in targ_files:
 
             # Call align_refs
-            log.debug(' Calling align_refs for member %s', target_file)
+            log.debug('Calling align_refs for member %s', target_file)
             psf_aligned = self.align_refs(target_file, psf_stack)
 
             # Save the alignment results
@@ -112,7 +109,7 @@ class Coron3Pipeline(Pipeline):
             psf_aligned.save(filename)
 
             # Call KLIP
-            log.debug(' Calling klip for member %s', target_file)
+            log.debug('Calling klip for member %s', target_file)
             #psf_sub, psf_fit = self.klip(target_file, psf_aligned)
             psf_sub = self.klip(target_file, psf_aligned)
             psf_aligned.close()
@@ -124,7 +121,7 @@ class Coron3Pipeline(Pipeline):
 
             # Create a ModelContainer of the psf_sub results to send to
             # outlier_detection
-            log.debug(' Building ModelContainer of klip results')
+            log.debug('Building ModelContainer of klip results')
             target_models = datamodels.ModelContainer()
             for i in range(psf_sub.data.shape[0]):
                 image = datamodels.ImageModel(data=psf_sub.data[i],
@@ -144,10 +141,8 @@ class Coron3Pipeline(Pipeline):
         result = self.resample(resample_input)
 
         # Save the final result
-        output_file = prod['name'].format(product_type='coroncmb')
-        if self.output_dir is not None:
-            output_file = os.path.join(self.output_dir, output_file)
-        self.log.info(' Saving final result to %s', output_file)
+        output_file = mk_prodname(self.output_dir, prod['name'], 'coroncmb')
+        self.log.info('Saving final result to %s', output_file)
         result.save(output_file)
         result.close()
 
@@ -159,6 +154,29 @@ class Coron3Pipeline(Pipeline):
 
 def mk_filename(output_dir, filename, suffix):
 
+    """
+    Build a file name to use when saving results.
+
+    An existing input file name is used as a template. A user-specified
+    output directory path is prepended to the root of the input file name.
+    The last product type suffix contained in the input file name is
+    replaced with the specified new suffix. Any existing file name
+    extension (e.g. ".fits") is preserved.
+
+    Args:
+        output_dir (str): The output_dir requested by the user
+        filename (str): The input file name, to be reworked
+        suffix (str): The desired file type suffix for the new file name
+
+    Returns:
+        string: The new file name
+
+    Examples:
+        For output_dir='/my/path', filename='jw12345_nrca_cal.fits', and
+        suffix='i2d', the returned file name will be
+        '/my/path/jw12345_nrca_i2d.fits'
+    """
+
     # If the user specified an output_dir, replace any existing
     # path with output_dir
     if output_dir is not None:
@@ -168,3 +186,42 @@ def mk_filename(output_dir, filename, suffix):
     # Now replace the existing suffix with the new one
     base, ext = os.path.splitext(filename)
     return base[:base.rfind('_')] + '_' + suffix + ext
+
+
+def mk_prodname(output_dir, filename, suffix):
+
+    """
+    Build a file name based on an ASN product name template.
+
+    The input ASN product name is used as a template. A user-specified
+    output directory path is prepended to the root of the product name.
+    The input product type suffix is appended to the root of the input
+    product name, preserving any existing file name extension 
+    (e.g. ".fits").
+
+    Args:
+        output_dir (str): The output_dir requested by the user
+        filename (str): The input file name, to be reworked
+        suffix (str): The desired file type suffix for the new file name
+
+    Returns:
+        string: The new file name
+
+    Examples:
+        For output_dir='/my/path', filename='jw12345_nrca_cal.fits', and
+        suffix='i2d', the returned file name will be
+        '/my/path/jw12345_nrca_cal_i2d.fits'
+    """
+
+    # If the user specified an output_dir, replace any existing
+    # path with output_dir
+    if output_dir is not None:
+        dirname, filename = os.path.split(filename)
+        filename = os.path.join(output_dir, filename)
+
+    # Now append the new suffix to the root name, preserving
+    # any existing extension
+    base, ext = os.path.splitext(filename)
+    if len(ext) == 0:
+        ext = ".fits"
+    return base + '_' + suffix + ext


### PR DESCRIPTION
Updated calwebb_coron3 and calwebb_ami3 pipeline modules to use new way of building output product file names from the product name specified in the ASN table. This method assumes the ASN product name is a "bare" root name and needs to have the appropriate product type suffix and extension appended to it.

Still need to update calwebb_image3 to incorporate similar changes.