### PR TITLE
Adjust fits record names to match schema

### DIFF
--- a/jwst/datamodels/tests/test_storage.py
+++ b/jwst/datamodels/tests/test_storage.py
@@ -13,4 +13,4 @@ def test_gentle_asarray():
 
     y = util.gentle_asarray(x, new_dtype)
 
-    assert y['BAR'][0] == 1.0
+    assert y['bar'][0] == 1.0

--- a/jwst/datamodels/util.py
+++ b/jwst/datamodels/util.py
@@ -70,10 +70,9 @@ def gentle_asarray(a, dtype):
                     "Wrong number of columns.  Expected {0}, got {1}".format(
                         len(out_dtype), len(in_dtype)))
             new_dtype = []
-            # We cannot change the names in the dtype record because
-            # they are separately stored in the table _coldefs attribute
-            if hasattr(in_dtype, 'names') and hasattr(out_dtype, 'names'):
-                out_dtype.names = in_dtype.names
+            # Change the fits record names to match the schema names
+            if hasattr(a.dtype, 'names') and hasattr(out_dtype, 'names'):
+                a.dtype.names = out_dtype.names
             for i in range(len(out_dtype.fields)):
                 in_type = in_dtype[i]
                 out_type = out_dtype[i]


### PR DESCRIPTION
Function gentle_asarray coerces datatypes to match the type specified
in the schema. This can lead to a mismatch with the column names in
the table. Something has to give and previously I overrode the schema
column names with the fits record column names. This caused
regressions in the overnight tests. This fix flips the coercion and
updates the fits record column names to match the schema column
names. I hadn't done this before because I though the change was more
difficult.