### PR TITLE
Fix handling of MultiSlitModels

### DIFF
--- a/jwst/background/subtract_images_step.py
+++ b/jwst/background/subtract_images_step.py
@@ -40,16 +40,10 @@ class SubtractImagesStep(Step):
 
         if isinstance(model1, datamodels.CubeModel):
             self.log.debug('Input is a CubeModel')
-            model1.close()
-            model1 = datamodels.CubeModel(input1)
         elif isinstance(model1, datamodels.ImageModel):
             self.log.debug('Input is an ImageModel')
-            model1.close()
-            model1 = datamodels.ImageModel(input1)
-        elif isinstance(model1, datamodels.DataModel):
+        elif isinstance(model1, datamodels.MultiSlitModel):
             self.log.debug('Input is a MultiSlitModel')
-            model1.close()
-            model1 = datamodels.MultiSlitModel(input1)
 
         # Assume that the second input model is always Image or MultiSlit with
         # a single image, which is safe to open as MultiSlit for either case

--- a/jwst/datamodels/__init__.py
+++ b/jwst/datamodels/__init__.py
@@ -207,9 +207,16 @@ def open(init=None, extensions=None):
         from . import cube
         new_class = cube.CubeModel
     elif len(shape) == 2:
-        # It's an ImageModel
-        from . import image
-        new_class = image.ImageModel
+        try:
+            hdu = hdulist[(fits_header_name('SCI'), 2)]
+        except KeyError:
+            # It's an ImageModel
+            from . import image
+            new_class = image.ImageModel
+        else:
+            # It's a MultiSlitModel
+            from . import multislit
+            new_class = multislit.MultiSlitModel
     else:
         raise ValueError("Don't have a DataModel class to match the shape")
 

--- a/jwst/datamodels/__init__.py
+++ b/jwst/datamodels/__init__.py
@@ -209,7 +209,7 @@ def open(init=None, extensions=None):
     elif len(shape) == 2:
         try:
             hdu = hdulist[(fits_header_name('SCI'), 2)]
-        except KeyError:
+        except (KeyError, NameError):
             # It's an ImageModel
             from . import image
             new_class = image.ImageModel

--- a/jwst/extract_1d/extract_1d_step.py
+++ b/jwst/extract_1d/extract_1d_step.py
@@ -31,11 +31,9 @@ class Extract1dStep(Step):
         elif isinstance(input_model, datamodels.ImageModel):
             # It's a single 2-D image
             self.log.debug('Input is an ImageModel')
-        elif isinstance(input_model, datamodels.DataModel):
+        elif isinstance(input_model, datamodels.MultiSlitModel):
             # It's a MultiSlitModel
             self.log.debug('Input is a MultiSlitModel')
-            input_model.close()
-            input_model = datamodels.MultiSlitModel(input)
 
         # Get the reference file name
         self.ref_file = self.get_reference_file(input_model, 'extract1d')

--- a/jwst/flatfield/flat_field_step.py
+++ b/jwst/flatfield/flat_field_step.py
@@ -26,10 +26,8 @@ class FlatFieldStep(Step):
             self.log.debug('Input is a CubeModel')
         elif isinstance(input_model, datamodels.ImageModel):
             self.log.debug('Input is an ImageModel')
-        elif isinstance(input_model, datamodels.DataModel):
+        elif isinstance(input_model, datamodels.MultiSlitModel):
             self.log.debug('Input is a MultiSlitModel')
-            input_model.close()
-            input_model = datamodels.MultiSlitModel(input)
 
         # Retrieve the reference file name
         self.flat_filename = self.get_reference_file(input_model, 'flat')

--- a/jwst/photom/photom_step.py
+++ b/jwst/photom/photom_step.py
@@ -25,10 +25,8 @@ class PhotomStep(Step):
             self.log.debug('Input is a CubeModel for a multiple integ file.')
         elif isinstance(dm, datamodels.ImageModel):  # standard product: 2D array
             self.log.debug('Input is an ImageModel.')
-        elif isinstance(dm, datamodels.DataModel): # multi 2D arrays
+        elif isinstance(dm, datamodels.MultiSlitModel): # multi 2D arrays
             self.log.debug('Input is a MultiSlitModel.')
-            dm.close()
-            dm = datamodels.MultiSlitModel(input_file)
         else:
             self.log.warning('Input is not a CubeModel, ImageModel or MultiSlitModel.')
 


### PR DESCRIPTION
The recent change to the datamodels __init__ function, to handle input FITS files that have more than one SCI extension, broke the functionality that had been relied on for detecting that an input dataset is a MultiSlitModel. In the past, a FITS file with more than one SCI extension would throw an error, in which case the model was returned as a plain DataModel. That was used in some cal steps to detect the presence of a MultiSlitModel. After the recent update, files with more than one SCI extension no longer trigger an error, so MultiSlit files were being loaded into an ImageModel, because they are 2-dimensional. This causes all kinds of havoc with the multiple sets of SCI, ERR, DQ extensions not getting passed along in the data model.

So I updated the datamodels __init__ to check for the presence of a 2nd SCI extension when the data in 2-dimensional and if a 2nd SCI extension is there, it assumes it's a MultiSlitModel. So now a call to the generic datamodels.open will return a MultiSlitModel instance.

This required changes to several cal steps that checked to see if the returned datamodel was an instance of DataModel. If so, it assumed it was a MultiSlitModel. That check is no longer required, because the model will be returned as a MultiSlitModel to begin with.