### PR TITLE
Replace targname with more generic target

### DIFF
--- a/jwst/associations/association.py
+++ b/jwst/associations/association.py
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
 # Timestamp template
-_TIMESTAMP_TEMPLATE = '%Y%m%dT%H%M%S'
+_TIMESTAMP_TEMPLATE = '%Y%m%dt%H%M%S'
 
 
 class Association(MutableMapping):
@@ -39,10 +39,9 @@ class Association(MutableMapping):
     member: dict
         The member to initialize the association with.
 
-    timestamp: str
-        Timestamp to use in the name of this association. Should conform
-        to the datetime.strftime format '%Y%m%dT%M%H%S'. If None, class
-        instantiation will create this string using current time.
+    version_id: str or None
+        Version_Id to use in the name of this association.
+        If None, nothing is added.
 
     Raises
     ------
@@ -90,7 +89,7 @@ class Association(MutableMapping):
     def __init__(
             self,
             member=None,
-            timestamp=None,
+            version_id=None,
     ):
 
         self.data = dict()
@@ -98,15 +97,12 @@ class Association(MutableMapping):
         self.run_init_hook = True
         self.meta = {}
 
-        if timestamp is not None:
-            self.timestamp = timestamp
-        else:
-            self.timestamp = make_timestamp()
+        self.version_id = version_id
 
         self.data.update({
             'asn_type': 'None',
             'asn_rule': self.asn_rule,
-            'creation_time': self.timestamp
+            'version_id': self.version_id
         })
 
         if member is not None:

--- a/jwst/associations/generate.py
+++ b/jwst/associations/generate.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
 
-def generate(pool, rules):
+def generate(pool, rules, version_id=None):
     """Generate associations in the pool according to the rules.
 
     Parameters
@@ -26,6 +26,12 @@ def generate(pool, rules):
 
     rules: Associations
         The associaton rule set.
+
+    version_id: None, True, or str
+        The string to use to tag associations and products.
+        If None, no tagging occurs.
+        If True, use a timestamp
+        If a string, the string.
 
     Returns
     -------
@@ -39,7 +45,8 @@ def generate(pool, rules):
 
     associations = []
     in_an_asn = np.zeros((len(pool),), dtype=bool)
-    timestamp = make_timestamp()
+    if type(version_id) is bool:
+        version_id = make_timestamp()
     process_list = [
         AssociationProcessMembers(
             members=pool,
@@ -52,7 +59,7 @@ def generate(pool, rules):
             logger.debug('Working member="{}"'.format(member))
             existing_asns, new_asns, to_process = generate_from_member(
                 member,
-                timestamp,
+                version_id,
                 associations,
                 rules,
                 process_event.allowed_rules
@@ -70,7 +77,7 @@ def generate(pool, rules):
 
 def generate_from_member(
         member,
-        timestamp,
+        version_id,
         associations,
         rules,
         allowed_rules):
@@ -82,8 +89,9 @@ def generate_from_member(
         The member to match to existing associations
         or generate new associations from
 
-    timestamp: str
-        Timestamp to use with association creation.
+    version_id: str or None
+        Version id to use with association creation.
+        If None, no versioning is used.
 
     associations: [association, ...]
         List of already existing associations.
@@ -123,7 +131,7 @@ def generate_from_member(
     ignore_asns = set([type(asn) for asn in existing_asns])
     new_asns, to_process = rules.match(
         member,
-        timestamp=timestamp,
+        version_id=version_id,
         allow=allowed_rules,
         ignore=ignore_asns,
     )

--- a/jwst/associations/lib/asn_schema_jw_level3.json
+++ b/jwst/associations/lib/asn_schema_jw_level3.json
@@ -24,9 +24,16 @@
             "description": "Name of the Association Pool from which this association was generated.",
             "type": "string"
         },
-        "creation_time": {
-            "description": "Timestamp of association creation.",
-            "type": "string"
+        "version_id": {
+            "description": "Version identifier.",
+            "anyOf":[
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ] 
         },
         "products": {
             "description": "Array of output products and their required inputs derived from this association.",
@@ -66,6 +73,5 @@
                  "program",
                  "target",
                  "asn_pool",
-                 "products",
-                 "creation_time"]
+                 "products"]
 }

--- a/jwst/associations/lib/asn_schema_jw_level3.json
+++ b/jwst/associations/lib/asn_schema_jw_level3.json
@@ -16,7 +16,7 @@
             "description": "The observing program identifier",
             "type": "string"
         },
-        "targname": {
+        "target": {
             "description": "Canonical name of the astronomical object being observed.",
             "type": "string"
         },
@@ -64,7 +64,7 @@
     "required": ["asn_type",
                  "asn_rule",
                  "program",
-                 "targname",
+                 "target",
                  "asn_pool",
                  "products",
                  "creation_time"]

--- a/jwst/associations/lib/rules_level2b.py
+++ b/jwst/associations/lib/rules_level2b.py
@@ -44,9 +44,9 @@ class DMS_Level2b_Base(Association):
                 'value': '(?!NULL).+',
                 'inputs': ['DETECTOR']
             },
-            'target_name': {
+            'target': {
                 'value': None,
-                'inputs': ['TARGNAME']
+                'inputs': ['TARGETID']
             },
         })
 
@@ -81,7 +81,7 @@ class DMS_Level2b_Base(Association):
     def _init_hook(self, member):
         """Post-check and pre-add initialization"""
         self.schema_file = ASN_SCHEMA
-        self.data['targname'] = member['TARGNAME']
+        self.data['target'] = member['TARGETID']
         self.data['program'] = str(member['PROGRAM'])
         self.data['asn_pool'] = basename(member.meta['pool_file']).split('.')[0]
         self.data['constraints'] = '\n'.join([cc for cc in self.constraints_to_text()])
@@ -107,7 +107,7 @@ class DMS_Level2b_Base(Association):
         result.append('        Product type: {:s}'.format(self.data['asn_type']))
         result.append('        Rule:         {:s}'.format(self.data['asn_rule']))
         result.append('        Program:      {:s}'.format(self.data['program']))
-        result.append('        Target:       {:s}'.format(self.data['targname']))
+        result.append('        Target:       {:s}'.format(self.data['target']))
         result.append('        Pool:         {:s}'.format(self.data['asn_pool']))
 
         for cc in self.constraints_to_text():

--- a/jwst/associations/lib/rules_level2b.py
+++ b/jwst/associations/lib/rules_level2b.py
@@ -60,7 +60,7 @@ class DMS_Level2b_Base(Association):
             self.data['program'],
             self.sequence,
             self.data['asn_type'],
-            self.timestamp
+            self.version_id
         )
         return name.lower()
 

--- a/jwst/associations/lib/rules_level3_base.py
+++ b/jwst/associations/lib/rules_level3_base.py
@@ -115,7 +115,7 @@ class DMS_Level3_Base(Association):
 
     def product_name(self):
         """Define product name."""
-        target = self._get_target_id()
+        target = self._get_target()
 
         instrument = self._get_instrument()
 
@@ -144,7 +144,7 @@ class DMS_Level3_Base(Association):
         super(DMS_Level3_Base, self)._init_hook(member)
 
         self.schema_file = ASN_SCHEMA
-        self.data['targname'] = member['TARGETID']
+        self.data['target'] = member['TARGETID']
         self.data['program'] = str(member['PROGRAM'])
         self.data['asn_pool'] = basename(
             member.meta['pool_file']
@@ -189,19 +189,19 @@ class DMS_Level3_Base(Association):
         # Add entry to the short list
         self.members.add(entry[KEY])
 
-    def _get_target_id(self):
+    def _get_target(self):
         """Get string representation of the target
 
         Returns
         -------
-        target_id: str
+        target: str
             The Level3 Product name representation
             of the target or source ID.
         """
         try:
             target = 's{0:0>5s}'.format(self.data['source_id'])
         except KeyError:
-            target = 't{0:0>3s}'.format(self.data['targname'])
+            target = 't{0:0>3s}'.format(self.data['target'])
         return target
 
     def _get_instrument(self):
@@ -458,7 +458,7 @@ class AsnMixin_Target(DMS_Level3_Base):
 
         # Setup for checking.
         self.add_constraints({
-            'target_name': {
+            'target': {
                 'value': None,
                 'inputs': ['TARGETID']
             },

--- a/jwst/associations/lib/rules_level3_base.py
+++ b/jwst/associations/lib/rules_level3_base.py
@@ -38,7 +38,8 @@ _DEGRADED_STATUS_NOTOK = (
 )
 
 # DMS file name templates
-_ASN_NAME_TEMPLATE = 'jw{program}-{acid}_{stamp}_{type}_{sequence:03d}_asn'
+_ASN_NAME_TEMPLATE_STAMP = 'jw{program}-{acid}_{stamp}_{type}_{sequence:03d}_asn'
+_ASN_NAME_TEMPLATE = 'jw{program}-{acid}_{type}_{sequence:03d}_asn'
 _LEVEL1B_REGEX = '(?P<path>.+)(?P<type>_uncal)(?P<extension>\..+)'
 _DMS_POOLNAME_REGEX = 'jw(\d{5})_(\d{8}[Tt]\d{6})_pool'
 
@@ -85,17 +86,25 @@ class DMS_Level3_Base(Association):
     @property
     def asn_name(self):
         program = self.data['program']
-        timestamp = self.timestamp
+        version_id = self.version_id
         asn_type = self.data['asn_type']
         sequence = self.sequence
 
-        name = _ASN_NAME_TEMPLATE.format(
-            program=program,
-            acid=self.acid.id,
-            stamp=timestamp,
-            type=asn_type,
-            sequence=sequence,
-        )
+        if version_id:
+            name = _ASN_NAME_TEMPLATE_STAMP.format(
+                program=program,
+                acid=self.acid.id,
+                stamp=version_id,
+                type=asn_type,
+                sequence=sequence,
+            )
+        else:
+            name = _ASN_NAME_TEMPLATE.format(
+                program=program,
+                acid=self.acid.id,
+                type=asn_type,
+                sequence=sequence,
+            )
         return name.lower()
 
     @property

--- a/jwst/associations/main.py
+++ b/jwst/associations/main.py
@@ -54,6 +54,26 @@ class Main(object):
             help='Produce all association candidate-specific associations'
         )
         parser.add_argument(
+            '-p', '--path', type=str,
+            default='.',
+            help='Folder to save the associations to. Default: "%(default)s"'
+        )
+        parser.add_argument(
+            '--save-orphans', dest='save_orphans',
+            nargs='?', const='orphaned.csv', default=False,
+            help='Save orphaned members into the specified table. Default: "%(default)s"'
+        )
+        parser.add_argument(
+            '--version-id', dest='version_id',
+            nargs='?', const=True, default=None,
+            help=(
+                'Version tag to add into association name and products.'
+                ' If not specified, no version will be used.'
+                ' If specified without a value, the current time is used.'
+                ' Otherwise, the specified string will be used.'
+            )
+        )
+        parser.add_argument(
             '-r', '--rules', action='append',
             help='Association Rules file.'
         )
@@ -65,16 +85,6 @@ class Main(object):
             '--dry-run',
             action='store_true', dest='dry_run',
             help='Execute but do not save results.'
-        )
-        parser.add_argument(
-            '-p', '--path', type=str,
-            default='.',
-            help='Folder to save the associations to. Default: "%(default)s"'
-        )
-        parser.add_argument(
-            '--save-orphans', dest='save_orphans',
-            nargs='?', const='orphaned.csv', default=False,
-            help='Save orphaned members into the specified table. Default: "%(default)s"'
         )
         parser.add_argument(
             '-d', '--delimiter', type=str,
@@ -177,7 +187,7 @@ class Main(object):
             )
 
         logger.info('Generating associations.')
-        self.associations, self.orphaned = generate(self.pool, self.rules)
+        self.associations, self.orphaned = generate(self.pool, self.rules, version_id=parsed.version_id)
 
         if parsed.discover:
             self.associations = self.rules.Utility.filter_discovered_only(

--- a/jwst/associations/registry.py
+++ b/jwst/associations/registry.py
@@ -110,7 +110,7 @@ class AssociationRegistry(dict):
     def rule_set(self):
         return self._rule_set
 
-    def match(self, member, timestamp=None, allow=None, ignore=None):
+    def match(self, member, version_id=None, allow=None, ignore=None):
         """See if member belongs to any of the associations defined.
 
         Parameters
@@ -118,9 +118,9 @@ class AssociationRegistry(dict):
         member: dict
             A member, like from a Pool, to find assocations for.
 
-        timestamp: str
+        version_id: str
             If specified, a string appened to association names.
-            Generated if not specified.
+            If None, nothing is used.
 
         allow: [type(Association), ...]
             List of rules to allow to be matched. If None, all
@@ -148,7 +148,7 @@ class AssociationRegistry(dict):
             if rule not in ignore and rule in allow:
                 logger.debug('Checking membership for rule "{}"'.format(rule))
                 try:
-                    associations.append(rule(member, timestamp))
+                    associations.append(rule(member, version_id))
                 except AssociationError as error:
                     logger.debug('Rule "{}" not matched'.format(name))
                     logger.debug('Reason="{}"'.format(error))

--- a/jwst/associations/tests/data/test_image_asn.json
+++ b/jwst/associations/tests/data/test_image_asn.json
@@ -1,0 +1,449 @@
+{
+    "asn_type": "image",
+    "constraints": "Constraints:\n    opt_elem2: CLEAR\n    instrument: NIRCAM\n    detector: (?!NULL).+\n    exp_type: NRC_IMAGE\n    pointing_type: SCIENCE\n    target: 1\n    program: 99009\n    opt_elem: F090W\n    wfsvisit: NULL",
+    "products": [
+        {
+            "members": [
+                {
+                    "exposerr": null,
+                    "expname": "jw_00001_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o001', 'OBSERVATION')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00002_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o001', 'OBSERVATION')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00003_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o001', 'OBSERVATION')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00004_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o001', 'OBSERVATION')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00006_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o001', 'OBSERVATION')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00007_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o001', 'OBSERVATION')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00008_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o001', 'OBSERVATION')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00009_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o001', 'OBSERVATION')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00011_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o002', 'OBSERVATION')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00012_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o002', 'OBSERVATION')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00013_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o002', 'OBSERVATION')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00014_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o002', 'OBSERVATION')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00016_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o002', 'OBSERVATION')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00017_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o002', 'OBSERVATION')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00018_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o002', 'OBSERVATION')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00019_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o002', 'OBSERVATION')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00021_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o003', 'OBSERVATION'), ('c1000', 'MOSAIC'), ('c1001', 'MOSAIC')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00022_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o003', 'OBSERVATION'), ('c1000', 'MOSAIC'), ('c1001', 'MOSAIC')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00023_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o003', 'OBSERVATION'), ('c1000', 'MOSAIC'), ('c1001', 'MOSAIC')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00024_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o003', 'OBSERVATION'), ('c1000', 'MOSAIC'), ('c1001', 'MOSAIC')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00026_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o003', 'OBSERVATION'), ('c1000', 'MOSAIC'), ('c1001', 'MOSAIC')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00027_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o003', 'OBSERVATION'), ('c1000', 'MOSAIC'), ('c1001', 'MOSAIC')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00028_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o003', 'OBSERVATION'), ('c1000', 'MOSAIC'), ('c1001', 'MOSAIC')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00029_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o003', 'OBSERVATION'), ('c1000', 'MOSAIC'), ('c1001', 'MOSAIC')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00031_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o004', 'OBSERVATION'), ('c1000', 'MOSAIC'), ('c1001', 'MOSAIC')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00032_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o004', 'OBSERVATION'), ('c1000', 'MOSAIC'), ('c1001', 'MOSAIC')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00033_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o004', 'OBSERVATION'), ('c1000', 'MOSAIC'), ('c1001', 'MOSAIC')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00034_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o004', 'OBSERVATION'), ('c1000', 'MOSAIC'), ('c1001', 'MOSAIC')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00036_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o004', 'OBSERVATION'), ('c1000', 'MOSAIC'), ('c1001', 'MOSAIC')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00037_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o004', 'OBSERVATION'), ('c1000', 'MOSAIC'), ('c1001', 'MOSAIC')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00038_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o004', 'OBSERVATION'), ('c1000', 'MOSAIC'), ('c1001', 'MOSAIC')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00039_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o004', 'OBSERVATION'), ('c1000', 'MOSAIC'), ('c1001', 'MOSAIC')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00041_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o005', 'OBSERVATION'), ('c1001', 'MOSAIC')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00042_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o005', 'OBSERVATION'), ('c1001', 'MOSAIC')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00043_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o005', 'OBSERVATION'), ('c1001', 'MOSAIC')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00044_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o005', 'OBSERVATION'), ('c1001', 'MOSAIC')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00046_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o005', 'OBSERVATION'), ('c1001', 'MOSAIC')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00047_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o005', 'OBSERVATION'), ('c1001', 'MOSAIC')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00048_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o005', 'OBSERVATION'), ('c1001', 'MOSAIC')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00049_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o005', 'OBSERVATION'), ('c1001', 'MOSAIC')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00051_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o006', 'OBSERVATION'), ('c1002', 'MOSAIC')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00052_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o006', 'OBSERVATION'), ('c1002', 'MOSAIC')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00053_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o006', 'OBSERVATION'), ('c1002', 'MOSAIC')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00054_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o006', 'OBSERVATION'), ('c1002', 'MOSAIC')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00056_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o006', 'OBSERVATION'), ('c1002', 'MOSAIC')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00057_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o006', 'OBSERVATION'), ('c1002', 'MOSAIC')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00058_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o006', 'OBSERVATION'), ('c1002', 'MOSAIC')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00059_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o006', 'OBSERVATION'), ('c1002', 'MOSAIC')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00061_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o007', 'OBSERVATION'), ('c1002', 'MOSAIC')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00062_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o007', 'OBSERVATION'), ('c1002', 'MOSAIC')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00063_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o007', 'OBSERVATION'), ('c1002', 'MOSAIC')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00064_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o007', 'OBSERVATION'), ('c1002', 'MOSAIC')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00066_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o007', 'OBSERVATION'), ('c1002', 'MOSAIC')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00067_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o007', 'OBSERVATION'), ('c1002', 'MOSAIC')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00068_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o007', 'OBSERVATION'), ('c1002', 'MOSAIC')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00069_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o007', 'OBSERVATION'), ('c1002', 'MOSAIC')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00079_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o009', 'OBSERVATION')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00080_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o009', 'OBSERVATION')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00081_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o009', 'OBSERVATION')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00082_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o009', 'OBSERVATION')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00084_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o009', 'OBSERVATION')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00085_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o009', 'OBSERVATION')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00086_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o009', 'OBSERVATION')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00087_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o009', 'OBSERVATION')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00088_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o009', 'OBSERVATION')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00089_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o009', 'OBSERVATION')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00090_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o009', 'OBSERVATION')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00091_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o009', 'OBSERVATION')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00092_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o009', 'OBSERVATION')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00093_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o009', 'OBSERVATION')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00094_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o009', 'OBSERVATION')]"
+                },
+                {
+                    "exposerr": null,
+                    "expname": "jw_00096_cal.fits",
+                    "exptype": "SCIENCE",
+                    "asn_candidate": "[('o009', 'OBSERVATION')]"
+                }
+            ],
+            "name": "jw99009-a3001_t001_nircam_f090w"
+        }
+    ],
+    "creation_time": "20160915T142211",
+    "target": "1",
+    "asn_pool": "mega_pool",
+    "program": "99009",
+    "degraded_status": "No known degraded exposures in association.",
+    "asn_rule": "discover_Asn_Image"
+}

--- a/jwst/associations/tests/test_asn_names.py
+++ b/jwst/associations/tests/test_asn_names.py
@@ -11,8 +11,7 @@ LEVEL3_ASN_ACID_NAME_REGEX = (
     'jw'
     '(?P<program>\d{5})'
     '-(?P<acid>(o|c)\d{3,4})'
-    '_(?P<stamp>.+)'
-    '_(?P<asn_type>.+)'
+    '_(?P<asn_type>[a-z]+)'
     '_(?P<sequence>\d{3})'
     '_asn'
 )
@@ -20,6 +19,15 @@ LEVEL3_ASN_DISCOVERED_NAME_REGEX = (
     'jw'
     '(?P<program>\d{5})'
     '-(?P<acid>a\d{4})'
+    '_(?P<asn_type>[a-z]+)'
+    '_(?P<sequence>\d{3})'
+    '_asn'
+)
+
+LEVEL3_ASN_WITH_VERSION = (
+    'jw'
+    '(?P<program>\d{5})'
+    '-(?P<acid>[a-z]\d{4})'
     '_(?P<stamp>.+)'
     '_(?P<asn_type>.+)'
     '_(?P<sequence>\d{3})'
@@ -52,4 +60,15 @@ class TestASNtNames():
                 m = re.match(LEVEL3_ASN_ACID_NAME_REGEX, name)
             else:
                 m = re.match(LEVEL3_ASN_DISCOVERED_NAME_REGEX, name)
+            assert m is not None
+
+    def test_level3_asn_names_with_version(self, pool_params):
+        pool_path = helpers.t_path(pool_params)
+        pool = helpers.combine_pools(pool_path)
+        rules = AssociationRegistry()
+        asns, orphaned = generate(pool, rules, version_id=True)
+        assert len(asns) > 0
+        for asn in asns:
+            name = asn.asn_name
+            m = re.match(LEVEL3_ASN_WITH_VERSION, name)
             assert m is not None

--- a/jwst/associations/tests/test_level3_basics.py
+++ b/jwst/associations/tests/test_level3_basics.py
@@ -13,7 +13,7 @@ from .. import (AssociationRegistry, generate)
 L3_PRODUCT_NAME = (
     'jw(?P<program>\d{5})'
     '-(?P<acid>[a-z]\d{3,4})'
-    '_(?P<targetid>t\d{3})'
+    '_(?P<target>t\d{3})'
     '_(?P<instrument>.+?)'
     '_(?P<opt_elem>.+)'
 )
@@ -31,7 +31,7 @@ class TestLevel3Environment(object):
         matches = match.groupdict()
         yield helpers.check_equal, matches['program'], '99009'
         yield helpers.check_equal, matches['acid'], 'a3001'
-        yield helpers.check_equal, matches['targetid'], 't001'
+        yield helpers.check_equal, matches['target'], 't001'
         yield helpers.check_equal, matches['instrument'], 'miri'
         yield helpers.check_equal, matches['opt_elem'], 'f560w'
 
@@ -52,6 +52,6 @@ class TestLevel3Environment(object):
         matches = match.groupdict()
         yield helpers.check_equal, matches['program'], '99009'
         yield helpers.check_equal, matches['acid'], 'o001'
-        yield helpers.check_equal, matches['targetid'], 't001'
+        yield helpers.check_equal, matches['target'], 't001'
         yield helpers.check_equal, matches['instrument'], 'miri'
         yield helpers.check_equal, matches['opt_elem'], 'f560w'

--- a/jwst/associations/tests/test_level3_product_names.py
+++ b/jwst/associations/tests/test_level3_product_names.py
@@ -11,7 +11,7 @@ LEVEL3_PRODUCT_NAME_REGEX = (
     'jw'
     '(?P<program>\d{5})'
     '-(?P<acid>[a-z]\d{3,4})'
-    '_(?P<targname>(?:t\d{3})|(?:s\d{5}))'
+    '_(?P<target>(?:t\d{3})|(?:s\d{5}))'
     '(?:-(?P<epoch>epoch\d+))?'
     '_(?P<instrument>.+?)'
     '_(?P<opt_elem>.+)'

--- a/jwst/associations/tests/test_main.py
+++ b/jwst/associations/tests/test_main.py
@@ -1,6 +1,7 @@
 """test_associations: Test of general Association functionality."""
 from __future__ import absolute_import
 import pytest
+import re
 
 from .helpers import full_pool_rules
 
@@ -71,3 +72,17 @@ class TestMain(object):
         candidates = Main([pool_fname, '--dry-run', '--all-candidates'])
         discovered = Main([pool_fname, '--dry-run', '--discover'])
         assert len(full.associations) == len(candidates.associations) + len(discovered.associations)
+
+
+    def test_version_id(self, full_pool_rules):
+        pool, rules, pool_fname = full_pool_rules
+
+        generated = Main([pool_fname, '--dry-run', '-i', 'o001', '--version-id'])
+        regex = re.compile('\d{3}t\d{6}')
+        for asn in generated.associations:
+            assert regex.search(asn.asn_name)
+
+        version_id = 'mytestid'
+        generated = Main([pool_fname, '--dry-run', '-i', 'o001', '--version-id', version_id])
+        for asn in generated.associations:
+            assert version_id in asn.asn_name

--- a/jwst/associations/tests/test_validate.py
+++ b/jwst/associations/tests/test_validate.py
@@ -20,7 +20,7 @@ def test_invalid():
 def test_valid():
     rules = AssociationRegistry()
     asn_file = helpers.t_path(
-        'data/jw96090_20160615t210324_mosaic_001_asn.json'
+        'data/test_image_asn.json'
     )
     with open(asn_file, 'r') as asn_fp:
         asn = Association.load(asn_fp)

--- a/jwst/cube_build/cube_build.py
+++ b/jwst/cube_build/cube_build.py
@@ -903,7 +903,7 @@ class IFUCubeInput(object):
     """
 
     template = {"asn_rule": "",
-              "targname": "",
+              "target": "",
               "asn_pool": "",
               "asn_type": "",
               "products": [
@@ -947,7 +947,7 @@ class IFUCubeInput(object):
 
         # An in-memory ImageModel for a single exposure was provided as input
         self.asn_table = self.template
-        self.asn_table['targname'] = model.meta.target.catalog_name
+        self.asn_table['target'] = model.meta.target.catalog_name
         self.asn_table['asn_rule'] = 'singleton'
         self.asn_table['asn_type'] = 'singleton'
 

--- a/jwst/datamodels/container.py
+++ b/jwst/datamodels/container.py
@@ -166,7 +166,7 @@ class ModelContainer(DataModel):
         self.meta.resample.output = str(asn_data['products'][0]['name'])
         self.meta.table_name = str(filepath)
         self.meta.pool_name = str(asn_data['asn_pool'])
-        self.meta.targname = str(asn_data['targname'])
+        self.meta.targname = str(asn_data['target'])
         self.meta.program = str(asn_data['program'])
         self.meta.asn_type = str(asn_data['asn_type'])
         self.meta.asn_rule = str(asn_data['asn_rule'])

--- a/jwst/pipeline/calniriss_ami3.py
+++ b/jwst/pipeline/calniriss_ami3.py
@@ -119,7 +119,7 @@ class AmiInput(object):
     """
 
     template = {"asn_rule": "",
-              "targname": "",
+              "target": "",
               "asn_pool": "",
               "program": "",
               "asn_type": "ami",
@@ -159,7 +159,7 @@ class AmiInput(object):
 
         # An in-memory ImageModel for a single exposure was provided as input
         self.asn = self.template
-        self.asn['targname'] = model.meta.target.catalog_name
+        self.asn['target'] = model.meta.target.catalog_name
         self.asn['program'] = model.meta.observation.program_number
         self.asn['asn_rule'] = 'Singleton_{0}'.format(model.meta.instrument.name)
 

--- a/jwst/pipeline/calwebb_spec2.py
+++ b/jwst/pipeline/calwebb_spec2.py
@@ -145,7 +145,7 @@ class Lvl2Input(object):
     """
 
     template = {"asn_rule": "",
-              "targname": "",
+              "target": "",
               "asn_pool": "",
               "asn_type": "",
               "members": [
@@ -177,7 +177,7 @@ class Lvl2Input(object):
 
         # A single exposure was provided as input
         self.asn = self.template
-        self.asn['targname'] = model.meta.target.catalog_name
+        self.asn['target'] = model.meta.target.catalog_name
         self.asn['asn_rule'] = 'singleton'
         self.asn['asn_type'] = 'singleton'
         self.asn['asn_pool'] = ''


### PR DESCRIPTION
@hbushouse @jemorrison Though target from the associations does not appear to be used anyplace, it is referred to in cube_build and datamodels/container. Review as needed.

Resolves #152 