### PR TITLE
Remove resolver as a parameter, use extension instead to add new url …

### DIFF
--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -9,6 +9,7 @@ import datetime
 import inspect
 import os
 import sys
+import warnings
 
 import numpy as np
 
@@ -20,6 +21,7 @@ from astropy.wcs import WCS
 from asdf import AsdfFile
 from asdf import yamlutil
 from asdf import schema as asdf_schema
+from asdf import extension as asdf_extension
 
 from . import fits_support
 from . import properties
@@ -38,7 +40,7 @@ class DataModel(properties.ObjectNode):
     schema_url = "core.schema.yaml"
 
     def __init__(self, init=None, schema=None, extensions=None,
-                 resolver=None, pass_invalid_values=False):
+                 pass_invalid_values=False):
         """
         Parameters
         ----------
@@ -66,11 +68,9 @@ class DataModel(properties.ObjectNode):
             If not provided, the schema associated with this class
             will be used.
 
-        extensions: classes extending the standard set of extensions, optional
+        extensions: classes extending the standard set of extensions, optional.
+            If an extension is defined, the prefix used should be 'url'.
 
-        resolver: an object which resolves references in schemas into filenames, optional
-            If None, the default resolver will be used.
-            
         pass_invalid_values: If True, values that do not validate the schema can
             be read and written, but with a warning message
         """
@@ -78,18 +78,19 @@ class DataModel(properties.ObjectNode):
         base_url = os.path.join(
             os.path.dirname(filename), 'schemas', '')
 
+        if extensions is None:
+            extensions = jwst_extensions[:]
+        else:
+            extensions.extend(jwst_extensions)
+        self._extensions = extensions
+
         if schema is None:
             schema_path = os.path.join(base_url, self.schema_url)
+            extension_list = asdf_extension.AsdfExtensionList(self._extensions)
             schema = asdf_schema.load_schema(schema_path, 
-                resolver=resolver, resolve_references=True)
+                resolver=extension_list.url_mapping, resolve_references=True)
 
         self._schema = mschema.flatten_combiners(schema)
-
-        if extensions is not None:
-            extensions.extend(jwst_extensions)
-        else:
-            extensions = jwst_extensions[:]
-        self._extensions = extensions
 
         if "PASS_INVALID_VALUES" in os.environ:
             pass_invalid_values = os.environ["PASS_INVALID_VALUES"]


### PR DESCRIPTION
…mappings

When Nadia saw my update which added resolver ss a parameter to
datamodels/model_base.py, she said it was redundant and I could pass
an extension to update the url_mapping instead. And that this was the
intended method to do this. I reviewed the code and saw she was right,
so I have removed resolver as a parameter.

But this presented another problem, because when load_schema is called
from __init__, it needs to receive a resolver in order for it to be
able to use the updated mappings. To generate this mapping, I had to
put the code that handles extensions before the call to load_schema
and I had to generate the resolver for load_schema from those
extensions. And after a little research, I have maded the needed lines
to do that.