### PR TITLE
Add missing else branch to gentle_asarray

### DIFF
--- a/jwst/datamodels/util.py
+++ b/jwst/datamodels/util.py
@@ -89,6 +89,8 @@ def gentle_asarray(a, dtype):
                 else:
                     return np.asanyarray(a, dtype=out_dtype)
             return a.view(dtype=np.dtype(new_dtype))
+        else:
+            return np.asanyarray(a, dtype=out_dtype)
     else:
         try:
             a = np.asarray(a, dtype=out_dtype)


### PR DESCRIPTION
Because of a logic error in the gentle_asarray code it is possible to traverse the code without generating an output array and thus return an undefined value. This fix adds an else branch that calls numpy.asanyarray if none of the other branches are executed.