### PR TITLE
Update wfs_combine to use output_dir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
     global:
         - MAIN_CMD='python setup.py'
         - CONDA_CHANNELS='http://ssb.stsci.edu/conda-dev'
-        - CONDA_DEPENDENCIES='pytest jwst sphinx=1.3.5'
+        - CONDA_DEPENDENCIES='pytest jwst sphinx=1.3.5 qt=4'
         - CONDA_JWST_DEPENDENCIES='pytest stsci-jwst sphinx=1.3.5'
         - PIP_DEPENDENCIES=''
         - CRDS_SERVER_URL='https://jwst-crds.stsci.edu'

--- a/jwst/wfs_combine/wfs_combine.py
+++ b/jwst/wfs_combine/wfs_combine.py
@@ -343,8 +343,8 @@ class DataSet(object):
 
         # Populate combined SCI, DQ and ERR arrays
         data_comb = sci_data_1 * 0  # Pixels that are bad in both will stay 0
-        data_comb[wh_1_good_2_good] = 0.5*(sci_data_1[wh_1_good_2_good] +
-                                       sci_data_2[wh_1_good_2_good])
+        data_comb[wh_1_good_2_good] = 0.5 * (sci_data_1[wh_1_good_2_good] +
+                                             sci_data_2[wh_1_good_2_good])
         data_comb[wh_1_good_2_bad] = sci_data_1[wh_1_good_2_bad]
         data_comb[wh_1_bad_2_good] = sci_data_2[wh_1_bad_2_good]
 
@@ -352,11 +352,11 @@ class DataSet(object):
         dq_comb[wh_1_good_2_bad] = dq_data_1[wh_1_good_2_bad]
         dq_comb[wh_1_bad_2_good] = dq_data_2[wh_1_bad_2_good]
         dq_comb[wh_1_bad_2_bad] = np.bitwise_or(dqflags.group['DO_NOT_USE'],
-                                               dq_comb[wh_1_bad_2_bad])
+                                                dq_comb[wh_1_bad_2_bad])
 
         err_comb = err_data_1.copy() * 0 # will leave bad (= 0)
-        err_comb[wh_1_good_2_good] = 0.5*(err_data_1[wh_1_good_2_good] +
-                                          err_data_2[wh_1_good_2_good])
+        err_comb[wh_1_good_2_good] = 0.5 * (err_data_1[wh_1_good_2_good] +
+                                            err_data_2[wh_1_good_2_good])
         err_comb[wh_1_good_2_bad] = err_data_1[wh_1_good_2_bad]
         err_comb[wh_1_bad_2_good] = err_data_2[wh_1_bad_2_good]
 

--- a/jwst/wfs_combine/wfs_combine_step.py
+++ b/jwst/wfs_combine/wfs_combine_step.py
@@ -3,6 +3,7 @@
 from ..stpipe import Step, cmdline
 from . import wfs_combine
 import json
+import os
 
 class WfsCombineStep(Step):
 
@@ -28,6 +29,9 @@ class WfsCombineStep(Step):
             infile_2 = asn_table['products'][which_set]['members'][1]['expname']
             outfile = asn_table['products'][which_set]['name']
 
+            # Construct the full output file name
+            outfile = mk_prodname(self.output_dir, outfile, 'wfscmb')
+
             wfs = wfs_combine.DataSet(infile_1, infile_2, outfile, self.do_refine)
 
             output_model = wfs.do_all()
@@ -35,6 +39,19 @@ class WfsCombineStep(Step):
             output_model.save(outfile)
 
         return None
+
+
+def mk_prodname(output_dir, filename, suffix):
+
+    if output_dir is not None:
+        dirname, filename = os.path.split(filename)
+        filename = os.path.join(output_dir, filename)
+
+    base, ext = os.path.splitext(filename)
+    if len(ext) == 0:
+        ext = ".fits"
+    return base + '_' + suffix + ext
+
 
 if __name__ == '__main__':
     cmdline.step_script(wfs_combine_step)


### PR DESCRIPTION
Updated the wfs_combine step to pay attention to the user-supplied output_dir, if there is one, when creating an output file name. Also updates the construction of the output file name to take into account the recent change to ASN product file names that no longer include the product type suffix, so the step needs to add the appropriate suffix (which in this case is 'wfscmb').

With similar recent updates to the calwebb_image3, calwebb_coron3, and calwebb_ami3 pipelines, all level-3 pipelines/steps should now be paying attention to the user-supplied output_dir value, which fixes #162.