### PR TITLE
ModelContainer now opens all DataModel types

### DIFF
--- a/jwst/datamodels/__init__.py
+++ b/jwst/datamodels/__init__.py
@@ -78,7 +78,7 @@ from .saturation import SaturationModel
 from .spec import SpecModel
 from .straylight import StrayLightModel
 from .superbias import SuperBiasModel
-from .util import fits_header_name
+from .util import open
 
 
 
@@ -91,136 +91,13 @@ __all__ = [
     'FlatModel', 'FringeModel', 'GainModel', 'GLS_RampFitModel',
     'ImageModel', 'IPCModel', 'IRS2Model', 'LastFrameModel', 'LinearityModel',
     'MaskModel', 'MIRIRampModel', 'ModelContainer',
-    'MultiExposureModel',
-    'MultiSlitModel',
+    'MultiExposureModel','MultiSlitModel',
     'MultiSpecModel', 'IFUCubeModel', 'PhotomModel', 'NircamPhotomModel',
     'NirissPhotomModel', 'NirspecPhotomModel', 'NirspecFSPhotomModel',
     'MiriImgPhotomModel', 'MiriMrsPhotomModel', 'QuadModel', 'RampModel',
     'RampFitOutputModel', 'ReadnoiseModel', 'ResetModel', 'RSCDModel',
     'SaturationModel', 'SpecModel', 'StrayLightModel']
 
-
-def open(init=None, extensions=None):
-    """
-    Creates a DataModel from a number of different types
-
-    Parameters
-    ----------
-
-    init : shape tuple, file path, file object, astropy.io.fits.HDUList, numpy array, dict, None
-
-        - None: A default data model with no shape
-
-        - shape tuple: Initialize with empty data of the given shape
-
-        - file path: Initialize from the given file (FITS , JSON or ASDF)
-
-        - readable file object: Initialize from the given file object
-
-        - astropy.io.fits.HDUList: Initialize from the given
-          `~astropy.io.fits.HDUList`
-
-        - A numpy array: A new model with the data array initialized
-          to what was passed in.
-
-        - dict: The object model tree for the data model
-
-    extensions : list of AsdfExtension
-        A list of extensions to the ASDF to support when reading
-        and writing ASDF files.
-
-   Results
-    -------
-
-    model : DataModel instance
-    """
-    from astropy.io import fits
-
-    if init is None:
-        return DataModel(None)
-    # Send _asn.json files to ModelContainer; avoid shape "cleverness" below
-    elif (isinstance(init, six.string_types) and
-            basename(init).split('.')[0].split('_')[-1] == 'asn'):
-        try:
-            m = ModelContainer(init, extensions=extensions)
-        except:
-            raise TypeError(
-                "init ASN not valid for ModelContainer"
-                )
-        return m
-    elif isinstance(init, DataModel):
-        # Copy the object so it knows not to close here
-        return init.__class__(init)
-    elif isinstance(init, tuple):
-        for item in init:
-            if not isinstance(item, int):
-                raise ValueError("shape must be a tuple of ints")
-        shape = init
-    elif isinstance(init, np.ndarray):
-        shape = init.shape
-    else:
-        if isinstance(init, (six.text_type, bytes)) or hasattr(init, "read"):
-            hdulist = fits.open(init)
-        elif isinstance(init, fits.HDUList):
-            hdulist = init
-        else:
-            raise TypeError(
-                "init must be None, shape tuple, file path, "
-                "readable file object, or astropy.io.fits.HDUList")
-
-        shape = ()
-        try:
-            hdu = hdulist[(fits_header_name('SCI'), 1)]
-        except KeyError:
-            pass
-        else:
-            if hasattr(hdu, 'shape'):
-                shape = hdu.shape
-
-    # Here, we try to be clever about which type to
-    # return, otherwise, just return a new instance of the
-    # requested class
-    if len(shape) == 0:
-        new_class = DataModel
-    elif len(shape) == 4:
-        # It's a RampModel, MIRIRampModel, or QuadModel
-        try:
-            dqhdu = hdulist[fits_header_name('DQ')]
-        except KeyError:
-            # It's a RampModel or MIRIRampModel
-            try:
-                refouthdu = hdulist[fits_header_name('REFOUT')]
-            except KeyError:
-                # It's a RampModel
-                from . import ramp
-                new_class = ramp.RampModel
-            else:
-                # It's a MIRIRampModel
-                from . import miri_ramp
-                new_class = miri_ramp.MIRIRampModel
-        else:
-            # It's a QuadModel
-            from . import quad
-            new_class = quad.QuadModel
-    elif len(shape) == 3:
-        # It's a CubeModel
-        from . import cube
-        new_class = cube.CubeModel
-    elif len(shape) == 2:
-        try:
-            hdu = hdulist[(fits_header_name('SCI'), 2)]
-        except (KeyError, NameError):
-            # It's an ImageModel
-            from . import image
-            new_class = image.ImageModel
-        else:
-            # It's a MultiSlitModel
-            from . import multislit
-            new_class = multislit.MultiSlitModel
-    else:
-        raise ValueError("Don't have a DataModel class to match the shape")
-
-    return new_class(init, extensions=extensions)
 
 '''
 def test(verbose=False) :

--- a/jwst/datamodels/container.py
+++ b/jwst/datamodels/container.py
@@ -10,7 +10,7 @@ from astropy.extern import six
 
 from ..associations import Association
 from . import model_base
-from . import open as datamodel_open
+from .open_model import open as datamodel_open
 
 
 __all__ = ['ModelContainer']

--- a/jwst/datamodels/container.py
+++ b/jwst/datamodels/container.py
@@ -9,14 +9,14 @@ from asdf import AsdfFile
 from astropy.extern import six
 
 from ..associations import Association
-from .model_base import DataModel
-from .image import ImageModel
+from . import model_base
+from . import open as datamodel_open
 
 
 __all__ = ['ModelContainer']
 
 
-class ModelContainer(DataModel):
+class ModelContainer(model_base.DataModel):
     """
     A container for holding DataModels.
 
@@ -34,8 +34,8 @@ class ModelContainer(DataModel):
     Examples
     --------
     >>> c = ModelContainer('example_asn.json')
-    >>> c[0]    # the first ImageModel in the container
-    >>> c.models_grouped    # a list of the ImageModels grouped by exposure
+    >>> c[0]    # the first DataModel in the container
+    >>> c.models_grouped    # a list of the DataModels grouped by exposure
     """
 
     # This schema merely extends the 'meta' part of the datamodel, and
@@ -50,7 +50,7 @@ class ModelContainer(DataModel):
             self._models = []
         elif isinstance(init, list):
             for item in init:
-                if not isinstance(item, DataModel):
+                if not isinstance(item, model_base.DataModel):
                     raise ValueError('list must contain only DataModels')
             self._models = init
         elif isinstance(init, self.__class__):
@@ -138,10 +138,7 @@ class ModelContainer(DataModel):
 
     def from_asn(self, filepath):
         """
-        Load the ImageModels from a JWST association file.
-
-        The from_asn() method assumes that all FITS files listed in the
-        association are ImageModels.
+        Load fits files from a JWST association file.
 
         Parameters
         ----------
@@ -160,7 +157,7 @@ class ModelContainer(DataModel):
         # make a list of all the input FITS files
         infiles = [op.join(basedir, member['expname']) for member
                    in asn_data['products'][0]['members']]
-        self._models = [ImageModel(infile) for infile in infiles]
+        self._models = [datamodel_open(infile) for infile in infiles]
 
         # populate the output metadata with the output file from the ASN file
         self.meta.resample.output = str(asn_data['products'][0]['name'])
@@ -189,9 +186,9 @@ class ModelContainer(DataModel):
     @property
     def group_names(self):
         """
-        Return a list of names for the ImageModel groups by exposure.
+        Return a list of names for the DataModel groups by exposure.
 
-        Note that this returns the ImageModel "group_id"s appended with
+        Note that this returns the DataModel "group_id"s appended with
         "_resamp.fits".
         """
 

--- a/jwst/datamodels/container.py
+++ b/jwst/datamodels/container.py
@@ -10,7 +10,7 @@ from astropy.extern import six
 
 from ..associations import Association
 from . import model_base
-from .open_model import open as datamodel_open
+from .util import open as datamodel_open
 
 
 __all__ = ['ModelContainer']

--- a/jwst/datamodels/util.py
+++ b/jwst/datamodels/util.py
@@ -4,10 +4,135 @@ Various utility functions and data types
 from __future__ import absolute_import, unicode_literals, division, print_function
 
 import sys
-
+from os.path import basename
 import numpy as np
-
 from astropy.extern import six
+from astropy.io import fits
+
+from . import model_base
+
+
+def open(init=None, extensions=None):
+    """
+    Creates a DataModel from a number of different types
+
+    Parameters
+    ----------
+
+    init : shape tuple, file path, file object, astropy.io.fits.HDUList, 
+           numpy array, dict, None
+
+        - None: A default data model with no shape
+
+        - shape tuple: Initialize with empty data of the given shape
+
+        - file path: Initialize from the given file (FITS , JSON or ASDF)
+
+        - readable file object: Initialize from the given file object
+
+        - astropy.io.fits.HDUList: Initialize from the given
+          `~astropy.io.fits.HDUList`
+
+        - A numpy array: A new model with the data array initialized
+          to what was passed in.
+
+        - dict: The object model tree for the data model
+
+    extensions : list of AsdfExtension
+        A list of extensions to the ASDF to support when reading
+        and writing ASDF files.
+
+   Results
+    -------
+
+    model : DataModel instance
+    """
+
+    if init is None:
+        return model_base.DataModel(None)
+    # Send _asn.json files to ModelContainer; avoid shape "cleverness" below
+    elif (isinstance(init, six.string_types) and
+            basename(init).split('.')[0].split('_')[-1] == 'asn'):
+        try:
+            from . import container
+            return container.ModelContainer(init, extensions=extensions)
+        except:
+            raise TypeError(
+                "init ASN not valid for ModelContainer"
+                )
+    elif isinstance(init, model_base.DataModel):
+        # Copy the object so it knows not to close here
+        return init.__class__(init)
+    elif isinstance(init, tuple):
+        for item in init:
+            if not isinstance(item, int):
+                raise ValueError("shape must be a tuple of ints")
+        shape = init
+    elif isinstance(init, np.ndarray):
+        shape = init.shape
+    else:
+        if isinstance(init, (six.text_type, bytes)) or hasattr(init, "read"):
+            hdulist = fits.open(init)
+        elif isinstance(init, fits.HDUList):
+            hdulist = init
+        else:
+            raise TypeError(
+                "init must be None, shape tuple, file path, "
+                "readable file object, or astropy.io.fits.HDUList")
+
+        shape = ()
+        try:
+            hdu = hdulist[(fits_header_name('SCI'), 1)]
+        except KeyError:
+            pass
+        else:
+            if hasattr(hdu, 'shape'):
+                shape = hdu.shape
+
+    # Be clever about which type to return, otherwise, just return a new 
+    # instance of the requested class
+    if len(shape) == 0:
+        new_class = model_base.DataModel
+    elif len(shape) == 4:
+        # It's a RampModel, MIRIRampModel, or QuadModel
+        try:
+            dqhdu = hdulist[fits_header_name('DQ')]
+        except KeyError:
+            # It's a RampModel or MIRIRampModel
+            try:
+                refouthdu = hdulist[fits_header_name('REFOUT')]
+            except KeyError:
+                # It's a RampModel
+                from . import ramp
+                new_class = ramp.RampModel
+            else:
+                # It's a MIRIRampModel
+                from . import miri_ramp
+                new_class = miri_ramp.MIRIRampModel
+        else:
+            # It's a QuadModel
+            from . import quad
+            new_class = quad.QuadModel
+    elif len(shape) == 3:
+        # It's a CubeModel
+        from . import cube
+        new_class = cube.CubeModel
+    elif len(shape) == 2:
+        try:
+            hdu = hdulist[(fits_header_name('SCI'), 2)]
+        except (KeyError, NameError):
+            # It's an ImageModel
+            from . import image
+            new_class = image.ImageModel
+        else:
+            # It's a MultiSlitModel
+            from . import multislit
+            new_class = multislit.MultiSlitModel
+    else:
+        raise ValueError("Don't have a DataModel class to match the shape")
+
+    return new_class(init, extensions=extensions)
+
 
 def can_broadcast(a, b):
     """


### PR DESCRIPTION
To support the calwebb_spec3 pipeline, ModelContainer is generalized to open not only ImageModels, but other DataModels as well.  This includes MultiSlitModels and CubeModels.  ModelContainer now uses datamodels.open(), which now resides in datamodels/util.py instead datamodels/__init__.py.  This refactor was required to make relative imports work within the datamodels package and allow datamodels.open() to work as it always has.