### PR TITLE
Add url mapping for datamodels schemas

### DIFF
--- a/jwst/datamodels/extension.py
+++ b/jwst/datamodels/extension.py
@@ -1,0 +1,23 @@
+from __future__ import absolute_import, division, unicode_literals, print_function
+import os.path
+from asdf.extension import AsdfExtension
+from asdf import util
+
+SCHEMA_PATH = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), 'schemas'))
+
+
+class BaseExtension(AsdfExtension):
+    @property
+    def types(self):
+        return []
+
+    @property
+    def tag_mapping(self):
+        return []
+
+    @property
+    def url_mapping(self):
+        return [('http://jwst.stsci.edu/schemas/',
+                 util.filepath_to_url(SCHEMA_PATH) +
+                 '/{url_suffix}')]

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -27,11 +27,12 @@ from . import fits_support
 from . import properties
 from . import schema as mschema
 
+from .extension import BaseExtension
 from jwst.transforms.jwextension import JWSTExtension
 from gwcs.extension import GWCSExtension
 
 
-jwst_extensions = [GWCSExtension(), JWSTExtension()]
+jwst_extensions = [GWCSExtension(), JWSTExtension(), BaseExtension()]
 
 class DataModel(properties.ObjectNode):
     """


### PR DESCRIPTION
Up to now there has been no way for other packages to refer to the
schemas in the datamodels package. The miri team requested that the
url http://jwst.stsc.edu/schemas be added, so their schemas could have
references to the datamodels schemas. This commit adds the new class
BaseExtension in datamodels/extension.py and modifies the list of
default extensions, jwst_extensions, in datamodels/model_base.py to
include it.