### PR TITLE
Add instance method to datamodel properties node

### DIFF
--- a/jwst/datamodels/properties.py
+++ b/jwst/datamodels/properties.py
@@ -114,10 +114,10 @@ def _make_node(instance, schema, ctx):
         return instance
 
 
-def _unmake_node(instance):
-    if isinstance(instance, (ObjectNode, ListNode)):
-        return instance._instance
-    return instance
+def _unmake_node(obj):
+    if isinstance(obj, Node):
+        return obj.instance
+    return obj
 
 
 def _get_schema_for_property(schema, attr):
@@ -156,6 +156,9 @@ class Node(object):
         schema.validate(
             instance, schema=self._schema)
 
+    @property
+    def instance(self):
+        return self._instance
 
 class ObjectNode(Node):
     @override__dir__


### PR DESCRIPTION
The Node object is a bundle made from a value, its schema, and its
context. Sometimes you want to retrieve the value from the node, if,
for example, you would like to copy it. The new method instance has
been added to the Node class and it returns the value. It is invoked
as:

    val = node.instance

where node is the object you wish to fetch the value from. I have also
rewritten the internal function _unmake_node to use this new method.