### PR TITLE
Nirspec full frame

### DIFF
--- a/jwst/assign_wcs/nirspec.py
+++ b/jwst/assign_wcs/nirspec.py
@@ -113,6 +113,8 @@ def imaging(input_model, reference_files):
                             (v2v3, v23_to_sky),
                             (world, None)]
     else:
+        # convert to microns if the pipeline ends earlier
+        gwa2msa = (gwa2msa | Identity(2) & Scale(10**6)).rename('gwa2msa')
         imaging_pipeline = [(det, dms2detector),
                             (sca, det2gwa),
                             (gwa, gwa2msa),
@@ -170,11 +172,13 @@ def ifu(input_model, reference_files):
                     (oteip, oteip2v23.rename('oteip2v23')),
                     (v2v3, None)]
     else:
-
+        # convert to microns if the pipeline ends earlier
+        #slit2msa = (Mapping((0, 1, 2, 3, 4)) | slit2msa | Identity(2) & Scale(10**6)).rename('slit2msa')
+        slit2msa = (Mapping((0, 1, 2, 3, 4)) | slit2msa).rename('slit2msa')
         pipeline = [(det, dms2detector),
                     (sca, det2gwa.rename('detector2gwa')),
                     (gwa, gwa2slit.rename('gwa2slit')),
-                    (slit_frame, (Mapping((0, 1, 2, 3, 4)) | slit2msa).rename('slit2msa')),
+                    (slit_frame, slit2msa),
                     (msa_frame, None)]
 
     return pipeline
@@ -239,6 +243,9 @@ def slits_wcs(input_model, reference_files):
                         (oteip, oteip2v23),
                         (v2v3, None)]
     else:
+        # convert to microns if the pipeline ends earlier
+        #gwa2slit = (gwa2slit | Identity(2) & Scale(10**6)).rename('gwa2slit')
+        gwa2slit = (gwa2slit).rename('gwa2slit')
         msa_pipeline = [(det, dms2detector),
                         (sca, det2gwa),
                         (gwa, gwa2slit),

--- a/jwst/assign_wcs/nirspec.py
+++ b/jwst/assign_wcs/nirspec.py
@@ -554,7 +554,11 @@ def dms_to_sca(input_model):
     if ystart is None:
         ystart = 1
     # The SCA coordinates are in full frame
-    subarray2full = models.Shift(xstart) & models.Shift(ystart)
+    # The inputs are 1-based, remove -1 when'if they are 0-based
+    # The outputs must be 1-based becaause this is what the model expects.
+    # If xstart was 0-based and the inputs were 0-based ->
+    # Shift(+1)
+    subarray2full = models.Shift(xstart - 1) & models.Shift(ystart - 1)
     if detector == 'NRS2':
         model = models.Shift(-2048) & models.Shift(-2048) | models.Scale(-1) & models.Scale(-1)
     elif detector == 'NRS1':
@@ -619,12 +623,13 @@ def compute_domain(slit2detector, wavelength_range, slit_ymin=-.5, slit_ymax=.5)
     x_range_high, y_range_high = slit2detector([0] * nsteps, [slit_ymax] * nsteps, lam_grid)
     x_range = np.hstack((x_range_low, x_range_high))
     y_range = np.hstack((y_range_low, y_range_high))
-    # add 5 px margin
-    x0 = int(max(0, x_range.min() - 10))
-    x1 = int(min(2047, x_range.max() + 10))
+    # add 10 px margin
+    # The -1 is technically because the output of slit2detector is 1-based coordinates.
+    x0 = int(max(0, x_range.min() -1 - 10))
+    x1 = int(min(2047, x_range.max() -1 + 10))
     # add 2 px margin
-    y0 = int(y_range.min()) - 2
-    y1 = int(y_range.max()) + 2
+    y0 = int(y_range.min() -1 -2)
+    y1 = int(y_range.max() -1 + 2)
 
     domain = [{'lower': x0, 'upper': x1}, {'lower': y0, 'upper': y1}]
     return domain

--- a/jwst/assign_wcs/tests/test_nirspec.py
+++ b/jwst/assign_wcs/tests/test_nirspec.py
@@ -144,7 +144,7 @@ def test_nirspec_ifu_against_esa():
     pipe = nirspec.create_pipeline(im, refs)
     w = wcs.WCS(pipe)
     im.meta.wcs = w
-    # Test evaluating the WCS
+    # Test evaluating the WCS (slice 0)
     w0 = nirspec.nrs_wcs_set_input(im, 0, 0)
 
     ref = fits.open(get_file_path('Trace_IFU_Slice_00_MON-COMBO-IFU-06_8410_jlab85.fits.gz'))
@@ -158,10 +158,11 @@ def test_nirspec_ifu_against_esa():
     cond = np.logical_and(slit1 < .5, slit1 > -.5)
     y, x = cond.nonzero()
     cor = crval - np.array(crpix)
-    y = y + cor[1]
-    x = x + cor[0]
-
-    ra, dec, lp = w0(x, y)
+    # 1-based coordinates full frame coordinates
+    y = y + cor[1] + 1
+    x = x + cor[0] + 1
+    sca2world = w0.get_transform('sca', 'msa_frame')
+    _, slit_y, lp = sca2world(x, y)
     assert_allclose(lp, lam[cond], atol=10**-13)
     ref.close()
 
@@ -209,11 +210,13 @@ def test_nirspec_fs_esa():
     cond = np.logical_and(slit1 < .5, slit1 > -.5)
     y, x = cond.nonzero()
     cor = crval - np.array(crpix)
-    y = y + cor[1]
-    x = x + cor[0]
-    ra, dec, lp = w1(x, y)
+    # 1-based coordinates full frame coordinates
+    y = y + cor[1] + 1
+    x = x + cor[0] + 1
+    sca2world = w1.get_transform('sca', 'v2v3')
+    ra, dec, lp = sca2world(x, y)
     # w1 now outputs in microns hence the 1e6 factor
-    assert_allclose(lp, lam[cond]*1e6, atol=10**-6)
+    assert_allclose(lp * 1e-6, lam[cond], atol=10**-13)
     ref.close()
 
 

--- a/jwst/extract_2d/extract_2d.py
+++ b/jwst/extract_2d/extract_2d.py
@@ -47,25 +47,25 @@ def extract2d(input_model, which_subarray=None):
         log.info('Subarray x-extents are: %s %s', xlo, xhi)
         log.info('Subarray y-extents are: %s %s', ylo, yhi)
 
-        ext_data = input_model.data[ylo: yhi + 1, xlo: xhi + 1].copy()
-        ext_err = input_model.err[ylo: yhi + 1, xlo: xhi + 1].copy()
-        ext_dq = input_model.dq[ylo: yhi + 1, xlo: xhi + 1].copy()
+        ext_data = input_model.data[ylo: yhi, xlo: xhi].copy()
+        ext_err = input_model.err[ylo: yhi, xlo: xhi].copy()
+        ext_dq = input_model.dq[ylo: yhi, xlo: xhi].copy()
         new_model = datamodels.ImageModel(data=ext_data, err=ext_err, dq=ext_dq)
         shape = ext_data.shape
-        domain = [{'lower': -0.5, 'upper': shape[1] + 0.5, 'includes_lower': True, 'includes_upper': False},
-                  {'lower': -0.5, 'upper': shape[0] + 0.5, 'includes_lower': True, 'includes_upper': False}]
+        domain = [{'lower': 0, 'upper': shape[1], 'includes_lower': True, 'includes_upper': False},
+                  {'lower':0, 'upper': shape[0], 'includes_lower': True, 'includes_upper': False}]
         slit_wcs.domain = domain
         new_model.meta.wcs = slit_wcs
         output_model.slits.append(new_model)
-        # set x/ystart values relative to full detector space
+        # set x/ystart values relative to the image (screen) frame.
+        # The overall subarray offset is recorded in model.meta.subarray.
         nslit = len(output_model.slits) - 1
         output_model.slits[nslit].name = slit_name
-        output_model.slits[nslit].xstart = xlo
+        output_model.slits[nslit].xstart = xlo + 1
         output_model.slits[nslit].xsize = xhi - xlo + 1
-        output_model.slits[nslit].ystart = ylo
+        output_model.slits[nslit].ystart = ylo +1
         output_model.slits[nslit].ysize = yhi - ylo + 1
     del input_model
-    #del output_model.meta.wcs
     # Set the step status to COMPLETE
     output_model.meta.cal_step.extract_2d = 'COMPLETE'
     return output_model


### PR DESCRIPTION
I went through the entire NIRSpec WCS pipeline in assign_wcs, slit extraction in extract_2d and wavelength assignment in compute_world_coordinates and checked that +/- 1 pixels exist at the correct places (0- vs 1- based coordinates). Also made sure that `domain` and `subarray.x(y)start` are used consistently within these modules. My testing shows that full frame coordinates are shifted by 1 pixel in x and y directions compared to IDT results. 
`SLITSTR` keywords are 0-base din IDT data (as far as I can tell) but I am not sure this is the difference.