### PR TITLE
Correct argument list for copy

### DIFF
--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -201,12 +201,14 @@ class DataModel(properties.ObjectNode):
             if fd is not None:
                 fd.close()
 
-    def copy(self):
+    def copy(self, memo=None):
         """
         Returns a deep copy of this model.
         """
         result = self.__class__(
-            init=copy.deepcopy(self._instance), schema=self._schema, extensions=self._extensions)
+            init=copy.deepcopy(self._instance, memo=memo),
+            schema=self._schema,
+            extensions=self._extensions)
         result._shape = self._shape
         return result
 


### PR DESCRIPTION
The DataModel class implements a copy method and the __copy__ and
__deepcopy__ methods are alaised to it. These two methods are called
by the copy module and the copy.deepcopy method requries that
__deepcopy__ takes a memo argument. When copy.deepcopy is called on a
DataModel object, it fails because of the missing argument. The fix
adds a keyword argument, memo=None, to the copy method and passes that
argument to the invocation of copy.deepcopy that it contains.