### PR TITLE
WCS for resampled data

### DIFF
--- a/jwst/assign_wcs/fgs.py
+++ b/jwst/assign_wcs/fgs.py
@@ -54,9 +54,8 @@ def imaging(input_model, reference_files):
     else:
         distortion = models.Identity(2)
     pipeline = [(detector, distortion),
-                (focal, fitswcs_transform),
-                (sky, None)
-                ]
+                (focal, None)]
+                #(sky, None)]
 
     return pipeline
 

--- a/jwst/assign_wcs/miri.py
+++ b/jwst/assign_wcs/miri.py
@@ -40,11 +40,11 @@ def imaging(input_model, reference_files):
     focal = cf.Frame2D(name='focal', axes_order=(0, 1), unit=(u.arcmin, u.arcmin))
     sky = cf.CelestialFrame(reference_frame=coord.ICRS())
     distortion = imaging_distortion(input_model, reference_files)
-    fitswcs_transform = pointing.create_fitswcs_transform(input_model)
+    #fitswcs_transform = pointing.create_fitswcs_transform(input_model)
     pipeline = [(detector, distortion),
-                (focal, fitswcs_transform),
-                (sky, None)
-                ]
+                (focal, None)]
+                #(sky, None)
+                #]
     return pipeline
 
 
@@ -151,13 +151,13 @@ def ifu(input_model, reference_files):
         "detector_to_alpha_beta")
     ab2xyan = (alpha_beta2XanYan(input_model, reference_files)).rename("alpha_beta_to_Xan_Yan")
     xyan2v23 = models.Identity(1) & (models.Shift(7.8) | models.Scale(-1)) & models.Identity(1)
-    fitswcs_transform = pointing.create_fitswcs_transform(input_model) & models.Identity(1)
+    #fitswcs_transform = pointing.create_fitswcs_transform(input_model) & models.Identity(1)
     pipeline = [(detector, det2alpha_beta),
                 (miri_focal, ab2xyan),
                 (xyan, xyan2v23),
-                (v2v3, fitswcs_transform),
-                (sky, None)
-                ]
+                (v2v3, None)]
+                 #fitswcs_transform),
+                #(sky, None)]
     return pipeline
 
 

--- a/jwst/assign_wcs/nircam.py
+++ b/jwst/assign_wcs/nircam.py
@@ -34,9 +34,8 @@ def imaging(input_model, reference_files):
     distortion = imaging_distortion(input_model, reference_files)
     fitswcs_transform = pointing.create_fitswcs_transform(input_model)
     pipeline = [(detector, distortion),
-                (focal, fitswcs_transform),
-                (sky, None)
-                ]
+                (focal, None)]
+                #(sky, None)]
     return pipeline
 
 

--- a/jwst/assign_wcs/niriss.py
+++ b/jwst/assign_wcs/niriss.py
@@ -34,9 +34,8 @@ def imaging(input_model, reference_files):
     distortion = imaging_distortion(input_model, reference_files)
     fitswcs_transform = pointing.create_fitswcs_transform(input_model)
     pipeline = [(detector, distortion),
-                (focal, fitswcs_transform),
-                (sky, None)
-                ]
+                (focal, None)]
+                #(sky, None)]
     return pipeline
 
 

--- a/jwst/assign_wcs/nirspec.py
+++ b/jwst/assign_wcs/nirspec.py
@@ -103,15 +103,15 @@ def imaging(input_model, reference_files):
             oteip2v23 = f.tree['model'].copy()
 
         # V2, V3 to wprld (RA, DEC) transform
-        v23_to_sky = pointing.fitswcs_transform_from_model(input_model)
+        #v23_to_sky = pointing.fitswcs_transform_from_model(input_model)
 
         imaging_pipeline = [(det, dms2detector),
                             (sca, det2gwa),
                             (gwa, gwa2msa),
                             (msa_frame, msa2oteip),
                             (oteip, oteip2v23),
-                            (v2v3, v23_to_sky),
-                            (world, None)]
+                            (v2v3, None)]
+                            #(world, None)]
     else:
         # convert to microns if the pipeline ends earlier
         gwa2msa = (gwa2msa | Identity(2) & Scale(10**6)).rename('gwa2msa')

--- a/jwst/assign_wcs/pointing.py
+++ b/jwst/assign_wcs/pointing.py
@@ -1,11 +1,14 @@
 from __future__ import (absolute_import, unicode_literals, division,
                         print_function)
+import six
 import numpy as np
-from ..datamodels import fits_support
+from astropy import units as u
+from astropy import coordinates as coords
+from astropy.modeling import models as astmodels
+from ..datamodels import fits_support, DataModel
 from gwcs import utils as gwutils
-
-
-##TODO: populate the core model with basiic WCS keywords?
+from gwcs import coordinate_frames as cf
+from gwcs import wcs
 
 
 def create_fitswcs_transform(input_model):
@@ -16,30 +19,103 @@ def create_fitswcs_transform(input_model):
     return transform
 
 
-def fitswcs_transform_from_model(input_model):
-    """
-    Create a fits wcs from a datamodel.meta.wcsinfo.
-    """
+def wcsinfo_from_model(input_model):
+    defaults = {'crpix': 0, 'crval': 0, 'cdelt': 1}
     wcsinfo = {}
-    wcsaxes = input_model._instance['meta']['wcsinfo']['wcsaxes']
+    wcsaxes = input_model.meta.wcsinfo.wcsaxes
     wcsinfo['WCSAXES'] = wcsaxes
-    for key in ['CTYPE', 'CRPIX', 'CRVAL', 'CDELT', 'CUNIT']:
+    for key in ['CRPIX', 'CRVAL', 'CDELT']:
         val = []
         for ax in range(1, wcsaxes + 1):
+            k = (key + "{0}".format(ax)).lower()
             try:
-                val.append(input_model._instance['meta']['wcsinfo'][(key + "{0}".format(ax)).lower()])
+                v = getattr(input_model.meta.wcsinfo, k)
+                if v is None:
+                    v = defaults[key]
+                val.append(v)
             except KeyError:
-                pass
-        wcsinfo[key.upper()] = val
+                val.append(defaults[key])
+        wcsinfo[key.upper()] = np.array(val)
+
+    ctypes = []
+    cunits = []
+    for ax in range(1, wcsaxes + 1):
+        try:
+            ctypes.append(getattr(input_model.meta.wcsinfo, ("CTYPE{0}".format(ax)).lower()))
+        except KeyError:
+            ctypes.append("")
+        try:
+            v = getattr(input_model.meta.wcsinfo, ("CUNIT{0}".format(ax)).lower())
+            cunits.append(u.Unit(v))
+        except KeyError:
+            cunits.append(u.Unit(""))
+
+    wcsinfo["CTYPE"] = np.array(ctypes)
+    wcsinfo["CUNIT"] = np.array(cunits)
 
     pc = np.zeros((wcsaxes, 2))
 
     for i in range(1, wcsaxes + 1):
         for j in range(1, 3):
-            pc[i - 1, j - 1] = input_model._instance['meta']['wcsinfo']['pc{0}_{1}'.format(i, j)]
+            pc[i - 1, j - 1] = getattr(input_model.meta.wcsinfo, 'pc{0}_{1}'.format(i, j))
     wcsinfo['PC'] = pc
-    # getting "coordinates" from the schema is currently broken.
-    wcsinfo['RADESYS'] = 'ICRS' #input_model._instance['meta']['coordinates']['reference_frame']
+    wcsinfo['RADESYS'] = input_model.meta.coordinates.reference_frame
     wcsinfo['has_cd'] = False
+    return wcsinfo
+
+
+def fitswcs_transform_from_model(wcsinfo):
+    """
+    Create a fits wcs from a datamodel.meta.wcsinfo.
+    """
+    spatial_axes, spectral_axes = gwutils.get_axes(wcsinfo)
+
     transform = gwutils.make_fitswcs_transform(wcsinfo)
+    if wcsinfo['WCSAXES'] == 3:
+        spectral_transform = astmodels.Shift(-wcsinfo['CRPIX'][spectral_axes]) | \
+                           astmodels.Scale(wcsinfo['CDELT'][spectral_axes]) | \
+                           astmodels.Shift(wcsinfo['CRVAL'][spectral_axes])
+        transform = transform & spectral_transform
+
     return transform
+
+
+def frame_from_fits(ff):
+    raise NotImplementedError()
+
+
+def frame_from_model(wcsinfo):
+    wcsaxes = wcsinfo['WCSAXES']
+    spatial_axes, spectral_axes = gwutils.get_axes(wcsinfo)
+    cunit = wcsinfo['CUNIT']
+    ref_frame = coords.ICRS()
+    sky = cf.CelestialFrame(name='sky', axes_order=tuple(spatial_axes), reference_frame=ref_frame,
+                            unit=cunit[spatial_axes], axes_names=('RA', 'DEC'))
+    if wcsaxes == 2:
+        return sky
+    elif wcsaxes == 3:
+        spec = cf.SpectralFrame(name='spectral', axes_order=tuple(spectral_axes), unit=cunit[spectral_axes[0]],
+                                axes_names=('wavelength',))
+        world = cf.CompositeFrame([sky, spec], name='world')
+        return world
+    else:
+        raise ValueError("WCSAXES can be 2 or 3, git {0}".format(wcsaxes))
+
+
+def create_fitswcs(inp):
+    if isinstance(inp, DataModel):
+        wcsinfo = wcsinfo_from_model(inp)
+        transform = fitswcs_transform_from_model(wcsinfo) #inp)
+        output_frame = frame_from_model(wcsinfo) #inp)
+    elif isinstance(inp, six.string_types):
+        transform = create_fitswcs_transform(inp)
+        output_frame = frame_from_fits(inp)
+    else:
+        raise TypeError("Input is expected to be a DataModel instance or a FITS file.")
+
+    input_frame = cf.Frame2D(name='detector', axes_order=(0, 1))
+    pipeline = [(input_frame, transform),
+               (output_frame, None)]
+
+    wcsobj = wcs.WCS(pipeline)
+    return wcsobj


### PR DESCRIPTION
This code is to be used by steps which resample the data and create a FITS standard WCS keywords. It is assumed that `model.meta.wcsinfo` has been populated with the correct values. The code cretaes a WCS object from these values.

```
from ..assign_wcs import pointing

wcsobj = pointing.create_fitswcs(output_model)
output_model.meta.wcs = wcsobj
```
Need to write tests.