### PR TITLE
Rename fornat to format

### DIFF
--- a/jwst/datamodels/util.py
+++ b/jwst/datamodels/util.py
@@ -222,7 +222,7 @@ def gentle_asarray(a, dtype):
         try:
             a = np.asarray(a, dtype=out_dtype)
         except:
-            raise ValueError("Can't convert {0!s} to ndarray".fornat(type(a)))
+            raise ValueError("Can't convert {0!s} to ndarray".format(type(a)))
         return a
 
 def get_short_doc(schema):


### PR DESCRIPTION
An error message used the format method but misspelled it fornat. It
went undetected because in Python such mistakes are only caught at
runtime and error branches are not often tested or invoked. The fix
spells the method correctly.