### PR TITLE
multislits to model container

### DIFF
--- a/jwst/exp_to_source/exp_to_source.py
+++ b/jwst/exp_to_source/exp_to_source.py
@@ -2,9 +2,10 @@
 """
 from collections import defaultdict
 
-from jwst.datamodels import MultiExposureModel
+from jwst.datamodels import MultiExposureModel, ModelContainer, ImageModel
+from jwst.datamodels.properties import merge_tree
 
-__all__ = ['exp_to_source']
+__all__ = ['exp_to_source', 'multislit_to_container']
 
 
 def exp_to_source(inputs):
@@ -27,4 +28,28 @@ def exp_to_source(inputs):
         for slit in exposure.slits:
             result[slit.name].exposures.append(slit)
             result[slit.name].exposures[-1].meta = exposure.meta
+    return result
+
+
+def multislit_to_container(inputs):
+    """Reformat exposure-based MSA data to source-based containers.
+
+    Parameters
+    ----------
+    inputs: [MultiSlitModel, ...]
+        List of MultiSlitModel instances to reformat.
+
+    Returns
+    -------
+    {str: ModelContainer, }
+        Returns a dict of ModelContainer instances wherein each
+        instance contains ImageModels of slits belonging to the same source.
+        The key is the name of each slit.
+    """
+    result = defaultdict(ModelContainer)
+    for exposure in inputs:
+        for slit in exposure.slits:
+            result[slit.name].append(ImageModel(slit.instance))
+            merge_tree(result[slit.name][-1].meta.instance, 
+                exposure.meta.instance)
     return result

--- a/jwst/exp_to_source/exp_to_source.py
+++ b/jwst/exp_to_source/exp_to_source.py
@@ -37,7 +37,8 @@ def multislit_to_container(inputs):
     Parameters
     ----------
     inputs: [MultiSlitModel, ...]
-        List of MultiSlitModel instances to reformat.
+        List of MultiSlitModel instances to reformat, or just a 
+        ModelContainer full of MultiSlitModels.
 
     Returns
     -------


### PR DESCRIPTION
exp_to_source() produces a dictionary of MultiSlitModels keyed off their slit names, with each MultiSlitModel containing the exposures for that slit.  multislit_to_container() now does the same, only instead of putting them in MultiSlitModels, it puts them in ModelContainers holding ImageModels.

The interface is easy to use as you can pass it ModelContainer object that was created from an association.

```
c = datamodels.open('lots_of_multislit_exposures_asn.json')
d = exp_to_source.multislit_to_container(c)
```
And now the source-based containers can be accessed by slit name:

`d['S200A1']`


@stsci-hack 