### PR TITLE
Fix to ramp_fit_step argument spec

### DIFF
--- a/jwst/ramp_fitting/ramp_fit_step.py
+++ b/jwst/ramp_fitting/ramp_fit_step.py
@@ -19,7 +19,7 @@ class RampFitStep (Step):
 
     spec = """
         int_name = string(default='')
-        save_opt = boolean(default=False) # Save optional output (Boolean)
+        save_opt = boolean(default=False) # Save optional output
         opt_name = string(default='')
         algorithm = option('OLS', 'GLS', default='OLS') # 'OLS' or 'GLS'
         weighting = option('unweighted', 'optimal', default='unweighted') \


### PR DESCRIPTION
I keep getting an error on both my Linux and Mac systems from one line in the ramp_fit_step specification for the save_opt argument. The configobj parser seems to be choking on the fact that there's something included in parentheses within the in-line comment in the argument definition. It's as if it tries to interpret anything and everything contained within parens as part of the argument definition, despite the fact that it's part of the in-line comment (i.e. after the # character). When I remove the parens, it's fine.

The mystery is that this error does not seem to be occurring on other systems, such as jwcalibdev that runs all the daily reg tests, nor have I heard anyone else complain of this problem. So I could understand it (sort of) if it only occurred on one of my systems, which I would blame on something wrong in my environment setup, but it happens on BOTH of my systems (Linux and Mac). It prevents me from running, testing, duplicating anything we've pushed out to either the rest of STScI users or DMS.

So even if it's not affecting anyone else, I'm removing those parens so that I can run things on my system (the extra info in the parens isn't necessary anyway).