### PR TITLE
remove qt from build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
     global:
         - MAIN_CMD='python setup.py'
         - CONDA_CHANNELS='http://ssb.stsci.edu/conda-dev'
-        - CONDA_DEPENDENCIES='pytest jwst sphinx=1.3.5 qt=4'
+        - CONDA_DEPENDENCIES='pytest jwst sphinx=1.3.5'
         - CONDA_JWST_DEPENDENCIES='pytest stsci-jwst sphinx=1.3.5'
         - PIP_DEPENDENCIES=''
         - CRDS_SERVER_URL='https://jwst-crds.stsci.edu'


### PR DESCRIPTION
I am seeing this error in travis:

```
Error: HTTPError: 404 Client Error: Not Found for url: https://repo.continuum.io/pkgs/free/osx-64/pillow-3.4.1-py35_0.tar.bz2: https://repo.continuum.io/pkgs/free/osx-64/pillow-3.4.1-py35_0.tar.bz2
```
qt is not needed any more as the plotting code was removed. Hopefully this will fix the builds.