### PR TITLE
name frames consistently

### DIFF
--- a/jwst/assign_wcs/fgs.py
+++ b/jwst/assign_wcs/fgs.py
@@ -46,8 +46,8 @@ def imaging(input_model, reference_files):
     reference_files={'distortion': 'jwst_fgs_distortioon_0001.asdf'}
     """
     detector = cf.Frame2D(name='detector', axes_order=(0, 1), unit=(u.pix, u.pix))
-    focal = cf.Frame2D(name='focal', axes_order=(0, 1), unit=(u.arcmin, u.arcmin))
-    sky = cf.CelestialFrame(name='icrs', reference_frame=coord.ICRS())
+    v2v3 = cf.Frame2D(name='v2v3', axes_order=(0, 1), unit=(u.arcmin, u.arcmin))
+    world = cf.CelestialFrame(name='world', reference_frame=coord.ICRS())
     # V2, V3 to sky
     tel2sky = pointing.v23tosky(input_model)
 
@@ -56,8 +56,8 @@ def imaging(input_model, reference_files):
     else:
         distortion = models.Identity(2)
     pipeline = [(detector, distortion),
-                (focal, tel2sky),
-                (sky, None)]
+                (v2v3, tel2sky),
+                (world, None)]
     return pipeline
 
 

--- a/jwst/assign_wcs/miri.py
+++ b/jwst/assign_wcs/miri.py
@@ -37,13 +37,13 @@ def imaging(input_model, reference_files):
     reference_files={'distortion': 'test.asdf', 'filter_offsets': 'filter_offsets.asdf'}
     """
     detector = cf.Frame2D(name='detector', axes_order=(0, 1), unit=(u.pix, u.pix))
-    focal = cf.Frame2D(name='focal', axes_order=(0, 1), unit=(u.arcmin, u.arcmin))
-    sky = cf.CelestialFrame(reference_frame=coord.ICRS())
+    v2v3 = cf.Frame2D(name='v2v3', axes_order=(0, 1), unit=(u.arcmin, u.arcmin))
+    world = cf.CelestialFrame(reference_frame=coord.ICRS(), name='world')
     distortion = imaging_distortion(input_model, reference_files)
     tel2sky = pointing.v23tosky(input_model)
     pipeline = [(detector, distortion),
-                (focal, tel2sky),
-                (sky, None)
+                (v2v3, tel2sky),
+                (world, None)
                 ]
     return pipeline
 
@@ -142,11 +142,11 @@ def ifu(input_model, reference_files):
     spec = cf.SpectralFrame(name='Xan_Yan_spectral', axes_order=(2,), unit=(u.micron,), axes_names=('lambda',))
     xyan = cf.CompositeFrame([xyan_spatial, spec], name='Xan_Yan')
     v23_spatial = cf.Frame2D(name='V2_V3_spatial', axes_order=(0, 1), unit=(u.arcmin, u.arcmin), axes_names=('v2', 'v3'))
-    spec = cf.SpectralFrame(name='V2_v3_spectral', axes_order=(2,), unit=(u.micron,), axes_names=('lambda',))
-    v2v3 = cf.CompositeFrame([v23_spatial, spec], name='V2_V3')
+    spec = cf.SpectralFrame(name='spectral', axes_order=(2,), unit=(u.micron,), axes_names=('lambda',))
+    v2v3 = cf.CompositeFrame([v23_spatial, spec], name='v2v3')
     icrs = cf.CelestialFrame(name='icrs', reference_frame=coord.ICRS(),
                              axes_order=(0, 1), unit=(u.deg, u.deg), axes_names=('RA', 'DEC'))
-    sky = cf.CompositeFrame([icrs, spec], name='sky_and_wavelength')
+    world = cf.CompositeFrame([icrs, spec], name='world')
     det2alpha_beta = (detector_to_alpha_beta(input_model, reference_files)).rename(
         "detector_to_alpha_beta")
     ab2xyan = (alpha_beta2XanYan(input_model, reference_files)).rename("alpha_beta_to_Xan_Yan")
@@ -156,7 +156,7 @@ def ifu(input_model, reference_files):
                 (miri_focal, ab2xyan),
                 (xyan, xyan2v23),
                 (v2v3, tel2sky),
-                (sky, None)]
+                (world, None)]
     return pipeline
 
 

--- a/jwst/assign_wcs/nircam.py
+++ b/jwst/assign_wcs/nircam.py
@@ -29,13 +29,13 @@ def imaging(input_model, reference_files):
     reference_files={'distortion': 'test.asdf', 'filter_offsets': 'filter_offsets.asdf'}
     """
     detector = cf.Frame2D(name='detector', axes_order=(0, 1), unit=(u.pix, u.pix))
-    focal = cf.Frame2D(name='focal', axes_order=(0, 1), unit=(u.arcmin, u.arcmin))
-    sky = cf.CelestialFrame(reference_frame=coord.ICRS())
+    v2v3 = cf.Frame2D(name='v2v3', axes_order=(0, 1), unit=(u.arcmin, u.arcmin))
+    world = cf.CelestialFrame(reference_frame=coord.ICRS(), name='world')
     distortion = imaging_distortion(input_model, reference_files)
     tel2sky = pointing.v23tosky(input_model)
     pipeline = [(detector, distortion),
-                (focal, tel2sky),
-                (sky, None)]
+                (v2v3, tel2sky),
+                (world, None)]
     return pipeline
 
 

--- a/jwst/assign_wcs/nirspec.py
+++ b/jwst/assign_wcs/nirspec.py
@@ -914,7 +914,7 @@ def create_frames():
     slit_spatial = cf.Frame2D(name='slit_spatial', axes_order=(0, 1), unit=("", ""),
                              axes_names=('x_slit', 'y_slit'))
     sky = cf.CelestialFrame(name='sky', axes_order=(0, 1), reference_frame=coord.ICRS())
-    v2v3_spatial = cf.Frame2D(name='V2V3_spatial', axes_order=(0, 1), unit=(u.deg, u.deg),
+    v2v3_spatial = cf.Frame2D(name='v2v3_spatial', axes_order=(0, 1), unit=(u.deg, u.deg),
                              axes_names=('V2', 'V3'))
 
     # The oteip_to_v23 incorporates a scale to convert the spectral units from
@@ -924,7 +924,7 @@ def create_frames():
     v2v3 = cf.CompositeFrame([v2v3_spatial, spec], name='v2v3')
     slit_frame = cf.CompositeFrame([slit_spatial, spec], name='slit_frame')
     msa_frame = cf.CompositeFrame([msa_spatial, spec], name='msa_frame')
-    oteip_spatial = cf.Frame2D(name='OTEIP_spatial', axes_order=(0, 1), unit=(u.deg, u.deg),
+    oteip_spatial = cf.Frame2D(name='oteip', axes_order=(0, 1), unit=(u.deg, u.deg),
                                axes_names=('X_OTEIP', 'Y_OTEIP'))
     oteip = cf.CompositeFrame([oteip_spatial, spec], name='oteip')
     world = cf.CompositeFrame([sky, spec], name='world')


### PR DESCRIPTION
Since different instrument were coded at different times the coordinate frames got different names. This intends to name them consistently as much as possibly.
The output frame is called `world`, the V2,V3 frame is called `v2v3` and the input frame is `detector`.