### PR TITLE
Initial version of new source-type step

### DIFF
--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -228,6 +228,10 @@ properties:
             title: Target proper motion epoch
             type: string
             fits_keyword: PROPEPOC
+          source_type:
+            title: Advised source type (point/extended)
+            type: string
+            fits_keyword: SRCTYPE
       instrument:
         title: Instrument configuration information
         type: object

--- a/jwst/srctype/__init__.py
+++ b/jwst/srctype/__init__.py
@@ -1,0 +1,4 @@
+from __future__ import absolute_import
+from .srctype_step import SourceTypeStep
+
+__version__ = '0.7.0'

--- a/jwst/srctype/srctype.py
+++ b/jwst/srctype/srctype.py
@@ -1,0 +1,47 @@
+from __future__ import absolute_import
+
+import logging
+
+log = logging.getLogger(__name__)
+log.setLevel(logging.DEBUG)
+
+def set_source_type(input_model):
+    """
+    """
+
+    # Get the exposure type of the input model
+    try:
+        exptype = input_model.meta.exposure.type
+        log.debug('Input EXP_TYPE is %s' % exptype)
+    except:
+        log.error('Failed to access EXP_TYPE value in input')
+        log.error('Step will be skipped')
+        return None
+
+    # For exposure types that use a single source, get the user-supplied
+    # source type from the selection they provided in the APT
+    if exptype in ['MIR_LRS-FIXEDSLIT', 'MIR_LRS-SLITLESS', 'MIR_MRS',
+                   'NIS_SOSS', 'NRS_FIXEDSLIT', 'NRS_IFU']:
+
+        # Get the value the user specified (if any)
+        user_type = input_model.meta.target.source_type
+
+        if (user_type is not None) and (user_type in ['POINT', 'EXTENDED']):
+
+            # Use the value supplied by the user
+            log.info('Using input SRCTYPE of %s' % user_type)
+            src_type = user_type
+
+        else:
+
+            # Set a default value based on the exposure type
+            if exptype == 'MIR_MRS':
+                src_type = 'EXTENDED'
+            else:
+                src_type = 'POINT'
+            log.info('Input SRCTYPE is unknown. Setting to default ' +
+                     'value of %s' % src_type)
+
+        input_model.meta.target.source_type = src_type
+    
+    return input_model

--- a/jwst/srctype/srctype_step.py
+++ b/jwst/srctype/srctype_step.py
@@ -1,0 +1,36 @@
+#! /usr/bin/env python
+
+from ..stpipe import Step, cmdline
+from .. import datamodels
+from .srctype import set_source_type
+
+
+class SourceTypeStep(Step):
+    """
+    SourceTypeStep: Selects and sets a source type based on various inputs.
+    The source type is used in later calibrations to determine the appropriate
+    methods to use. Input comes from either the SRCTYPE keyword value, which
+    is populated from user info in the APT, or the NIRSpec MSA planning tool.
+    """
+
+    spec = """
+    """
+
+    def process(self, input):
+
+        with datamodels.open(input) as input_model:
+
+            # Call the source selection routine
+            result = set_source_type(input_model)
+
+            if result is None:
+                result = input_model.copy()
+                result.meta.cal_step.srctype = 'SKIPPED'
+            else:
+                result.meta.cal_step.srctype = 'COMPLETE'
+
+        return result
+
+
+if __name__ == '__main__':
+    cmdline.step_script(SourceTypeStep)

--- a/jwst/steps.py
+++ b/jwst/steps.py
@@ -33,6 +33,7 @@ from . import rscd
 from . import saturation
 from . import skymatch
 from . import source_catalog
+from . import srctype
 from . import stpipe
 from . import straylight
 from . import superbias


### PR DESCRIPTION
Initial version of new step called SourceType, which does the work of the "Point vs Extended Decision" step outlined in the JCCWG calspec3 baseline pipeline (https://confluence.stsci.edu/display/JWSTCC/Vanilla+Point+vs+Extended+Decision).

This initial version so far only works with spectroscopic exposure types that observe a single source (MIRI LRS & MRS, NIRSpec IFU, NIRISS SOSS), in which case the user had a chance to specify a source type in the APT. If the user did so, that choice will be stored in the header keyword "SRCTYPE". If the user did not specify a source type or they selected "UNKNOWN", this routine will reset SRCTYPE to either POINT or EXTENDED based on default rules for each exposure type established by the JCCWG.

This still needs to be expanded to also work on NIRSpec MSA exposures, where a 'stellarity' value for each source will be read from the MSA configuration file and stored as a keyword in the appropriate Slit object for each source.