### PR TITLE
Photom update for writing RELSENS

### DIFF
--- a/jwst/photom/photom.py
+++ b/jwst/photom/photom.py
@@ -374,8 +374,8 @@ class DataSet(object):
         # If the relative response arrays have length > 0, copy them into the
         # relsens table of the data model
         if nelem > 0:
-            waves = tabdata['wavelength']
-            relresps = tabdata['relresponse']
+            waves = tabdata['wavelength'][:nelem]
+            relresps = tabdata['relresponse'][:nelem]
 
             # Set the relative sensitivity table for the correct Model type
             if isinstance(self.input, datamodels.MultiSlitModel):


### PR DESCRIPTION
Modified the photom_io function to only copy the first nelem valid elements of the wavelength and response arrays loaded from the photom table to the RELSENS table stored in the science product. That way the arrays in the science product don't have zero padding at the ends.