### PR TITLE
generalize import of asn table data into meta.asn_table

### DIFF
--- a/jwst/datamodels/container.py
+++ b/jwst/datamodels/container.py
@@ -164,7 +164,12 @@ class ModelContainer(model_base.DataModel):
         except IOError:
             raise IOError('Cannot open data models.')
 
+        # Pull the whole association table into meta.asn_table
+        self.meta.asn_table = {}
+        model_base.properties.merge_tree(self.meta.asn_table._instance, asn_data)
+
         # populate the output metadata with the output file from the ASN file
+        # Should generalize this in the future
         self.meta.resample.output = str(asn_data['products'][0]['name'])
         self.meta.table_name = str(filepath)
         self.meta.pool_name = str(asn_data['asn_pool'])

--- a/jwst/datamodels/container.py
+++ b/jwst/datamodels/container.py
@@ -235,3 +235,30 @@ class ModelContainer(model_base.DataModel):
                 model.save(outpath, *args, **kwargs)
         except IOError as err:
             raise err
+
+    def _get_recursively(self, field, search_dict):
+        """
+        Takes a dict with nested lists and dicts, and searches all dicts for
+        a key of the field provided.
+        """
+        values_found = []
+        for key, value in search_dict.items():
+            if key == field:
+                values_found.append(value)
+            elif isinstance(value, dict):
+                results = self._get_recursively(field, value)
+                for result in results:
+                    values_found.append(result)
+            elif isinstance(value, list):
+                for item in value:
+                    if isinstance(item, dict):
+                        more_results = self._get_recursively(field, item)
+                        for another_result in more_results:
+                            values_found.append(another_result)
+        return values_found
+
+    def get_recursively(self, field):
+        """
+        Returns a list of values of the specified field from meta.
+        """
+        return self._get_recursively(field, self.meta._instance)


### PR DESCRIPTION
This update to ModelContainer allows the complete association dictionary to be pulled into meta.asn_table upon initialization, so now the container will have available all attributes that are in the input association table.  So for instance, to get the EXPTYPE values, in model container c:

```
In [5]: for m in c.meta.asn_table.products[0].members:
   ...:     print(m.exptype)
   ...:     
SCIENCE
SCIENCE
```


@stsci-hack 