### PR TITLE
Change asarray to asanyarray in _fits_array_writer

### DIFF
--- a/jwst/datamodels/container.py
+++ b/jwst/datamodels/container.py
@@ -107,6 +107,13 @@ class ModelContainer(model_base.DataModel):
         else:
             self._models.pop(index)
 
+    def flatten(self):
+        """
+        Iterator over all the models in the container
+        """
+        for model in self._models:
+            yield model
+    
     def assign_group_ids(self):
         for model in self._models:
             model_attrs = [model.meta.observation.program_number,
@@ -225,7 +232,7 @@ class ModelContainer(model_base.DataModel):
         if path is None:
             path = os.getcwd()
         try:
-            for model in self._models:
+            for model in self.flatten():
                 outpath = op.join(path, model.meta.filename)
                 model.save(outpath, *args, **kwargs)
         except IOError as err:

--- a/jwst/datamodels/container.py
+++ b/jwst/datamodels/container.py
@@ -112,7 +112,8 @@ class ModelContainer(model_base.DataModel):
         Iterator over all the models in the container
         """
         for model in self._models:
-            yield model
+            for submodel in model.flatten():
+                yield submodel
     
     def assign_group_ids(self):
         for model in self._models:

--- a/jwst/datamodels/fits_support.py
+++ b/jwst/datamodels/fits_support.py
@@ -256,7 +256,7 @@ def _fits_array_writer(validator, _, instance, schema):
     if instance is None:
         return
 
-    instance = np.asarray(instance)
+    instance = np.asanyarray(instance)
 
     if not len(instance.shape):
         return

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -565,6 +565,12 @@ class DataModel(properties.ObjectNode):
             """
             return list(self.itervalues())
 
+    def flatten(self):
+        """
+        Iterator over a single model. Base case.
+        """
+        yield self
+
     def update(self, d, only=''):
         """
         Updates this model with the metadata elements from another model.


### PR DESCRIPTION
Binary tables are stored in memory as a type derived from numpy arrays. One has to be careful when copying them to use asanyarray instead of asarray so the`copy has the same type and does not lose the methods and fields of the base type. In this case, the _coldefs attribute, which contains the attributes of a column, was lost, making it impossible to update a column's attributes with the datamodels code.
