### PR TITLE
NIRISS photom data model update

### DIFF
--- a/jwst/datamodels/schemas/niriss_photom.schema.yaml
+++ b/jwst/datamodels/schemas/niriss_photom.schema.yaml
@@ -11,6 +11,8 @@ allOf:
         datatype: [ascii, 12]
       - name: pupil
         datatype: [ascii, 12]
+      - name: order
+        datatype: int16
       - name: photmjsr
         datatype: float32
       - name: uncertainty


### PR DESCRIPTION
Updated the NIRISS photom data model schema to include a new table column for the spectral order number. In partial fulfillment of #339. This completes the necessary updates to the reference file data model. Still have to make updates to the photom step to handle multiple orders of flux conversion data.