### PR TITLE
Comvert print statements to calls to logger

### DIFF
--- a/jwst/datamodels/dynamicdq.py
+++ b/jwst/datamodels/dynamicdq.py
@@ -2,6 +2,10 @@ from __future__ import print_function
 import numpy as np
 from . import dqflags
 
+import logging
+log = logging.getLogger(__name__)
+log.setLevel(logging.DEBUG)
+
 def dynamic_mask(input_model):
     #
     # Return a mask model given a mask with dynamic DQ flags
@@ -22,7 +26,7 @@ def dynamic_mask(input_model):
             try:
                 standard_bitvalue = dqflags.pixel[dqname]
             except KeyError:
-                print('Keyword %s does not correspond to an existing DQ mnemonic, so will be ignored' % (dqname))
+                log.warning('Keyword %s does not correspond to an existing DQ mnemonic, so will be ignored' % (dqname))
                 continue
             just_this_bit = np.bitwise_and(input_model.dq, bitplane)
             pixels = np.where(just_this_bit != 0)

--- a/jwst/datamodels/util.py
+++ b/jwst/datamodels/util.py
@@ -9,6 +9,10 @@ import numpy as np
 from astropy.extern import six
 from astropy.io import fits
 
+import logging
+log = logging.getLogger(__name__)
+log.setLevel(logging.DEBUG)
+
 def open(init=None, extensions=None, **kwargs):
     """
     Creates a DataModel from a number of different types
@@ -130,9 +134,9 @@ def open(init=None, extensions=None, **kwargs):
     else:
         raise ValueError("Don't have a DataModel class to match the shape")
     if isinstance(init, (six.text_type, bytes)):
-        print('Opening {0} as {1}'.format(basename(init), new_class))
+        log.debug('Opening {0} as {1}'.format(basename(init), new_class))
     else:
-        print('Opening as {0}'.format(new_class))
+        log.debug('Opening as {0}'.format(new_class))
     return new_class(init, extensions=extensions, **kwargs)
 
 


### PR DESCRIPTION
For the proper operation of the pipeline, messages should be sent to the logger instead of stdout, which is where print sends them. Three print statements were converted to calls to the python logger.