### PR TITLE
Additional MultiSlit keyword entries

### DIFF
--- a/jwst/datamodels/schemas/multislit.schema.yaml
+++ b/jwst/datamodels/schemas/multislit.schema.yaml
@@ -88,4 +88,21 @@ allOf:
             type: number
             fits_keyword: STLARITY
             fits_hdu: SCI
+          source_type:
+            title: Source type (point/extended)
+            type: string
+            fits_keyword: SRCTYPE
+            fits_hdu: SCI
+          source_xpos:
+            title: Source position in slit (x-axis)
+            type: number
+            default: 0.0
+            fits_keyword: SRCXPOS
+            fits_hdu: SCI
+          source_ypos:
+            title: Source position in slit (y-axis)
+            type: number
+            default: 0.0
+            fits_keyword: SRCYPOS
+            fits_hdu: SCI
 $schema: http://stsci.edu/schemas/fits-schema/fits-schema


### PR DESCRIPTION
Added entries to the MultiSlit data model schema for 3 new keywords that will be populated for each extracted slit: SRCTYPE (point vs. extended), SRCXPOS (source x position in slit), and SRCYPOS (source y position in slit). SRCTYPE will be populated by the source_type step, while SRCXPOS and SRCYPOS will be populated by the extract_2d step (from data in the MSA config file).