### PR TITLE
Remove unneeded PATTTYPE check on MIR_LRS-FIXEDSLIT

### DIFF
--- a/jwst/associations/lib/rules_level3.py
+++ b/jwst/associations/lib/rules_level3.py
@@ -97,11 +97,6 @@ class Asn_MIRI_LRS_FIXEDSLIT(
 
         # Setup for checking.
         self.add_constraints({
-            'patttype': {
-                'value': None,
-                'inputs': ['PATTTYPE'],
-                'force_unique': True
-            },
             'exp_type': {
                 'value': 'MIR_LRS-FIXEDSLIT|MIR_TACQ',
                 'inputs': ['EXP_TYPE']


### PR DESCRIPTION
This check had been removed from other rules; missed this one.
It may come back, but not specifications have been received
concerning this.