### PR TITLE
Fixed shift column/row order

### DIFF
--- a/jwst/assign_wcs/miri.py
+++ b/jwst/assign_wcs/miri.py
@@ -36,15 +36,22 @@ def imaging(input_model, reference_files):
 
     reference_files={'distortion': 'test.asdf', 'filter_offsets': 'filter_offsets.asdf'}
     """
+
+    # Create the Frames
     detector = cf.Frame2D(name='detector', axes_order=(0, 1), unit=(u.pix, u.pix))
     v2v3 = cf.Frame2D(name='v2v3', axes_order=(0, 1), unit=(u.arcsec, u.arcsec))
     world = cf.CelestialFrame(reference_frame=coord.ICRS(), name='world')
+
+    # Create the transforms
     distortion = imaging_distortion(input_model, reference_files)
     tel2sky = pointing.v23tosky(input_model)
+
+    # Create the pipeline
     pipeline = [(detector, distortion),
                 (v2v3, tel2sky),
                 (world, None)
                 ]
+
     return pipeline
 
 
@@ -61,7 +68,8 @@ def imaging_distortion(input_model, reference_files):
 
 
     using CDP 3 Reference distortion file
-    MIRI_FM_MIRIMAGE_F1000W_PSF_03.01.00.fits
+        Old one: ~~MIRI_FM_MIRIMAGE_F1000W_PSF_03.01.00.fits~~
+    Current one: MIRI_FM_MIRIMAGE_DISTORTION_06.03.00.fits
 
     reference files/corrections needed (pixel to sky):
 
@@ -74,11 +82,17 @@ def imaging_distortion(input_model, reference_files):
     ref_file: filter_offset.asdf - (1)
     ref_file: distortion.asdf -(2,3,4)
     """
+
+    # Load the distortion and filter from the reference files.
     distortion = AsdfFile.open(reference_files['distortion']).tree['model']
     filter_offset = AsdfFile.open(reference_files['filteroffset']).tree[input_model.meta.instrument.filter]
-    full_distortion = models.Shift(filter_offset['row_offset']) & models.Shift(
-        filter_offset['column_offset']) | distortion | models.Scale(60) & models.Scale(60)
+
+    # Now apply each of the models.  The Scale(60) converts from arc-minutes to arc-seconds.
+    full_distortion = models.Shift(filter_offset['column_offset']) & models.Shift(
+        filter_offset['row_offset']) | distortion | models.Scale(60) & models.Scale(60)
+
     full_distortion = full_distortion.rename('distortion')
+
     return full_distortion
 
 


### PR DESCRIPTION
In discussion with @nden , originally it was thought the miri.py file had an issue with the order of V2/V3 that was being calculated.  After some looking it was found that the distortion file used as an input into this routine was the one that was outputting V3/V2 (rather than V2/V3).  This was corrected in PR https://github.com/spacetelescope/jwreftools/pull/13.  

So this PR only has a small correction in the order of the filter offsets which does not appear to make a big difference in the output but should now be correct.

I did some brief testing of this code where I checked the detector to v2v3 transform using:
```
from jwst.datamodels import ImageModel
a = ImageModel('jw93065001002_02105_00001_mirimage_rate_assign_wcs.fits')
tt = a.meta.wcs.get_transform('detector', 'v2v3')
print(tt(945, 728))
```
The output of this was:
```
(-7.99312834932954, -2.000738074507566)
```
which is what was expected based on data on page 5 of MIRI-TN-00070-ATC_Imager_distortion_CDP_Issue_9.pdf.

This, along with https://github.com/spacetelescope/jwreftools/pull/13, fixes issue #164 