### PR TITLE
convert v2v3 to deg

### DIFF
--- a/jwst/assign_wcs/fgs.py
+++ b/jwst/assign_wcs/fgs.py
@@ -46,7 +46,7 @@ def imaging(input_model, reference_files):
     reference_files={'distortion': 'jwst_fgs_distortioon_0001.asdf'}
     """
     detector = cf.Frame2D(name='detector', axes_order=(0, 1), unit=(u.pix, u.pix))
-    v2v3 = cf.Frame2D(name='v2v3', axes_order=(0, 1), unit=(u.arcsec, u.arcsec))
+    v2v3 = cf.Frame2D(name='v2v3', axes_order=(0, 1), unit=(u.deg, u.deg))
     world = cf.CelestialFrame(name='world', reference_frame=coord.ICRS())
     # V2, V3 to sky
     tel2sky = pointing.v23tosky(input_model)
@@ -64,7 +64,7 @@ def imaging(input_model, reference_files):
 def imaging_distortion(input_model, reference_files):
     distortion = AsdfFile.open(reference_files['distortion']).tree['model']
     # Convert to arcsec
-    transform = distortion | models.Scale(60) & models.Scale(60)
+    transform = distortion | models.Scale(1/60) & models.Scale(1/60)
     return transform
 
 

--- a/jwst/assign_wcs/miri.py
+++ b/jwst/assign_wcs/miri.py
@@ -39,7 +39,7 @@ def imaging(input_model, reference_files):
 
     # Create the Frames
     detector = cf.Frame2D(name='detector', axes_order=(0, 1), unit=(u.pix, u.pix))
-    v2v3 = cf.Frame2D(name='v2v3', axes_order=(0, 1), unit=(u.arcsec, u.arcsec))
+    v2v3 = cf.Frame2D(name='v2v3', axes_order=(0, 1), unit=(u.deg, u.deg))
     world = cf.CelestialFrame(reference_frame=coord.ICRS(), name='world')
 
     # Create the transforms
@@ -89,7 +89,7 @@ def imaging_distortion(input_model, reference_files):
 
     # Now apply each of the models.  The Scale(60) converts from arc-minutes to arc-seconds.
     full_distortion = models.Shift(filter_offset['column_offset']) & models.Shift(
-        filter_offset['row_offset']) | distortion | models.Scale(60) & models.Scale(60)
+        filter_offset['row_offset']) | distortion | models.Scale(1/60) & models.Scale(1/60)
 
     full_distortion = full_distortion.rename('distortion')
 
@@ -155,7 +155,7 @@ def ifu(input_model, reference_files):
     xyan_spatial = cf.Frame2D(name='Xan_Yan_spatial', axes_order=(0, 1), unit=(u.arcmin, u.arcmin), axes_names=('v2', 'v3'))
     spec = cf.SpectralFrame(name='Xan_Yan_spectral', axes_order=(2,), unit=(u.micron,), axes_names=('lambda',))
     xyan = cf.CompositeFrame([xyan_spatial, spec], name='Xan_Yan')
-    v23_spatial = cf.Frame2D(name='V2_V3_spatial', axes_order=(0, 1), unit=(u.arcsec, u.arcsec), axes_names=('v2', 'v3'))
+    v23_spatial = cf.Frame2D(name='V2_V3_spatial', axes_order=(0, 1), unit=(u.deg, u.deg), axes_names=('v2', 'v3'))
     spec = cf.SpectralFrame(name='spectral', axes_order=(2,), unit=(u.micron,), axes_names=('lambda',))
     v2v3 = cf.CompositeFrame([v23_spatial, spec], name='v2v3')
     icrs = cf.CelestialFrame(name='icrs', reference_frame=coord.ICRS(),
@@ -165,7 +165,7 @@ def ifu(input_model, reference_files):
         "detector_to_alpha_beta")
     ab2xyan = (alpha_beta2XanYan(input_model, reference_files)).rename("alpha_beta_to_Xan_Yan")
     xyan2v23 = models.Identity(1) & (models.Shift(7.8) | models.Scale(-1)) & models.Identity(1) | \
-        models.Scale(60) & models.Scale(60) & models.Identity(1)
+        models.Scale(1/60) & models.Scale(1/60) & models.Identity(1)
     tel2sky = pointing.v23tosky(input_model) & models.Identity(1)
     pipeline = [(detector, det2alpha_beta),
                 (miri_focal, ab2xyan),

--- a/jwst/assign_wcs/nircam.py
+++ b/jwst/assign_wcs/nircam.py
@@ -30,7 +30,7 @@ def imaging(input_model, reference_files):
     reference_files={'distortion': 'test.asdf', 'filter_offsets': 'filter_offsets.asdf'}
     """
     detector = cf.Frame2D(name='detector', axes_order=(0, 1), unit=(u.pix, u.pix))
-    v2v3 = cf.Frame2D(name='v2v3', axes_order=(0, 1), unit=(u.arcsec, u.arcsec))
+    v2v3 = cf.Frame2D(name='v2v3', axes_order=(0, 1), unit=(u.deg, u.deg))
     world = cf.CelestialFrame(reference_frame=coord.ICRS(), name='world')
     distortion = imaging_distortion(input_model, reference_files)
     tel2sky = pointing.v23tosky(input_model)
@@ -43,7 +43,7 @@ def imaging(input_model, reference_files):
 def imaging_distortion(input_model, reference_files):
     distortion = AsdfFile.open(reference_files['distortion']).tree['model']
     # Convert to arcsec
-    transform = distortion | Scale(60) & Scale(60)
+    transform = distortion | Scale(1/60) & Scale(1/60)
     return transform
 
 

--- a/jwst/assign_wcs/niriss.py
+++ b/jwst/assign_wcs/niriss.py
@@ -120,7 +120,7 @@ def imaging(input_model, reference_files):
     reference_files={'distortion': 'jwst_niriss_distortioon_0001.asdf'}
     """
     detector = cf.Frame2D(name='detector', axes_order=(0, 1), unit=(u.pix, u.pix))
-    v2v3 = cf.Frame2D(name='v2v3', axes_order=(0, 1), unit=(u.arcsec, u.arcsec))
+    v2v3 = cf.Frame2D(name='v2v3', axes_order=(0, 1), unit=(u.deg, u.deg))
     world = cf.CelestialFrame(reference_frame=coord.ICRS(), name='world')
     distortion = imaging_distortion(input_model, reference_files)
     tel2sky = pointing.v23tosky(input_model)
@@ -133,7 +133,7 @@ def imaging(input_model, reference_files):
 def imaging_distortion(input_model, reference_files):
     distortion = AsdfFile.open(reference_files['distortion']).tree['model']
     # Convert to arcsec
-    transform = distortion | Scale(60) & Scale(60)
+    transform = distortion | Scale(1/60) & Scale(1/60)
     return transform
 
 

--- a/jwst/assign_wcs/nirspec.py
+++ b/jwst/assign_wcs/nirspec.py
@@ -884,7 +884,7 @@ def oteip_to_v23(reference_files):
     # meters as required by the pipeline but the desired output wavelength units is microns.
     # So we are going to Scale the spectral units by 1e6 (meters -> microns)
     # The spatial units are currently in deg. Convertin to arcsec.
-    oteip_to_xyan = fore2ote_mapping | (ote & Identity(1)) | (Scale(3600) & Scale(3600) & Scale(1e6))
+    oteip_to_xyan = fore2ote_mapping | (ote & Scale(1e6))
     # Add a shift for the aperture.
     oteip2v23 = oteip_to_xyan | Identity(1) & (Shift(468) | Scale(-1)) & Identity(1)
     return oteip2v23

--- a/jwst/assign_wcs/tests/test_wcs.py
+++ b/jwst/assign_wcs/tests/test_wcs.py
@@ -35,8 +35,8 @@ def test_v23_to_sky():
     v3_ref = -318.742464 / 3600 # in deg
     r0 = 37 # in deg
 
-    v2 = 210 * 3600   # in arcsec
-    v3 = -75 * 3600  # in arcsec
+    v2 = 210 # in deg
+    v3 = -75 # in deg
     expected_ra_dec = (107.12810484789563, -35.97940247128502) # in deg
     angles = [-v2_ref, v3_ref, -r0, -dec_ref, ra_ref]
     axes = "zyxyz"

--- a/jwst/transforms/models.py
+++ b/jwst/transforms/models.py
@@ -703,8 +703,6 @@ class V23ToSky(Rotation3D):
         return alpha, delta
 
     def evaluate(self, v2, v3, angles):
-        v2 /= 3600.
-        v3 /= 3600.
         x, y, z = self.spherical2cartesian(v2, v3)
         x1, y1, z1 = super(V23ToSky, self).evaluate(x, y, z, angles)
         return self.cartesian2spherical(x1, y1, z1)


### PR DESCRIPTION
Changed units in V2V3 to degrees.
The transform from V2V3 to sky and the inverse transform use the same class so having the same input units in V2V3 and on sky helps.