### PR TITLE
Removed target-acq keywords

### DIFF
--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -925,38 +925,6 @@ properties:
             title: Nominal pixel area in arcsec^2
             type: number
             fits_keyword: PIXAR_A2
-      target_acq:
-        title: Target acquisition files
-        type: object
-        properties:
-          tacqname:
-            title: target acquisition file name
-            type: string
-            fits_keyword: TACQNAME
-          refstrfl:
-            title: reference star file name
-            type: string
-            fits_keyword: REFSTRFL
-          tacqslit:
-            title: target acq illuminated slit image file name
-            type: string
-            fits_keyword: TACQSLIT
-          tacq1img:
-            title: first target acq image file name
-            type: string
-            fits_keyword: TACQ1IMG
-          tacq2img:
-            title: second target acq image file name
-            type: string
-            fits_keyword: TACQ2IMG
-          tacnfimg:
-            title: target acq confirmation image file name
-            type: string
-            fits_keyword: TACNFIMG
-          sccnfimg:
-            title: science confirmation image file name
-            type: string
-            fits_keyword: SCCNFIMG
       nircam_focus:
         title: NIRCam Focus Adjust Mechanism parameters
         type: object


### PR DESCRIPTION
Removed all keywords in the core schema block "target_acq". Fixes #377.