### PR TITLE
Added imaging TSO photometry step

### DIFF
--- a/jwst/tso_photometry/__init__.py
+++ b/jwst/tso_photometry/__init__.py
@@ -1,0 +1,3 @@
+from .tso_photometry_step import TSOPhotometryStep
+
+__version__ = '0.7'

--- a/jwst/tso_photometry/tso_photometry.py
+++ b/jwst/tso_photometry/tso_photometry.py
@@ -3,6 +3,7 @@ from collections import OrderedDict
 import numpy as np
 from astropy.table import QTable
 import astropy.units as u
+from astropy.time import Time, TimeDelta
 from photutils import aperture_photometry, CircularAperture, CircularAnnulus
 
 from ..datamodels import CubeModel
@@ -88,6 +89,15 @@ def tso_aperture_photometry(datamodel, xcenter, ycenter, radius, radius_inner,
     meta['photometry'] = info
 
     tbl = QTable(meta=meta)
+
+    dt = (datamodel.meta.exposure.group_time *
+          (datamodel.meta.exposure.ngroups + 1))
+    dt_arr = (np.arange(1, 1 + datamodel.meta.exposure.nints) *
+              dt - (dt / 2.))
+    int_dt = TimeDelta(dt_arr, format='sec')
+    int_times = (Time(datamodel.meta.exposure.start_time, format='mjd') +
+                 int_dt)
+    tbl['MJD'] = int_times.mjd
 
     tbl['aperture_sum'] = aperture_sum
     tbl['aperture_sum_err'] = aperture_sum_err

--- a/jwst/tso_photometry/tso_photometry.py
+++ b/jwst/tso_photometry/tso_photometry.py
@@ -1,0 +1,113 @@
+from collections import OrderedDict
+
+import numpy as np
+from astropy.table import QTable
+import astropy.units as u
+from photutils import aperture_photometry, CircularAperture, CircularAnnulus
+
+from ..datamodels import CubeModel
+
+
+def tso_aperture_photometry(datamodel, xcenter, ycenter, radius, radius_inner,
+                            radius_outer):
+    """
+    Create a photometric catalog for NIRCam TSO imaging observations.
+
+    Parameters
+    ----------
+    datamodel : `CubeModel`
+        The input `CubeModel` of a NIRCam TSO imaging observation.
+
+    xcenter, ycenter : float
+        The ``x`` and ``y`` center of the aperture.
+
+    radius : float
+        The radius (in pixels) of the circular aperture.
+
+    radius_inner, radius_outer : float
+        The inner and outer radii (in pixels) of the circular-annulus
+        aperture, used for local background estimation.
+
+    Returns
+    -------
+    catalog : `~astropy.table.QTable`
+        An astropy QTable (Quantity Table) containing the source
+        photometry.
+    """
+
+    if not isinstance(datamodel, CubeModel):
+        raise ValueError('The input data model must be a CubeModel.')
+
+    aper1 = CircularAperture((xcenter, ycenter), r=radius)
+    aper2 = CircularAnnulus((xcenter, ycenter), r_in=radius_inner,
+                            r_out=radius_outer)
+
+    nimg = datamodel.data.shape[0]
+    aperture_sum = []
+    aperture_sum_err = []
+    annulus_sum = []
+    annulus_sum_err = []
+
+    for i in np.arange(nimg):
+        tbl1 = aperture_photometry(datamodel.data[i, :, :], aper1,
+                                   error=datamodel.err[i, :, :])
+        tbl2 = aperture_photometry(datamodel.data[i, :, :], aper2,
+                                   error=datamodel.err[i, :, :])
+
+        aperture_sum.append(tbl1['aperture_sum'][0])
+        aperture_sum_err.append(tbl1['aperture_sum_err'][0])
+        annulus_sum.append(tbl2['aperture_sum'][0])
+        annulus_sum_err.append(tbl2['aperture_sum_err'][0])
+
+    # convert array of Quantities to Quantity arrays
+    aperture_sum = u.Quantity(aperture_sum)
+    aperture_sum_err = u.Quantity(aperture_sum_err)
+    annulus_sum = u.Quantity(annulus_sum)
+    annulus_sum_err = u.Quantity(annulus_sum_err)
+
+    # construct metadata for output table
+    meta = OrderedDict()
+    meta['instrument'] = datamodel.meta.instrument.name
+    meta['detector'] = datamodel.meta.instrument.detector
+    meta['channel'] = datamodel.meta.instrument.channel
+    meta['subarray'] = datamodel.meta.subarray.name
+    meta['filter'] = datamodel.meta.instrument.filter
+    meta['pupil'] = datamodel.meta.instrument.pupil
+
+    meta['target_name'] = datamodel.meta.target.catalog_name
+    meta['xcenter'] = xcenter
+    meta['ycenter'] = ycenter
+    ra_icrs, dec_icrs = datamodel.meta.wcs(xcenter, ycenter)
+    meta['ra_icrs'] = ra_icrs
+    meta['dec_icrs'] = dec_icrs
+
+    info = ('Circular aperture photometry, r={0} pixels. Background '
+            'estimated as the mean in a circular annulus with r_inner={1} '
+            'pixels and r_outer={2} pixels.'.format(radius, radius_inner,
+                                                    radius_outer))
+    meta['photometry'] = info
+
+    tbl = QTable(meta=meta)
+
+    tbl['aperture_sum'] = aperture_sum
+    tbl['aperture_sum_err'] = aperture_sum_err
+    tbl['annulus_sum'] = annulus_sum
+    tbl['annulus_sum_err'] = annulus_sum_err
+
+    annulus_mean = annulus_sum / aper2.area()
+    annulus_mean_err = annulus_sum_err / aper2.area()
+    tbl['annulus_mean'] = annulus_mean
+    tbl['annulus_mean_err'] = annulus_mean_err
+
+    aperture_bkg = annulus_mean * aper1.area()
+    aperture_bkg_err = annulus_mean_err * aper1.area()
+    tbl['aperture_bkg'] = aperture_bkg
+    tbl['aperture_bkg_err'] = aperture_bkg_err
+
+    net_aperture_sum = aperture_sum - aperture_bkg
+    net_aperture_sum_err = np.sqrt(aperture_sum_err ** 2 +
+                                   aperture_bkg_err ** 2)
+    tbl['net_aperture_sum'] = net_aperture_sum
+    tbl['net_aperture_sum_err'] = net_aperture_sum_err
+
+    return tbl

--- a/jwst/tso_photometry/tso_photometry.py
+++ b/jwst/tso_photometry/tso_photometry.py
@@ -82,11 +82,11 @@ def tso_aperture_photometry(datamodel, xcenter, ycenter, radius, radius_inner,
     meta['ra_icrs'] = ra_icrs
     meta['dec_icrs'] = dec_icrs
 
-    info = ('Circular aperture photometry, r={0} pixels. Background '
-            'estimated as the mean in a circular annulus with r_inner={1} '
-            'pixels and r_outer={2} pixels.'.format(radius, radius_inner,
-                                                    radius_outer))
-    meta['photometry'] = info
+    info = ('Photometry measured in a circular aperture of r={0} pixels. '
+            'Background calculated as the mean in a circular annulus with '
+            'r_inner={1} pixels and r_outer={2} pixels.'
+            .format(radius, radius_inner, radius_outer))
+    meta['apertures'] = info
 
     tbl = QTable(meta=meta)
 

--- a/jwst/tso_photometry/tso_photometry_step.py
+++ b/jwst/tso_photometry/tso_photometry_step.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+
+from ..stpipe import Step, cmdline
+from ..datamodels import DrizProductModel
+from . import source_catalog
+
+
+class TSOPhotometryStep(Step):
+    """
+    Perform circular aperture photometry on Time-Series (Imaging)
+    Observations (TSO).
+
+    Parameters
+    -----------
+    input : str or `DrizProductModel`
+        A FITS filename or an `DrizProductModel` of a single drizzled
+        image.  The input image is assumed to be background subtracted.
+    """
+
+    spec = """
+        catalog_format = string(default='ecsv')   # Catalog output file format
+        kernel_fwhm = float(default=2.0)    # Gaussian kernel FWHM in pixels
+        kernel_xsize = float(default=5)     # Kernel x size in pixels
+        kernel_ysize = float(default=5)     # Kernel y size in pixels
+        snr_threshold = float(default=3.0)  # SNR threshold above the bkg
+        npixels = float(default=5.0)        # min number of pixels in source
+        deblend = boolean(default=False)    # deblend sources?
+    """
+
+    def process(self, input):
+
+        catalog_format = self.catalog_format
+        kernel_fwhm = self.kernel_fwhm
+        kernel_xsize = self.kernel_xsize
+        kernel_ysize = self.kernel_ysize
+        snr_threshold = self.snr_threshold
+        npixels = self.npixels
+        deblend = self.deblend
+
+        with DrizProductModel(input) as model:
+            catalog = source_catalog.make_source_catalog(
+                model, kernel_fwhm, kernel_xsize, kernel_ysize, snr_threshold,
+                npixels, deblend=deblend)
+            self.log.info('Detected {0} sources'.format(len(catalog)))
+
+            catalog_filename = model.meta.filename.replace(
+                '.fits', '_cat.{0}'.format(catalog_format))
+            if catalog_format == 'ecsv':
+                fmt = 'ascii.ecsv'
+            elif catalog_format == 'fits':
+                # NOTE: The catalog must not contain any 'None' values.
+                #       FITS will also not clobber existing files.
+                fmt = 'fits'
+            else:
+                raise ValueError('catalog_format must be "ecsv" or "fits".')
+            catalog.write(catalog_filename, format=fmt)
+            self.log.info('Wrote source catalog: {0}'.
+                          format(catalog_filename))
+            model.meta.source_catalog.filename = catalog_filename
+
+        # because the is the last CALIMAGE3 step, nothing is returned
+        return
+
+
+if __name__ == '__main__':
+    cmdline.step_script(source_catalog_step)


### PR DESCRIPTION
This PR is the initial version of the imaging TSO photometry step.  A notebook of example usage with `/grp/jwst/ssb/bushouse/jwst_data/NIRCam/tsoimg/jw11001001001_01101_00001_NRCA1_calints.fits` can be found here:
https://gist.github.com/larrybradley/f8cbf29560e3d3768f62a98a7bfb7120

One piece of information that I'm still missing is the `(x, y)` position of the source in the image.  In this PR I've simply used the geometric center of the subarray.  However, that doesn't make sense for the `FULL` subarray mode because the center position is located in the `B` detector gaps.  Also, I noticed that the source in `jw11001001001_01101_00001_NRCA1_calints.fits` is centered at ~`(153, 161)`, which is not the center of the subarray.  I'll update the aperture position when we get more information about the actual source position for each subarray mode.

The are a few other peculiarities with `jw11001001001_01101_00001_NRCA1_calints.fits`.  It used the NIRCam `A1` detector with a `SUB320` subarray, but the NIRCam documentation (https://jwst-docs-stage.stsci.edu/display/JTI/NIRCam+Detector+Subarrays) states that TSO imaging uses the `B` detector and `SUB320` is not listed as a valid TSO subarray.

CC: @hbushouse, @stsci-hack

