### PR TITLE
crpix is 1-based

### DIFF
--- a/jwst/assign_wcs/pointing.py
+++ b/jwst/assign_wcs/pointing.py
@@ -127,15 +127,29 @@ def wcsinfo_from_model(input_model):
 
 def fitswcs_transform_from_model(wcsinfo):
     """
-    Create a fits wcs from a datamodel.meta.wcsinfo.
+    Create a WCS object using from datamodel.meta.wcsinfo.
+    Transforms assume 0-based coordinates.
+
+    Parameters
+    ----------
+    wcsinfo : dict-like
+        `~jwst.meta.wcsinfo`` structure.
+
+    Return
+    ------
+    transform : `~astropy.modeling.core.Model`
+        WCS forward transform - from pixel to world coordinates.
+
     """
     spatial_axes, spectral_axes = gwutils.get_axes(wcsinfo)
+    sp_axis = spectral_axes[0]
 
     transform = gwutils.make_fitswcs_transform(wcsinfo)
     if wcsinfo['WCSAXES'] == 3:
-        spectral_transform = astmodels.Shift(-wcsinfo['CRPIX'][spectral_axes[0]]) | \
-                           astmodels.Scale(wcsinfo['CDELT'][spectral_axes[0]]) | \
-                           astmodels.Shift(wcsinfo['CRVAL'][spectral_axes[0]])
+        # Subtract one from CRPIX which is 1-based.
+        spectral_transform = astmodels.Shift(-(wcsinfo['CRPIX'][sp_axis] - 1)) | \
+                           astmodels.Scale(wcsinfo['CDELT'][sp_axis]) | \
+                           astmodels.Shift(wcsinfo['CRVAL'][sp_axis])
         transform = transform & spectral_transform
 
     return transform


### PR DESCRIPTION
Coordnates are 0-based, while CRPIX are 1-based. Remove 1 from CRPIX before applying the transform.