### PR TITLE
Rework non-NIRSpec flat-field algorithms

### DIFF
--- a/jwst/flatfield/flat_field.py
+++ b/jwst/flatfield/flat_field.py
@@ -65,19 +65,19 @@ def do_correction(input_model, flat_model,
         if flat_suffix is not None:
             log.warning("The flat_suffix parameter is not implemented"
                         " for this mode; will be ignored.")
-        do_slit_flat_field(output_model, flat_model)
+        do_flat_field(output_model, flat_model)
         interpolated_flats = None
 
     return (output_model, interpolated_flats)
 
 #
-# These functions are for slit (i.e. not MSA) flat fielding.
+# These functions are for non-NIRSpec flat fielding.
 #
-def do_slit_flat_field(output_model, flat_model):
+def do_flat_field(output_model, flat_model):
     """
     Short Summary
     -------------
-    Apply flat-fielding for the slit (not MSA) mode, updating the output model.
+    Apply flat-fielding for non-NIRSpec modes, updating the output model.
 
     Parameters
     ----------
@@ -92,96 +92,35 @@ def do_slit_flat_field(output_model, flat_model):
     None
     """
 
-    log.debug("Flat field correction for multi-slit mode.")
+    log.debug("Flat field correction for non-NIRSpec modes.")
 
     any_updated = False # will set True if any flats applied
 
-    # Check for a single image in the flat model
-    if len(flat_model.slits) == 1 and flat_model.slits[0].name is None:
-        # Populate slit attributes that will be needed later
-        flat_model.slits[0].name = flat_model.meta.subarray.name
-        flat_model.slits[0].xstart = flat_model.meta.subarray.xstart
-        flat_model.slits[0].ystart = flat_model.meta.subarray.ystart
-        flat_model.slits[0].xsize = flat_model.meta.subarray.xsize
-        flat_model.slits[0].ysize = flat_model.meta.subarray.ysize
-
     # Apply flat to simple ImageModels
     if isinstance(output_model, datamodels.ImageModel):
-        flat = get_flat(output_model, flat_model)
-        if flat is not None:
-            apply_flat_field(output_model, flat)
-            any_updated = True
+        log.debug('Applying flat to ImageModel ...')
+        apply_flat_field(output_model, flat_model)
+        any_updated = True
 
     # Apply flat to MultiSlits
     elif isinstance(output_model, datamodels.MultiSlitModel):
 
-        # Retrieve and apply flat to each slit contained in the input
+        # Apply flat to each slit contained in the input
         for slit in output_model.slits:
-            log.info('Retrieving flat for slit %s' % (slit.name))
-            flat = get_flat(slit, flat_model)
-            if flat is not None:
-                apply_flat_field(slit, flat)
-                any_updated = True
+            log.debug('Applying flat to slit %s' % (slit.name))
+            apply_flat_field(slit, flat_model)
+            any_updated = True
 
     # Apply flat to multiple-integration dataset
     elif isinstance(output_model, datamodels.CubeModel):
-        sci_data = output_model.data
-        nints = sci_data.shape[0]   # number of integrations
-
-        #  Loop over integrations to flat field each
-        for integ in range(nints):
-            data_slice = sci_data[integ, :, :]
-
-            # Create model for integration's data, w/needed subarray metadata
-            integ_model = datamodels.ImageModel(data_slice)
-            integ_model.update(output_model)
-
-            log.info('Retrieving flat for integration %s' % (integ))
-            flat = get_flat(integ_model, flat_model)
-            if flat is not None:
-                apply_flat_field(integ_model, flat)
-                any_updated = True
+        log.debug('Applying flat to CubeModel')
+        apply_flat_field(output_model, flat_model)
+        any_updated = True
 
     if any_updated:
         output_model.meta.cal_step.flat_field = 'COMPLETE'
     else:
         output_model.meta.cal_step.flat_field = 'SKIPPED'
-
-
-def get_flat(slit, flat_model):
-    """
-    Short Summary
-    -------------
-    For a simple ImageModel, get the single flat. Otherwise (for the multislit
-    model), get the flat having the same name as the specified slit.
-
-    Parameters
-    ----------
-    slit: JWST data model
-        output data model
-
-    flat_model: JWST data model
-        data model containing flat-field
-
-    Returns
-    -------
-    flat: 2D array
-        flat field array for output model
-    """
-
-    if len(flat_model.slits) == 1:
-        return flat_model.slits[0]
-    else:
-        found_one = False
-        for flat in flat_model.slits:
-            if flat.name == slit.name:
-                log.info('Found matching flat %s' % (flat.name))
-                found_one = True
-                return flat
-
-        if not found_one:
-            log.error("Couldn't find matching flat-field for slit %s" % (slit.name))
-            return None
 
 
 def apply_flat_field(science, flat):
@@ -228,12 +167,23 @@ def apply_flat_field(science, flat):
     wh_dq = np.bitwise_and(flat_dq, dqflags.pixel['NO_FLAT_FIELD'])
     flat_data[wh_dq == dqflags.pixel['NO_FLAT_FIELD']] = 1.0
 
-    # Flatten data and error arrays
-    science.data /= flat_data
-    science.err /= flat_data
+    # For CubeModel science data, apply flat to each integration
+    if isinstance(science, datamodels.CubeModel):
+        for integ in range(science.data.shape[0]):
+            # Flatten data and error arrays
+            science.data[integ] /= flat_data
+            science.err[integ] /= flat_data
+            # Combine the science and flat DQ arrays
+            science.dq[integ] = np.bitwise_or(science.dq[integ], flat_dq)
 
-    # Combine the science and flat DQ arrays
-    science.dq = np.bitwise_or(science.dq, flat_dq)
+    else:
+
+        # Flatten data and error arrays
+        science.data /= flat_data
+        science.err /= flat_data
+
+        # Combine the science and flat DQ arrays
+        science.dq = np.bitwise_or(science.dq, flat_dq)
 
 
 def ref_matches_sci(ref_model, sci_model):
@@ -271,12 +221,16 @@ def ref_matches_sci(ref_model, sci_model):
 
     log.debug(' sci xstart=%d, xsize=%d', xstart, xsize)
     log.debug(' sci ystart=%d, ysize=%d', ystart, ysize)
-    log.debug(' ref xstart=%d, xsize=%d', ref_model.xstart, ref_model.xsize)
-    log.debug(' ref ystart=%d, ysize=%d', ref_model.ystart, ref_model.ysize)
+    log.debug(' ref xstart=%d, xsize=%d', ref_model.meta.subarray.xstart,
+              ref_model.meta.subarray.xsize)
+    log.debug(' ref ystart=%d, ysize=%d', ref_model.meta.subarray.ystart,
+              ref_model.meta.subarray.ysize)
 
     # See if they match the reference model subarray parameters
-    if (ref_model.xstart == xstart and ref_model.xsize == xsize and
-        ref_model.ystart == ystart and ref_model.ysize == ysize):
+    if (ref_model.meta.subarray.xstart == xstart and
+        ref_model.meta.subarray.xsize == xsize and
+        ref_model.meta.subarray.ystart == ystart and
+        ref_model.meta.subarray.ysize == ysize):
         return True
     else:
         return False

--- a/jwst/flatfield/flat_field_step.py
+++ b/jwst/flatfield/flat_field_step.py
@@ -82,16 +82,8 @@ class FlatFieldStep(Step):
             s_flat_model = datamodels.NirspecFlatModel(self.s_flat_filename)
             d_flat_model = datamodels.NirspecFlatModel(self.d_flat_filename)
         else:
-            # If datamodels.open() thinks it's a CubeModel, leave it as such
-            # (a multiple-integration dataset); otherwise, open it as a
-            # MultiSlitModel.
-            flat_model = datamodels.open(self.flat_filename)
-            if isinstance(flat_model, datamodels.CubeModel):
-                self.log.debug('Flatfield is a CubeModel')
-            else:
-                self.log.debug('Flatfield is an ImageModel or MultiSlitModel')
-                flat_model.close()
-                flat_model = datamodels.MultiSlitModel(self.flat_filename)
+            self.log.debug('Opening flat as FlatModel')
+            flat_model = datamodels.FlatModel(self.flat_filename)
             f_flat_model = None
             s_flat_model = None
             d_flat_model = None


### PR DESCRIPTION
These updates address several issues, including #187. Much of the entire structure of handling and applying flat-field to non-NIRSpec exposures has been updated to remove a lot of the old unnecessary infrastructure that was put in place over the past 1-2 years to handle special modes of NIRSpec data. These are no longer needed, because there is a completely separate routine now for all NIRSpec data.

Specifically, non-NIRSpec flat ref files will never be in the form of CubeModel's or MultiSlitModel's - they will always be simple image-like models and hence the flat ref file can be loaded into a FlatModel, which applies the dynamic DQ mapping to the ref file data (thus fixing #187). Not having to worry about Flats in the form of MultiSlitModel's allows for the removal of a lot of old infrastructure for populating slit-related metadata and making a simple flat ImageModel look like a MultiSlitModel.

Also rewrote the apply_flat_field function so that the looping over multiple integrations in the input science data is done there, rather than in a higher-level routine. The old approach was only applying the flat data to the science data SCI array, leaving out application to the ERR array and also not propagating the DQ values from the ref file to the science data. 