### PR TITLE
Revert "Moved wavelength unit conversion earlier"

### DIFF
--- a/jwst/assign_wcs/nirspec.py
+++ b/jwst/assign_wcs/nirspec.py
@@ -520,10 +520,6 @@ def gwa_to_ifuslit(slits, disperser, wrange, order, reference_files):
     ymax = .55
     agreq = AngleFromGratingEquation(disperser['groove_density'], order, name='alpha_from_greq')
     lgreq = WavelengthFromGratingEquation(disperser['groove_density'], order, name='lambda_from_greq')
-    # The wavelength units up to this point are
-    # meters as required by the pipeline but the desired output wavelength units is microns.
-    # So we are going to Scale the spectral units by 1e6 (meters -> microns)
-    lgreq = lgreq | Scale(1e6)
     collimator2gwa = collimator_to_gwa(reference_files, disperser)
     mask = mask_slit(ymin, ymax)
 
@@ -578,10 +574,6 @@ def gwa_to_slit(open_slits, disperser, wrange, order, reference_files):
     """
     agreq = AngleFromGratingEquation(disperser['groove_density'], order, name='alpha_from_greq')
     lgreq = WavelengthFromGratingEquation(disperser['groove_density'], order, name='lambda_from_greq')
-    # The wavelength units up to this point are
-    # meters as required by the pipeline but the desired output wavelength units is microns.
-    # So we are going to Scale the spectral units by 1e6 (meters -> microns)
-    lgreq = lgreq | Scale(1e6)
     collimator2gwa = collimator_to_gwa(reference_files, disperser)
 
     msa = AsdfFile.open(reference_files['msa'])
@@ -897,9 +889,11 @@ def oteip_to_v23(reference_files):
         ote = f.tree['model'].copy()
     fore2ote_mapping = Identity(3, name='fore2ote_mapping')
     fore2ote_mapping.inverse = Mapping((0, 1, 2, 2))
-    # Create the transform to v2/v3/lambda.
+    # Create the transform to v2/v3/lambda.  The wavelength units up to this point are
+    # meters as required by the pipeline but the desired output wavelength units is microns.
+    # So we are going to Scale the spectral units by 1e6 (meters -> microns)
     # The spatial units are currently in deg. Convertin to arcsec.
-    oteip_to_xyan = fore2ote_mapping | (ote & Scale(1))
+    oteip_to_xyan = fore2ote_mapping | (ote & Scale(1e6))
     # Add a shift for the aperture.
     oteip2v23 = oteip_to_xyan | Identity(1) & (Shift(468 / 3600) | Scale(-1)) & Identity(1)
     return oteip2v23

--- a/jwst/assign_wcs/tests/test_nirspec.py
+++ b/jwst/assign_wcs/tests/test_nirspec.py
@@ -180,10 +180,7 @@ def test_nirspec_ifu_against_esa():
     x = x + cor[0] + 1
     sca2world = w0.get_transform('sca', 'msa_frame')
     _, slit_y, lp = sca2world(x, y)
-
-    # Multiplying by 1e6 to convert the lam[cond] units from meters into microns as
-    # the lp output data is in microns.
-    assert_allclose(lp, lam[cond]*1e6, rtol=1e-4, atol=1e-4)
+    assert_allclose(lp, lam[cond], atol=10**-13)
     ref.close()
 
 '''


### PR DESCRIPTION
Reverts STScI-JWST/jwst#375

Conversion of wavelengths from meters to microns was moved ahead in the WCS pipeline to
cover the case when filter=OPAQUE and the pipeline stops before the filter wheel.
However, the NIRSpec transform through the filters is chromatic and expects the wavelength to be in meters.