### PR TITLE
Add offset transform to WCS for each slit in extract_2d MultiSlitModel

### DIFF
--- a/jwst/extract_2d/extract_2d.py
+++ b/jwst/extract_2d/extract_2d.py
@@ -7,7 +7,7 @@ import logging
 import copy
 import numpy as np
 from astropy.io import fits
-from astropy.modeling import models as astmodels
+from astropy.modeling.models import Shift
 from .. import datamodels
 from asdf import AsdfFile
 from ..assign_wcs import nirspec
@@ -39,6 +39,11 @@ def extract2d(input_model, which_subarray=None):
             slit_wcs = nirspec.nrs_wcs_set_input(input_model, slit.name)
             xlo, xhi = slit_wcs.domain[0]['lower'], slit_wcs.domain[0]['upper']
             ylo, yhi = slit_wcs.domain[1]['lower'], slit_wcs.domain[1]['upper']
+
+            # Add the slit offset to each slit WCS object
+            tr = slit_wcs.get_transform('detector', 'sca')
+            tr = tr | Shift(xlo) & Shift(ylo)
+            slit_wcs.set_transform('detector', 'sca', tr.rename('dms2sca'))
 
             log.info('Name of subarray extracted: %s', slit.name)
             log.info('Subarray x-extents are: %s %s', xlo, xhi)


### PR DESCRIPTION
@nden @philhodge This PR allows the wcs object to take as input native coordinates of the extracted 2-d slit array.

Before, to get world coordinates at position (x, y) in the slit:

`ra, dec, lambda = slit.meta.wcs(x + slit.xstart - 1, y + slit.ystart - 1)`

Now we simply can call the wcs object with native (zero-based) coordinates of the slit:

`ra, dec, lambda = slit.meta.wcs(x, y)`

and get the same result.  Now functions and methods that use the wcs object can work with the wcs object alone instead of having to work with the full datamodel and needing to read in `xstart` and `ystart`.  This change is made to allow the API of resample and other functions that use the wcs object to be much simpler.  Now the gwcs.WCS object is self-contained, fully describing the slit to which it is attached.

This will require small changes to code in [compute_world_coordinates.py](https://github.com/STScI-JWST/jwst/blob/master/jwst/assign_wcs/tools/nirspec/compute_world_coordinates.py) and any other code that uses the wcs object to compute world coordinates downstream of extract_2d.