### PR TITLE
Core schema update

### DIFF
--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -1298,7 +1298,7 @@ properties:
               name:
                 title: Spectral distortion reference file name
                 type: string
-                fits_keyword: R_SPDIST
+                fits_keyword: R_SPCWCS
           regions:
             title: Regions reference file information
             type: object


### PR DESCRIPTION
CRDS folks want the R_SPDIST keyword name for the SPECWCS reference file updated to conform (at least more closely) to the usual syntax for these keywords, so we're changing it to R_SPCWCS. Only the keyword name is changing; the data model attribute name (model.meta.ref_file.specwcs.name) is not changing, so hopefully no cal pipeline code updates are necessary to keep up with this change.