### PR TITLE
Moved wavelength unit conversion earlier -- corrected

### DIFF
--- a/jwst/assign_wcs/nirspec.py
+++ b/jwst/assign_wcs/nirspec.py
@@ -526,6 +526,12 @@ def gwa_to_ifuslit(slits, input_model, disperser, reference_files):
     agreq = angle_from_disperser(disperser, input_model)
     lgreq = wavelength_from_disperser(disperser, input_model)
 
+    # The wavelength units up to this point are
+    # meters as required by the pipeline but the desired output wavelength units is microns.
+    # So we are going to Scale the spectral units by 1e6 (meters -> microns)
+    if input_model.meta.instrument.filter == 'OPAQUE':
+        lgreq = lgreq | Scale(1e6)
+
     collimator2gwa = collimator_to_gwa(reference_files, disperser)
     mask = mask_slit(ymin, ymax)
 
@@ -586,6 +592,12 @@ def gwa_to_slit(open_slits, input_model, disperser, reference_files):
     agreq = angle_from_disperser(disperser, input_model)
     collimator2gwa = collimator_to_gwa(reference_files, disperser)
     lgreq = wavelength_from_disperser(disperser, input_model)
+
+    # The wavelength units up to this point are
+    # meters as required by the pipeline but the desired output wavelength units is microns.
+    # So we are going to Scale the spectral units by 1e6 (meters -> microns)
+    if input_model.meta.instrument.filter == 'OPAQUE':
+        lgreq = lgreq | Scale(1e6)
 
     msa = AsdfFile.open(reference_files['msa'])
     slit_models = []

--- a/jwst/assign_wcs/tests/test_nirspec.py
+++ b/jwst/assign_wcs/tests/test_nirspec.py
@@ -180,7 +180,10 @@ def test_nirspec_ifu_against_esa():
     x = x + cor[0] + 1
     sca2world = w0.get_transform('sca', 'msa_frame')
     _, slit_y, lp = sca2world(x, y)
-    assert_allclose(lp, lam[cond], atol=10**-13)
+
+    # Convert meters to microns for the second parameters as the
+    # first parameter will be in microns.
+    assert_allclose(lp, lam[cond]*1e6, rtol=1e-4, atol=1e-4)
     ref.close()
 
 '''


### PR DESCRIPTION
**_Note:_** This is in reference to #375 which was not implemented quite right.  So, this one should now be fixed. The main thing is the meter -> micron transform is applied at the MSA _only if_ the filter is OPAQUE otherwise it is applied at the OTE. 

@nden requested that I look into moving the wavelength unit conversion (meters -> microns) earlier in the assign_wcs piece of the pipeline as it was being missed by data with a filter="OPAQUE".  The meter -> micron was moved earlier and tested against a NIRSPEC IFU dataset.

Non-opaque version:

```
from datetime import datetime
from jwst.assign_wcs import nirspec
from jwst import datamodels
a = datamodels.ImageModel('jw00011001001_01120_00001_NRS1_rate_assign_wcs.fits')
a_wcs = nirspec.nrs_ifu_wcs(a)
w1 = a_wcs[0].get_transform('detector', 'v2v3')
x = int( (a_wcs[0].domain[0]['upper'] - a_wcs[0].domain[0]['lower']) / 2 + a_wcs[0].domain[0]['lower'])
y = int( (a_wcs[0].domain[1]['upper'] - a_wcs[0].domain[1]['lower']) / 2 + a_wcs[0].domain[1]['lower'])
print('{}, {} -> {}'.format(x, y, w1(x, y)))

In [17]: run -i runme.py
1170, 810 -> (0.08337280974877552, -468.00840926837924, 2.048868634635015)
```

Opaque version:

```
from datetime import datetime
from jwst.assign_wcs import nirspec
from jwst import datamodels
a = datamodels.ImageModel('jw00011001001_01120_00001_NRS1_rate_opaque_assign_wcs.fits')
a_wcs = nirspec.nrs_ifu_wcs(a)
w1 = a_wcs[0].get_transform('detector', 'v2v3')
x = int( (a_wcs[0].domain[0]['upper'] - a_wcs[0].domain[0]['lower']) / 2 + a_wcs[0].domain[0]['lower'])
y = int( (a_wcs[0].domain[1]['upper'] - a_wcs[0].domain[1]['lower']) / 2 + a_wcs[0].domain[1]['lower'])
print('{}, {} -> {}'.format(x, y, w1(x, y)))

In [17]: run -i runme.py
1170, 810 -> (0.08337280974877552, -468.00840926837924, 2.048868634635015)
```

The wavelength value, 2.049, was compared to the non-opaque version before the changes were made and is the same.  So this appears to be working. 