### PR TITLE
Update schema for necessary SIAF keywords

### DIFF
--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -826,7 +826,7 @@ properties:
           vparity:
             title: V2-V3 coordinate frame parity
             type: integer
-            default: 1.0
+            default: 1
             fits_keyword: VPARITY
           v3yangle:
             title: V3 position angle (deg)

--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -813,16 +813,6 @@ properties:
             title: default spectral order
             type: number
             fits_keyword: SPORDER
-          ra_ref:
-            title: Right ascension of the reference point (deg)
-            type: number
-            default: 0.0
-            fits_keyword: RA_REF
-          dec_ref:
-            title: Declination of the reference point (deg)
-            type: number
-            default: 0.0
-            fits_keyword: DEC_REF
           v2_ref:
             title: Telescope v2 coordinate of the reference point (arcsec)
             type: number
@@ -833,6 +823,26 @@ properties:
             type: number
             default: 0.0
             fits_keyword: V3_REF
+          vparity:
+            title: V2-V3 coordinate frame parity
+            type: integer
+            default: 1.0
+            fits_keyword: VPARITY
+          v3yangle:
+            title: V3 position angle (deg)
+            type: number
+            default: 0.0
+            fits_keyword: V3I_YANG
+          ra_ref:
+            title: Right ascension of the reference point (deg)
+            type: number
+            default: 0.0
+            fits_keyword: RA_REF
+          dec_ref:
+            title: Declination of the reference point (deg)
+            type: number
+            default: 0.0
+            fits_keyword: DEC_REF
           roll_ref:
             title: Telescope roll angle of V3 measured from North over East at the ref. point (deg)
             type: number

--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -824,12 +824,12 @@ properties:
             default: 0.0
             fits_keyword: V3_REF
           vparity:
-            title: V2-V3 coordinate frame parity
+            title: Relative sense of rotation between Ideal xy and V2V3
             type: integer
             default: 1
             fits_keyword: VPARITY
           v3yangle:
-            title: V3 position angle (deg)
+            title: Angle from V3 axis to Ideal y axis (deg)
             type: number
             default: 0.0
             fits_keyword: V3I_YANG


### PR DESCRIPTION
Two more values are needed from the SIAF to compute telescope pointing info. Those will be stored in two new header keywords VPARITY and V3I_YANG. Added these to the core schema. DP will be populating them from the SIAF entries, along with V2_REF and V3_REF.