### PR TITLE
Calspec2 updates for cube_build and extract_1d

### DIFF
--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -179,6 +179,9 @@ class DataModel(properties.ObjectNode):
         if isinstance(init, six.string_types):
             self.meta.filename = os.path.basename(init)
 
+        # store the data model type
+        self.meta.model_type = self.__class__.__name__
+
         if is_array:
             primary_array_name = self.get_primary_array_name()
             if primary_array_name is None:
@@ -244,6 +247,7 @@ class DataModel(properties.ObjectNode):
         self.meta.date = Time(datetime.datetime.now())
         self.meta.date.format = 'isot'
         self.meta.date = self.meta.date.value
+        self.meta.model_type = self.__class__.__name__
 
     def save(self, path, *args, **kwargs):
         """

--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -43,6 +43,10 @@ properties:
         title: Calibration software revision number
         type: string
         fits_keyword: CAL_SVN
+      model_type:
+        title: Type of data model
+        type: string
+        fits_keyword: DATAMODL
       telescope:
         title: Telescope used to acquire the data
         type: string

--- a/jwst/extract_1d/extract_1d_step.py
+++ b/jwst/extract_1d/extract_1d_step.py
@@ -25,13 +25,10 @@ class Extract1dStep(Step):
 
         # Open the input and figure out what type of model it is
         input_model = datamodels.open(input)
-        # begin xxx temporary ...
-        fd = fits.open(input)
-        data_model_from_header = fd[0].header.get("datamodl", "missing")
+        data_model_from_header = input_model.meta.model_type
         self.log.debug("data_model_from_header = %s",
                       data_model_from_header)
-        fd.close()
-        # ... end xxx temporary
+
         if data_model_from_header == "IFUCubeModel" and \
            not isinstance(input_model, datamodels.IFUCubeModel):
             self.log.debug("Close and reopen as an IFUCubeModel")

--- a/jwst/pipeline/calwebb_spec2.cfg
+++ b/jwst/pipeline/calwebb_spec2.cfg
@@ -11,4 +11,6 @@ save_bsub = False
       [[straylight]]
       [[fringe]]
       [[photom]]
+      [[cube_build]]
+      [[extract_1d]]
 

--- a/jwst/pipeline/calwebb_spec2.py
+++ b/jwst/pipeline/calwebb_spec2.py
@@ -14,8 +14,10 @@ from ..srctype import srctype_step
 from ..straylight import straylight_step
 from ..fringe import fringe_step
 from ..photom import photom_step
+from ..cube_build import cube_build_step
+from ..extract_1d import extract_1d_step
 
-__version__ = "2.0"
+__version__ = "3.0"
 
 # Define logging
 import logging
@@ -30,7 +32,8 @@ class Spec2Pipeline(Pipeline):
     Included steps are:
     assign_wcs, background subtraction, NIRSpec MSA imprint subtraction,
     NIRSpec MSA bad shutter flagging, 2-D subwindow extraction, flat field,
-    source type decision, straylight, fringe, and photom.
+    source type decision, straylight, fringe, photom, resample_spec,
+    cube_build, and extract_1d.
     """
 
     spec = """
@@ -47,7 +50,9 @@ class Spec2Pipeline(Pipeline):
                  'srctype': srctype_step.SourceTypeStep,
                  'straylight': straylight_step.StraylightStep,
                  'fringe': fringe_step.FringeStep,
-                 'photom': photom_step.PhotomStep
+                 'photom': photom_step.PhotomStep,
+                 'cube_build': cube_build_step.CubeBuildStep,
+                 'extract_1d': extract_1d_step.Extract1dStep
                 }
 
     # The main process method
@@ -118,7 +123,7 @@ class Spec2Pipeline(Pipeline):
             # Apply flux calibration
             input = self.photom(input)
 
-            # Save the calibrated exposure
+            # Record ASN pool and table names in output
             if input_table.poolname:
                 input.meta.asn.pool_name = input_table.poolname
                 input.meta.asn.table_name = input_table.filename
@@ -126,13 +131,61 @@ class Spec2Pipeline(Pipeline):
                 input.meta.asn.pool_name = ' '
                 input.meta.asn.table_name = ' '
 
+            # Save the calibrated exposure
             if isinstance(input, datamodels.CubeModel):
                 self.save_model(input, 'calints')
             else:
                 self.save_model(input, "cal")
-            log.info('Save calibrated product to %s' % input.meta.filename)
+            log.info('Saved calibrated product to %s' % input.meta.filename)
+
+            # Produce a resampled product, either via resample_spec for
+            # "regular" spectra or cube_build for IFU data. No resampled
+            # product is produced for time-series modes.
+            if input.meta.exposure.type in ['MIR_LRS-FIXEDSLIT',
+                'NRS_FIXEDSLIT', 'NRS_MSASPEC', 'NIS_WFSS', 'NRC_GRISM']:
+
+                # xxxx Remove the following 2 lines once resamp_spec is activated
+                log.warning('Skipping resample_spec for now ...')
+                x1d_input = input
+
+                # Call the resample_spec step
+                #resamp = self.resample_spec(input)
+
+                # Save the resampled product
+                #self.save_model(resamp, 's2d')
+                #log.info('Saved resampled product to %s' % resamp.meta.filename)
+
+                # Pass the resampled data to 1D extraction
+                #x1d_input = resamp.copy()
+                #resamp.close()
+
+            elif input.meta.exposure.type in ['MIR_MRS', 'NRS_IFU']:
+
+                # Call the cube_build step for IFU data
+                cube = self.cube_build(input)
+
+                # Save the cube product
+                self.save_model(cube, 's3d')
+                log.info('Saved IFU cube product to %s' % cube.meta.filename)
+
+                # Pass the cube along for input to 1D extraction
+                x1d_input = cube.copy()
+                cube.close()
+
+            else:
+                # Pass the unresampled cal product to 1D extraction
+                x1d_input = input
+
+            # Extract a 1D spectrum from the 2D/3D data
+            x1d_output = self.extract_1d(x1d_input)
+            x1d_input.close()
+
+            # Save the extracted spectrum
+            self.save_model(x1d_output, 'x1d')
+            log.info('Saved extracted spectrum to %s' % x1d_output.meta.filename)
 
             input.close()
+            x1d_output.close()
 
         # We're done
         log.info('... ending calwebb_spec2')


### PR DESCRIPTION
Several updates to move towards enabling everything that's needed for B7 calspec2 operations.

Updated the calwebb_spec2 pipeline module to include calls to cube_build and extract_1d, with a stubbed out entry for now for resamp_spec. This includes updates for saving the various products produced along the way.

Also updated the core schema and the model_base infrastructure to include a meta attribute that gives the datamodel type. The FITS keyword name is "DATAMODL" and the corresponding meta attribute is model.meta.model_type. It is populated when a model is created and is updated before saving a model to disk in case the meta data for the model got overwritten by the meta data of another model through use of the model.update method.

Finally, the extract_1d_step module was updated to no longer try to open the input directly using astropy.io.fits routines to read the DATAMODL keyword, because it's now available in the model meta data.