### PR TITLE
Updated documentation to remove reference to steps subtracting and ad…

### DIFF
--- a/docs/refpix/source/description.rst
+++ b/docs/refpix/source/description.rst
@@ -41,17 +41,17 @@ The algorithm for the NIR and MIR detectors is different.
 NIR Detector Data
 -----------------
 
-1) The data from most detectors will have been rotated and/or
+  1) The data from most detectors will have been rotated and/or
 flipped from their detector frame in order to give them the same orientation
 and parity in the telescope focal plane.  The first step is to transform
 them back to the detector frame so that all NIR and MIR detectors can be treated
 equivalently.
 
-2) Subtract the first group from each group within an integration.
+It is assumed that a superbias correction has been performed.
 
-For each integration, and for each group after the first:
+For each integration, and for each group:
 
-  3) Calculate the mean value in the top and bottom reference pixels.  The
+  2) Calculate the mean value in the top and bottom reference pixels.  The
 reference pixel means for each amplifier are calculated separately, and
 the top and bottom means are calculated separately.  Optionally, the user
 can choose to calculate the means of odd and even columns separately by using
@@ -61,13 +61,13 @@ there is a significant odd-even column effect in some datasets.  Bad pixels
 calculation of the mean.  The mean is calculated as a clipped mean with a
 3-sigma rejection threshold.
 
-  4) Average the top and bottom reference pixel mean values
+  3) Average the top and bottom reference pixel mean values
 
-  5) Subtract each mean from all pixels that the mean is representative
+  4) Subtract each mean from all pixels that the mean is representative
 of, i.e. by amplifier and using the odd mean for the odd pixels and even
 mean for even pixels if this option is selected.
 
-  6) If the ``--use_side_ref_pixels`` option is selected, use the reference
+  5) If the ``--use_side_ref_pixels`` option is selected, use the reference
 pixels up the side of the A and D amplifiers to calculate a smoothed
 reference pixel signal as a function of row.  A running median of height set
 by the runtime parameter ``side_smoothing_length`` (default value 11) is
@@ -76,9 +76,7 @@ reference signal is obtained by averaging the left and right signals.  A
 multiple of this signal (set by the runtime parameter ``side_gain``, which
 defaults to 1.0) is subtracted from the full group on a row-by-row basis.
 
-7) Add the first group of each integration back to each group.
-
-8) Transform the data back to the JWST focal plane, or DMS, frame.
+  6) Transform the data back to the JWST focal plane, or DMS, frame.
 
 MIR Detector Data
 -----------------

--- a/jwst/refpix/refpix_step.py
+++ b/jwst/refpix/refpix_step.py
@@ -42,6 +42,7 @@ class RefPixStep(Step):
                 irs2_model = datamodels.IRS2Model(self.irs2_name)
                 result = irs2_subtract_reference.correct_model(input_model,
                                                                irs2_model)
+                result.meta.cal_step.refpix = 'COMPLETE'
                 irs2_model.close()
             else:
                 self.log.info('use_side_ref_pixels = %s' %
@@ -53,13 +54,15 @@ class RefPixStep(Step):
                 self.log.info('side_gain = %f' % (self.side_gain,))
                 self.log.info('odd_even_rows = %s' % (self.odd_even_rows,))
                 result = reference_pixels.correct_model(input_model,
-                                                    self.odd_even_columns,
-                                                    self.use_side_ref_pixels,
-                                                    self.side_smoothing_length,
-                                                    self.side_gain,
-                                                    self.odd_even_rows)
-
-        result.meta.cal_step.refpix = 'COMPLETE'
+                                                        self.odd_even_columns,
+                                                        self.use_side_ref_pixels,
+                                                        self.side_smoothing_length,
+                                                        self.side_gain,
+                                                        self.odd_even_rows)
+                if input_model.meta.subarray.name == 'FULL':
+                    result.meta.cal_step.refpix = 'COMPLETE'
+                else:
+                    result.meta.cal_step.refpix = 'SKIPPED'
 
         return result
 


### PR DESCRIPTION
…ding

back the first group for NIR data.

Step now sets S_REFPIX to 'SKIPPED' for non-IRS2 subarray data.