### PR TITLE
Use model type from input file

### DIFF
--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -179,8 +179,9 @@ class DataModel(properties.ObjectNode):
         if isinstance(init, six.string_types):
             self.meta.filename = os.path.basename(init)
 
-        # store the data model type
-        self.meta.model_type = self.__class__.__name__
+        # store the data model type, if not already set
+        if self.meta.model_type is None:
+            self.meta.model_type = self.__class__.__name__
 
         if is_array:
             primary_array_name = self.get_primary_array_name()

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -180,8 +180,11 @@ class DataModel(properties.ObjectNode):
             self.meta.filename = os.path.basename(init)
 
         # store the data model type, if not already set
-        if self.meta.model_type is None:
-            self.meta.model_type = self.__class__.__name__
+        if hasattr(self.meta, 'model_type'):
+            if self.meta.model_type is None:
+                self.meta.model_type = self.__class__.__name__
+        else:
+            self.meta.model_type = None
 
         if is_array:
             primary_array_name = self.get_primary_array_name()

--- a/jwst/datamodels/util.py
+++ b/jwst/datamodels/util.py
@@ -51,6 +51,8 @@ def open(init=None, extensions=None, **kwargs):
 
     from . import model_base
 
+    model_type = None
+
     if init is None:
         return model_base.DataModel(None)
     # Send _asn.json files to ModelContainer; avoid shape "cleverness" below
@@ -85,7 +87,6 @@ def open(init=None, extensions=None, **kwargs):
                 "readable file object, or astropy.io.fits.HDUList")
 
         # Try to get the datamodel class name from the header
-        model_type = None
         try:
             model_type = hdulist[0].header['DATAMODL']
         except:


### PR DESCRIPTION
Updates to the handling of datamodel types. The initial version just stored the class name of the datamodel when saving a model to disk. These updates now add the capability to use that stored class name when reloading a file from disk into a datamodel, so that datamodels.open() returns a model of that type.

The approach isn't pretty, due to the need to know the full class path name, consisting of "jwst.datamodels.<module>.<class_name>" in order to be able to import it, but it works - for now. It uses a dictionary to find the module name that defines a given class, and then hardcodes the "jwst.datamodels" prefix to the full class path. The dict will need to be updated whenever someone adds a new datamodel or changes any class/module names.