### PR TITLE
Python3 compatibility

### DIFF
--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -40,7 +40,7 @@ def get_extract_parameters(refname, slitname, meta,
     with open(refname) as f:
         ref = json.load(f)
     for aper in ref['apertures']:
-        if aper.has_key('id') and aper['id'] != "dummy" and \
+        if 'id' in aper and aper['id'] != "dummy" and \
            (aper['id'] == slitname or aper['id'] == "ANY" or
             slitname == "ANY"):
             region_type = aper.get("region_type", "target")
@@ -714,8 +714,8 @@ def do_extract1d(input_model, refname, smoothing_length, bkg_order):
             nerror = np.ones_like(net)
             berror = np.ones_like(net)
             spec = datamodels.SpecModel()
-            otab = np.array(zip(wavelength, flux, fl_error, dq,
-                                net, nerror, background, berror),
+            otab = np.array(list(zip(wavelength, flux, fl_error, dq,
+                                net, nerror, background, berror)),
                             dtype=spec.spec_table.dtype)
             spec = datamodels.SpecModel(spec_table=otab)
             output_model.spec.append(spec)


### PR DESCRIPTION
The methods dict.has_key() and zip() changed in python3.  These updates allow the code to run under both python2.7 and python3+.  @philhodge 