### PR TITLE
Jump step bug fixes

### DIFF
--- a/jwst/dq_init/dq_init_step.py
+++ b/jwst/dq_init/dq_init_step.py
@@ -18,6 +18,18 @@ class DQInitStep(Step):
 
         with datamodels.open(input) as input_model:
 
+            # Check for consistency between keyword values and data shape
+            nints = input_model.data.shape[0]
+            ngroups = input_model.data.shape[1]
+            nints_kwd = input_model.meta.exposure.nints
+            ngroups_kwd = input_model.meta.exposure.ngroups
+            if nints != nints_kwd:
+                self.log.error("Keyword 'NINTS' value of '{0} does not match data array size of '{1}'".format(nints_kwd,nints))
+                raise ValueError("Bad data dimensions")
+            if ngroups != ngroups_kwd:
+                self.log.error("Keyword 'NGROUPS' value of '{0}' does not match data array size of '{1}'".format(ngroups_kwd,ngroups))
+                raise ValueError("Bad data dimensions")
+
             # Retreive the mask reference file name
             self.mask_filename = self.get_reference_file(input_model, 'mask')
             self.log.info('Using MASK reference file %s', self.mask_filename)

--- a/jwst/jump/jump.py
+++ b/jwst/jump/jump.py
@@ -79,7 +79,7 @@ def detect_jumps (input_model, gain_model, readnoise_model,
     if do_yint:
 
         # Set up the ramp time array for the y-intercept method
-        group_time = output_model.meta.exposure.group_integration_time
+        group_time = output_model.meta.exposure.group_time
         times = np.array([(k+1)*group_time for k in range(ngroups)])
         median_slopes /= group_time
 

--- a/jwst/jump/jump_step.py
+++ b/jwst/jump/jump_step.py
@@ -25,11 +25,17 @@ class JumpStep(Step):
 
         with datamodels.open(input) as input_model:
 
-            # Check for an input model with NGROUPS <=2
-            if input_model.meta.exposure.ngroups <= 2:
+            # Check for consistency between keyword values and data shape
+            ngroups = input_model.data.shape[1]
+            ngroups_kwd = input_model.meta.exposure.ngroups
+            if ngroups != ngroups_kwd:
+                self.log.error("Keyword 'NGROUPS' value of '{0}' does not match data array size of '{1}'".format(ngroups_kwd,ngroups))
+                raise ValueError("Bad data dimensions")
+
+            # Check for an input model with NGROUPS<=2
+            if ngroups <= 2:
                 self.log.warn('Can not apply jump detection when NGROUPS<=2;')
                 self.log.warn('Jump step will be skipped')
-
                 result = input_model.copy()
                 result.meta.cal_step.jump = 'SKIPPED'
                 return result


### PR DESCRIPTION
Updated the jump step to address two bugs, as documented in #438 and #445.

Changed the reference to "group_integration_time" to "group_time", which is the proper name as currently defined in the core schema.

Added checks to see if the ngroups keyword value is consistent with the actual data array dimensions. If not, throw an error.

Added similar checks for the values of nints and ngroups to the dq_init step, not because it relies on them, but because it's usually the first step in any pipeline processing and hence any problems with the data dimensions will be caught early.