### PR TITLE
Rework datamodel type dictionary

### DIFF
--- a/jwst/datamodels/__init__.py
+++ b/jwst/datamodels/__init__.py
@@ -100,6 +100,10 @@ __all__ = [
     'RampFitOutputModel', 'ReadnoiseModel', 'ResetModel', 'RSCDModel',
     'SaturationModel', 'SpecModel', 'StrayLightModel']
 
+_all_models = __all__[1:]
+_local_dict = dict(locals())
+_defined_models = { k: _local_dict[k] for k in _all_models }
+
 
 '''
 def test(verbose=False) :


### PR DESCRIPTION
Moved population of the datamodel type dictionary to __init__.py, which ensures that all defined model types are included in the dictionary and greatly simplifies the use of it in the util.py open function. When open is called and the specified model_type exists in the dictionary, a new class of that type is returned. If the specified model_type doesn't exist in the dictionary, it falls back to trying to figure out the type using the old logic based on data array shape, etc.