### PR TITLE
Split datamodels.util.open into several functions

### DIFF
--- a/jwst/datamodels/__init__.py
+++ b/jwst/datamodels/__init__.py
@@ -105,7 +105,6 @@ _all_models = __all__[1:]
 _local_dict = dict(locals())
 _defined_models = { k: _local_dict[k] for k in _all_models }
 
-
 '''
 def test(verbose=False) :
     import nose

--- a/jwst/datamodels/util.py
+++ b/jwst/datamodels/util.py
@@ -54,6 +54,9 @@ def open(init=None, extensions=None, **kwargs):
 
     model_type = None
 
+    # Get three special cases for opening a model out of the way
+    # all three cases return a model if they match
+    
     if init is None:
         return model_base.DataModel(None)
     # Send _asn.json files to ModelContainer; avoid shape "cleverness" below
@@ -70,7 +73,9 @@ def open(init=None, extensions=None, **kwargs):
     elif isinstance(init, model_base.DataModel):
         # Copy the object so it knows not to close here
         return init.__class__(init)
-    elif isinstance(init, tuple):
+    
+    # Get the shape from the input argument where possible
+    if isinstance(init, tuple):
         for item in init:
             if not isinstance(item, int):
                 raise ValueError("shape must be a tuple of ints")
@@ -78,24 +83,69 @@ def open(init=None, extensions=None, **kwargs):
     elif isinstance(init, np.ndarray):
         shape = init.shape
     else:
-        if isinstance(init, (six.text_type, bytes)) or hasattr(init, "read"):
-            hdulist = fits.open(init)
-        elif isinstance(init, fits.HDUList):
-            hdulist = init
-        else:
-            raise TypeError(
-                "init must be None, shape tuple, file path, "
-                "readable file object, or astropy.io.fits.HDUList")
-
-        # Try to get the datamodel class name from the header
-        try:
-            model_type = hdulist[0].header['DATAMODL']
-        except:
-            pass
-
-        # Try to get the data shape, to be used later to try to figure
-        # out the datamodel type
         shape = ()
+
+    # Get the list of hdus where possible
+    if isinstance(init, (six.text_type, bytes)) or hasattr(init, "read"):
+        hdulist = fits.open(init)
+    elif isinstance(init, fits.HDUList):
+        hdulist = init
+    else:
+        hdulist = {}
+        
+    # First try to get the class name from the primary header
+    if hdulist:
+        # Can also return None if no header keyword
+        new_class = _class_from_model_type(hdulist)
+    else:
+        new_class = None
+
+    # Get the class name from the shape and other header keywords
+    if new_class is None:
+        new_class = _class_from_shape(hdulist, shape)
+
+    # Throw an error if these attempts were unsuccessful
+    if new_class is None:
+        raise TypeError("Can't determine datamodel class from argument to open")
+        
+    # Log a message about how the model was opened
+    if isinstance(init, (six.text_type, bytes)):
+        log.debug('Opening {0} as {1}'.format(basename(init), new_class))
+    else:
+        log.debug('Opening as {0}'.format(new_class))
+
+    # Actually open the model
+    model = new_class(init, extensions=extensions, **kwargs)
+    return model
+
+
+def _class_from_model_type(hdulist):
+    """
+    Get the model type from the primary header, lookup to get class
+    """
+    from . import _defined_models as defined_models
+
+    try:
+        primary = hdulist[0]
+    except KeyError:
+        model_type = None
+    else:
+        model_type = primary.header.get('DATAMODL')
+
+    if model_type is None:
+        new_class = None
+    else:
+        new_class = defined_models.get(model_type)
+
+    return new_class
+
+
+def _class_from_shape(hdulist, shape):
+    """
+    Get the class name from the shape and other header keywords
+    """
+    # If we do not have it, determine the shape from the science hdu
+    if len(shape) == 0:
         try:
             hdu = hdulist[(fits_header_name('SCI'), 1)]
         except KeyError:
@@ -104,21 +154,10 @@ def open(init=None, extensions=None, **kwargs):
             if hasattr(hdu, 'shape'):
                 shape = hdu.shape
 
-    # If the model_type has been given, return that type
-    if model_type is not None:
-        if model_type in defined_models:
-            new_class = defined_models[model_type]
-            if isinstance(init, (six.text_type, bytes)):
-                log.debug('Opening {0} as {1}'.format(basename(init), new_class))
-            else:
-                log.debug('Opening as {0}'.format(new_class))
-            return new_class(init, extensions=extensions, **kwargs)
-        else:
-            log.warning("Unknown datamodel type '{0}'".format(model_type))
-
     # Try to figure out which type to return, otherwise, just return a
     # new instance of the requested class
     if len(shape) == 0:
+        from . import model_base
         new_class = model_base.DataModel
     elif len(shape) == 4:
         # It's a RampModel, MIRIRampModel, or QuadModel
@@ -156,13 +195,9 @@ def open(init=None, extensions=None, **kwargs):
             from . import multislit
             new_class = multislit.MultiSlitModel
     else:
-        raise ValueError("Don't have a DataModel class to match the shape")
-
-    if isinstance(init, (six.text_type, bytes)):
-        log.debug('Opening {0} as {1}'.format(basename(init), new_class))
-    else:
-        log.debug('Opening as {0}'.format(new_class))
-    return new_class(init, extensions=extensions, **kwargs)
+        new_class = None
+        
+    return new_class
 
 
 def can_broadcast(a, b):


### PR DESCRIPTION
The util.open function in datamodels tries to determine the best datamodels class to use when opening an image. The code has always been complex and recently has grown more complex when new code to read the class name from a header keyword was added. This change splits off two new functions, _class_from_model_type and _class_from_shape which encapsulate the code that determines the datamodels class used to open an image from a primary header keyword and from the image shape, respectively.