### PR TITLE
Include metadata in MultiProduct model

### DIFF
--- a/jwst/datamodels/schemas/multiproduct.schema.yaml
+++ b/jwst/datamodels/schemas/multiproduct.schema.yaml
@@ -26,4 +26,88 @@ allOf:
             datatype: int32
           relsens:
             $ref: relsens.schema.yaml
+          name:
+            title: Name of the slit
+            type: string
+            fits_keyword: SLTNAME
+            fits_hdu: SCI
+          xstart:
+            title: Starting pixel in x direction
+            type: integer
+            default: 1
+            fits_keyword: SLTSTRT1
+            fits_hdu: SCI
+          xsize:
+            title: Number of pixels in x direction
+            type: integer
+            default: 0
+            fits_keyword: SLTSIZE1
+            fits_hdu: SCI
+          ystart:
+            title: Starting pixel in y direction
+            type: integer
+            default: 1
+            fits_keyword: SLTSTRT2
+            fits_hdu: SCI
+          ysize:
+            title: Number of pixels in y direction
+            type: integer
+            default: 0
+            fits_keyword: SLTSIZE2
+            fits_hdu: SCI
+          slitlet_id:
+            title: Slitlet ID
+            type: integer
+            default: 0
+            fits_keyword: SLITID
+            fits_hdu: SCI
+          source_id:
+            title: Source ID
+            type: integer
+            default: 0
+            fits_keyword: SOURCEID
+            fits_hdu: SCI
+          source_name:
+            title: Source name
+            type: string
+            fits_keyword: SRCNAME
+            fits_hdu: SCI
+          source_alias:
+            title: Source alias
+            type: string
+            fits_keyword: SRCALIAS
+            fits_hdu: SCI
+          catalog_id:
+            title: Catalog ID
+            type: string
+            fits_keyword: CATLOGID
+            fits_hdu: SCI
+          stellarity:
+            title: Source stellarity
+            type: number
+            fits_keyword: STLARITY
+            fits_hdu: SCI
+          source_type:
+            title: Source type (point/extended)
+            type: string
+            fits_keyword: SRCTYPE
+            fits_hdu: SCI
+          source_xpos:
+            title: Source position in slit (x-axis)
+            type: number
+            default: 0.0
+            fits_keyword: SRCXPOS
+            fits_hdu: SCI
+          source_ypos:
+            title: Source position in slit (y-axis)
+            type: number
+            default: 0.0
+            fits_keyword: SRCYPOS
+            fits_hdu: SCI
+          nshutters:
+            title: Number of open shutters
+            type: integer
+            default: 0
+            fits_keyword: NSHUT
+            fits_hdu: SCI
 $schema: http://stsci.edu/schemas/fits-schema/fits-schema


### PR DESCRIPTION
Updated the datamodels/schemas/multiproduct.schema.yaml file to contain the same list of meta data definitions as the MultiSlitModel, so that those values can then be copied over from a MultiSlitModel to a MultiProductModel.