### PR TITLE
Photom bug fix and wavelength updates

### DIFF
--- a/jwst/photom/photom.py
+++ b/jwst/photom/photom.py
@@ -93,7 +93,7 @@ class DataSet(object):
 
         # Handle fixed-slit exposures separately
         if (isinstance(self.input, datamodels.MultiSlitModel) and
-            self.exptype == 'NRS_FIXEDSLIT'):
+            self.exptype in ['NRS_FIXEDSLIT', 'NRS_BRIGHTOBJ']):
 
             # We have to find and attach a separate set of flux cal
             # data for each of the fixed slits in the input
@@ -424,6 +424,12 @@ class DataSet(object):
             waves = tabdata['wavelength'][:nelem]
             relresps = tabdata['relresponse'][:nelem]
 
+            # Convert wavelengths from meters to microns, if necessary
+            MICRONS_100 = 1.e-4         # 100 microns, in meters
+            if waves.max() > 0. and waves.max() < MICRONS_100:
+                waves *= 1.e+6
+            wl_unit = 'microns'
+                
             # Set the relative sensitivity table for the correct Model type
             if isinstance(self.input, datamodels.MultiSlitModel):
                 otab = np.array(list(zip(waves, relresps)),
@@ -535,7 +541,7 @@ class DataSet(object):
             conv_factor = self.calc_niriss(ftab)
 
         if self.instrument == 'NIRSPEC':
-            if self.exptype == 'NRS_FIXEDSLIT':
+            if self.exptype in ['NRS_FIXEDSLIT', 'NRS_BRIGHTOBJ']:
                 ftab = datamodels.NirspecFSPhotomModel(photom_fname)
             else:
                 ftab = datamodels.NirspecPhotomModel(photom_fname)


### PR DESCRIPTION
Two updates to the photom step code.

1) Treat NRS_BRIGHTOBJ exposures the same as NRS_FIXEDSLIT. Previously it was defaulting to treating them like IFU and MSA exposures, which uses a slightly different photom ref table format.

2) Check the wavelength array read from the photom reference file and convert the values from meters to microns, when necessary. Eventually I want to find a way to then set the TUNIT keyword for the wavelength column in the output RELSENS extension, but can't seem to do that right now when creating the RELSENS data table from scratch.