### PR TITLE
fix nircam v2v3 units

### DIFF
--- a/jwst/assign_wcs/miri.py
+++ b/jwst/assign_wcs/miri.py
@@ -89,7 +89,7 @@ def imaging_distortion(input_model, reference_files):
     distortion = AsdfFile.open(reference_files['distortion']).tree['model']
     filter_offset = AsdfFile.open(reference_files['filteroffset']).tree[input_model.meta.instrument.filter]
 
-    # Now apply each of the models.  The Scale(60) converts from arc-minutes to arc-seconds.
+    # Now apply each of the models.  The Scale(60) converts from arc-minutes to deg.
     full_distortion = models.Shift(filter_offset['column_offset']) & models.Shift(
         filter_offset['row_offset']) | distortion | models.Scale(1/60) & models.Scale(1/60)
 

--- a/jwst/assign_wcs/nircam.py
+++ b/jwst/assign_wcs/nircam.py
@@ -42,8 +42,8 @@ def imaging(input_model, reference_files):
 
 def imaging_distortion(input_model, reference_files):
     distortion = AsdfFile.open(reference_files['distortion']).tree['model']
-    # Convert to arcsec
-    transform = distortion | Scale(1/60) & Scale(1/60)
+    # Convert to deg - output of distortion models is in arcsec.
+    transform = distortion | Scale(1/3600) & Scale(1/3600)
     return transform
 
 


### PR DESCRIPTION
New distortion models produce output in arcsec. All V2V3 data should be in deg.