### PR TITLE
Add TARGID keyword to core schema

### DIFF
--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -205,6 +205,10 @@ properties:
             title: Type of target (fixed, moving, generic)
             type: string
             fits_keyword: TARGTYPE
+          id:
+            title: Target id used in PPS DB queries
+            type: string
+            fits_keyword: TARGID
           ra:
             title: Target RA at mid time of exposure
             type: number


### PR DESCRIPTION
SDP needs to add this keyword to the FITS headers, so adding it to our schema too.