### PR TITLE
Update calwebb_spec2 to abort when assign_wcs is skipped

### DIFF
--- a/jwst/pipeline/calwebb_spec2.py
+++ b/jwst/pipeline/calwebb_spec2.py
@@ -75,6 +75,14 @@ class Spec2Pipeline(Pipeline):
             # Apply WCS info
             input = self.assign_wcs(input)
 
+            # If assign_wcs was skipped, abort the rest of processing,
+            # because so many downstream steps depend on the WCS
+            if input.meta.cal_step.assign_wcs == 'SKIPPED':
+                log.error('Assign_wcs processing was skipped')
+                log.error('Aborting remaining processing for this exposure')
+                log.error('No output product will be created')
+                continue
+
             # Do background processing
             if len(member['bkgexps']) > 0:
 


### PR DESCRIPTION
Some NIRSpec filter+grating combinations result in no useable data falling on the detector (usually NRS2), in which case assign_wcs will skip its processing and return. This update to the calwebb_spec2 pipeline checks to see if assign_wcs was skipped and aborts all remaining processing for the exposure, because so many of the downstream steps depend on having valid and useful WCS information. It's easier to abort here in the pipeline rather than having each step check to see if the WCS is valid.