### PR TITLE
Fall off detector

### DIFF
--- a/jwst/assign_wcs/assign_wcs.py
+++ b/jwst/assign_wcs/assign_wcs.py
@@ -32,13 +32,13 @@ def load_wcs(input_model, reference_files={}):
     # Make the copy after the WCS pipeline is created in order to pass updates to the model.
     if pipeline is None:
         input_model.meta.cal_step.assign_wcs = 'SKIPPED'
-        log.info("SKIPPED assign_wcs")
+        log.warning("SKIPPED assign_wcs")
         return input_model
     else:
         output_model = input_model.copy()
         wcs = WCS(pipeline)
         output_model.meta.wcs = wcs
         output_model.meta.cal_step.assign_wcs = 'COMPLETE'
-        log.info("COMPLETE assign_wcs")
+        log.info("COMPLETED assign_wcs")
     return output_model
 

--- a/jwst/assign_wcs/assign_wcs.py
+++ b/jwst/assign_wcs/assign_wcs.py
@@ -30,14 +30,15 @@ def load_wcs(input_model, reference_files={}):
     pipeline = mod.create_pipeline(input_model, reference_files)
     # Initialize the output model as a copy of the input
     # Make the copy after the WCS pipeline is created in order to pass updates to the model.
-    output_model = input_model.copy()
     if pipeline is None:
-        output_model.meta.cal_step.assign_wcs = 'SKIPPED'
+        input_model.meta.cal_step.assign_wcs = 'SKIPPED'
+        log.info("SKIPPED assign_wcs")
+        return input_model
     else:
+        output_model = input_model.copy()
         wcs = WCS(pipeline)
-        #if output_model.meta.exposure.type.lower() in ['nrs_fixedslit', 'nrs_msaspec']:
-            #record_open_slits(wcs)
         output_model.meta.wcs = wcs
         output_model.meta.cal_step.assign_wcs = 'COMPLETE'
+        log.info("COMPLETE assign_wcs")
     return output_model
 

--- a/jwst/assign_wcs/nirspec.py
+++ b/jwst/assign_wcs/nirspec.py
@@ -42,8 +42,9 @@ def create_pipeline(input_model, reference_files):
     """
     exp_type = input_model.meta.exposure.type.lower()
     pipeline = exp_type2transform[exp_type](input_model, reference_files)
-    log.info("Creating a NIRSPEC {0} pipeline with references {1}".format(
-        exp_type, reference_files))
+    if pipeline:
+        log.info("Created a NIRSPEC {0} pipeline with references {1}".format(
+                exp_type, reference_files))
     return pipeline
 
 
@@ -120,6 +121,12 @@ def ifu(input_model, reference_files):
     """
     IFU pipeline
     """
+    detector = input_model.meta.instrument.detector
+    grating = input_model.meta.instrument.grating
+    if detector == "NRS2" and grating.endswith('M'):
+        log.critical("No IFU slices fall on detector {0}".format(detector))
+        return None
+
     slits = np.arange(30)
     # Get the corrected disperser model
     disperser = get_disperser(input_model, reference_files['disperser'])
@@ -194,6 +201,8 @@ def slits_wcs(input_model, reference_files):
 
     """
     open_slits_id = get_open_slits(input_model, reference_files)
+    if not open_slits_id:
+        return None
     n_slits = len(open_slits_id)
     log.info("Computing WCS for {0} open slitlets".format(n_slits))
 
@@ -255,17 +264,7 @@ def slits_wcs(input_model, reference_files):
 def get_open_slits(input_model, reference_files=None):
     exp_type = input_model.meta.exposure.type.lower()
     if exp_type == "nrs_msaspec":
-        msa_config = input_model.meta.instrument.msa_configuration_file
-        if msa_config is None:
-            message = "MSA metadata file is not available (keyword MSAMETFL)."
-            log.critical(message)
-            raise KeyError(message)
-        msa_metadata_id = input_model.meta.instrument.msa_metadata_id
-        if msa_metadata_id is None:
-            message = "MSA metadata ID is not available (keyword MSAMETID)."
-            log.critical(message)
-            raise KeyError(message)
-        slits = get_open_msa_slits(msa_config, msa_metadata_id)
+        slits = get_open_msa_slits(input_model, reference_files)
     elif exp_type == "nrs_fixedslit":
         slits = get_open_fixed_slits(input_model, reference_files)
     elif exp_type == "nrs_brightobj":
@@ -275,9 +274,7 @@ def get_open_slits(input_model, reference_files=None):
     else:
         raise ValueError("EXP_TYPE {0} is not supported".format(exp_type.upper()))
     if not slits:
-        message = "There are no open slits in this file."
-        log.critical(message)
-        raise ValueError(message)
+        log.critical("No open slits fall on detector {0}.".format(input_model.meta.instrument.detector))
     return slits
 
 
@@ -303,19 +300,15 @@ def get_open_fixed_slits(input_model, reference_files=None):
     elif  subarray == "S200B1":
         slits.append(s2b1)
     else:
-        slits.extend([s2a1, s2a2, s4a1, s16a1])
-        if input_model.meta.instrument.detector == 'NRS1':
-            if input_model.meta.instrument.filter == 'F070LP' and \
-                    input_model.meta.instrument.grating == 'G140H':
-                slits.append(s2b1)
-        elif input_model.meta.instrument.detector == 'NRS2':
-            slits.append(s2b1)
-    if reference_files is not None:
-        slits = validate_open_slits(input_model, reference_files)
+        slits.extend([s2a1, s2a2, s4a1, s16a1, s2b1])
+        if reference_files is not None:
+            slits = validate_open_slits(input_model, slits, reference_files)
+        log.info("Slits falling on detector {0}:".format(input_model.meta.instrument.detector))
+        log.info("{0}".format(slits))
     return slits
 
 
-def get_open_msa_slits(msa_file, msa_metadata_id):
+def get_open_msa_slits(input_model, reference_files):
     """
     Computes (ymin, ymax) of open slitlets.
 
@@ -351,12 +344,20 @@ def get_open_msa_slits(msa_file, msa_metadata_id):
         ("name", "shutter_id", "xcen", "ycen", "ymin", "ymax", "quadrant", "source_id", "nshutters")
 
     """
-
+    msa_config = input_model.meta.instrument.msa_configuration_file                                 
+    if msa_config is None:                                                                          
+        message = "MSA metadata file is not available (keyword MSAMETFL)."                          
+        log.critical(message)                                                                       
+        raise KeyError(message)                                                                     
+    msa_metadata_id = input_model.meta.instrument.msa_metadata_id                                   
+    if msa_metadata_id is None:                                                                     
+        message = "MSA metadata ID is not available (keyword MSAMETID)."                            
+        log.critical(message)      
     slitlets = []
 
     # If they passed in a string then we shall assume it is the filename
     # of the configuration file.
-    with fits.open(msa_file) as msa_file:
+    with fits.open(msa_config) as msa_file:
         # Get the configuration header from teh _msa.fits file.  The EXTNAME should be 'SHUTTER_INFO'
         msa_conf = msa_file[('SHUTTER_INFO', 1)]
         msa_source = msa_file[("SOURCE_INFO", 1)].data
@@ -431,7 +432,7 @@ def get_open_msa_slits(msa_file, msa_metadata_id):
             slitlets.append(Slit(slitlet_id, shutter_id, xcen, ycen, ymin, ymax,
                                  quadrant, source_id, nshutters, source_name, source_alias,
                                  catalog_id, stellarity, source_xpos, source_ypos))
-
+    slitlets = validate_open_slits(input_model, slitlets, reference_files)
     return slitlets
 
 
@@ -1149,8 +1150,8 @@ def nrs_wcs_set_input(input_model, slit_name, wavelength_range=None):
     slit_wcs.domain = domain
     return slit_wcs
 
-### todo
-def validate_open_slits(input_model, reference_files):
+
+def validate_open_slits(input_model, open_slits, reference_files):
     """
     For each slit computes the transform from the slit to the detector.
 
@@ -1165,6 +1166,7 @@ def validate_open_slits(input_model, reference_files):
         A dictionary with the slit to detector transform for each slit,
         {slit_id: astropy.modeling.Model}
     """
+    
     def _is_valid_slit(domain):
         xlow, xhigh = domain[0]['lower'], domain[0]['upper']
         ylow, yhigh = domain[1]['lower'], domain[1]['upper']
@@ -1200,7 +1202,6 @@ def validate_open_slits(input_model, reference_files):
     msa = AsdfFile.open(reference_files['msa'])
     col2det = collimator2gwa & Identity(1) | Mapping((3, 0, 1, 2)) | agreq | \
             gwa2det | det2dms
-    open_slits = get_open_slits(input_model)
     for quadrant in range(1, 6):
         slits_in_quadrant = [s for s in open_slits if s.quadrant==quadrant]
         if any(slits_in_quadrant):
@@ -1220,6 +1221,7 @@ def validate_open_slits(input_model, reference_files):
                 if not valid:
                     log.info("Removing slit {0} from the list of open slits because the"
                              "WCS domain is completely outside the detector.".format(slit.name))
+                    log.debug("Slit domain is {0}".format(domain))
                     idx = np.nonzero([s.name==slit.name for s in open_slits])[0][0]
                     open_slits.pop(idx)
 

--- a/jwst/extract_2d/extract_2d.py
+++ b/jwst/extract_2d/extract_2d.py
@@ -30,7 +30,8 @@ def extract2d(input_model, which_subarray=None):
         output_model.update(input_model)
 
     if exp_type in ['NRS_FIXEDSLIT', 'NRS_MSASPEC']:
-        open_slits = nirspec.get_open_slits(input_model)
+        slit2msa = input_model.meta.wcs.get_transform('slit_frame', 'msa_frame')
+        open_slits = slit2msa[1].slits[:]
         if which_subarray is not None:
             open_slits = [sub for sub in open_slits if sub.name==which_subarray]
         log.debug('open slits {0}'.format(open_slits))

--- a/jwst/extract_2d/extract_2d.py
+++ b/jwst/extract_2d/extract_2d.py
@@ -31,6 +31,8 @@ def extract2d(input_model, which_subarray=None):
 
     if exp_type in ['NRS_FIXEDSLIT', 'NRS_MSASPEC']:
         slit2msa = input_model.meta.wcs.get_transform('slit_frame', 'msa_frame')
+        # This is a cludge but will work for now.
+        # This model keeps open_slits as an attribute.
         open_slits = slit2msa[1].slits[:]
         if which_subarray is not None:
             open_slits = [sub for sub in open_slits if sub.name==which_subarray]


### PR DESCRIPTION
This PR implements a check that an open slit/slice is projected on one of the NIRSpec detectors. If it does not fall within a detector it is removed from the list of open slits. If there's no open slit that falls on the detector the assign_wcs step is set to "SKIPPED". 
This works by running the models from the MSA to the detector for each open slit and examining the domain. If the domain shows the slit does not fall on the detector, the slit is removed.

Extract2d was changed to get the list of open slits from one of the transforms in the WCS pipeline ( a cludge but will work for build 7). Since flat field and resample work with outputs fromextract_2d, they don't need to be modified. They also don;t need to check the domain now (flat field may be modified to not check the domain). For IFU observations this also works because either all slices fall on the detector or none (in which case assign_wcs is set to "SKIPPED" altogether).

@hbushouse @philhodge @jdavies-st 