### PR TITLE
Update FCSRLPOS keyword data type

### DIFF
--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -1021,7 +1021,7 @@ properties:
             fits_keyword: RMA_POS
           rma_step:
             title: Refocus Mechanism Assembly relative position
-            type: integer
+            type: string
             fits_keyword: FCSRLPOS
       guide_star:
         title: Guide star information


### PR DESCRIPTION
Level-1 data processing is failing because the values coming from the database for the FCRLPOS keyword are in the form of a string, but the keyword is currently defined as integer type. So updated the type to string, in order to allow schema validation to succeed.