### PR TITLE
Update dq_init for IRS2 size check

### DIFF
--- a/jwst/dq_init/dq_init_step.py
+++ b/jwst/dq_init/dq_init_step.py
@@ -30,7 +30,7 @@ class DQInitStep(Step):
             if ngroups != ngroups_kwd:
                 self.log.error("Keyword 'NGROUPS' value of '{0}' does not match data array size of '{1}'".format(ngroups_kwd,ngroups))
                 raise ValueError("Bad data dimensions")
-            if ysize != ysize_kwd:
+            if ysize != ysize_kwd and 'IRS2' not in input_model.meta.exposure.readpatt.upper():
                 self.log.error("Keyword 'SUBSIZE2' value of '{0}' does not match data array size of '{1}'".format(ysize_kwd,ysize))
                 raise ValueError("Bad data dimensions")
             if xsize != xsize_kwd:


### PR DESCRIPTION
Updated the array dimension checking in the front end of the dq_init step to allow for a mismatch in SUBSIZE2 (ysize) vs. NAXIS2 when you're dealing with a NIRSpec exposure that uses the IRS2 readout mode. In these cases the actual data array dimension is 3200, while SUBSIZE2 (ysize) is 2048.