### PR TITLE
refpix step refers to reftype 'irs2' instead of 'refpix'

### DIFF
--- a/jwst/refpix/refpix_step.py
+++ b/jwst/refpix/refpix_step.py
@@ -27,7 +27,7 @@ class RefPixStep(Step):
         with datamodels.open(input) as input_model:
             if input_model.meta.exposure.readpatt is not None and \
                input_model.meta.exposure.readpatt.find("IRS2") >= 0:
-                self.irs2_name = self.get_reference_file(input_model, 'irs2')
+                self.irs2_name = self.get_reference_file(input_model, 'refpix')
                 self.log.info('Using IRS2 reference file: %s' % self.irs2_name)
 
                 # Check for a valid reference file

--- a/jwst/refpix/refpix_step.py
+++ b/jwst/refpix/refpix_step.py
@@ -28,11 +28,12 @@ class RefPixStep(Step):
             if input_model.meta.exposure.readpatt is not None and \
                input_model.meta.exposure.readpatt.find("IRS2") >= 0:
                 self.irs2_name = self.get_reference_file(input_model, 'refpix')
-                self.log.info('Using IRS2 reference file: %s' % self.irs2_name)
+                self.log.info('Using refpix reference file: %s' %
+                              self.irs2_name)
 
                 # Check for a valid reference file
                 if self.irs2_name == 'N/A':
-                    self.log.warning('No IRS2 reference file found')
+                    self.log.warning('No refpix reference file found')
                     self.log.warning('RefPix step will be skipped')
                     result = input_model.copy()
                     result.meta.cal_step.refpix = 'SKIPPED'


### PR DESCRIPTION
The second argument to get_reference_file was changed from 'irs2' to
'refpix'.  See Github issue #506 and JIRA issue JP-115.