### PR TITLE
Update dark step to use generic open for science input

### DIFF
--- a/jwst/dark_current/dark_current_step.py
+++ b/jwst/dark_current/dark_current_step.py
@@ -18,7 +18,7 @@ class DarkCurrentStep(Step):
     def process(self, input):
 
         # Open the input data model
-        with datamodels.RampModel(input) as input_model:
+        with datamodels.open(input) as input_model:
 
             # Get the name of the dark reference file to use
             self.dark_name = self.get_reference_file(input_model, 'dark')


### PR DESCRIPTION
Modified the dark_current_step module to use the generic datamodels.open() method to open the input science data, rather than hardwiring it to open as a RampModel. This was messing up the passing of datamodel components when the input was a MIRIRampModel. The generic open method now uses the datamodel type stored in the datamodel itself to determine whether the input is a plain RampModel or the special case of a MIRIRampModel.