### PR TITLE
add exp_types to extract2d

### DIFF
--- a/jwst/extract_2d/extract_2d.py
+++ b/jwst/extract_2d/extract_2d.py
@@ -18,7 +18,7 @@ log.setLevel(logging.INFO)
 
 
 def extract2d(input_model, which_subarray=None):
-    supported_modes = ['NRS_FIXEDSLIT', 'NRS_MSASPEC']
+    supported_modes = ['NRS_FIXEDSLIT', 'NRS_MSASPEC', 'NRS_BRIGHTOBJ', 'NRS_LAMP']
     exp_type = input_model.meta.exposure.type.upper()
     log.info('EXP_TYPE is {0}'.format(exp_type))
 
@@ -29,7 +29,7 @@ def extract2d(input_model, which_subarray=None):
         output_model = datamodels.MultiSlitModel()
         output_model.update(input_model)
 
-    if exp_type in ['NRS_FIXEDSLIT', 'NRS_MSASPEC']:
+    if exp_type in supported_modes:
         slit2msa = input_model.meta.wcs.get_transform('slit_frame', 'msa_frame')
         # This is a cludge but will work for now.
         # This model keeps open_slits as an attribute.


### PR DESCRIPTION
New `EXP_TYPE` values were added to `assign_wcs` in build7. These need to be added to `extract_2d` as well.