### PR TITLE
Revert calspec2 for MIRI LRS fixedslit

### DIFF
--- a/jwst/pipeline/calwebb_spec2.py
+++ b/jwst/pipeline/calwebb_spec2.py
@@ -159,9 +159,8 @@ class Spec2Pipeline(Pipeline):
             # Produce a resampled product, either via resample_spec for
             # "regular" spectra or cube_build for IFU data. No resampled
             # product is produced for time-series modes.
-            if input.meta.exposure.type in ['MIR_LRS-FIXEDSLIT',
-                'NRS_FIXEDSLIT', 'NRS_BRIGHTOBJ', 'NRS_MSASPEC', 'NIS_WFSS',
-                'NRC_GRISM']:
+            if input.meta.exposure.type in ['NRS_FIXEDSLIT', 'NRS_BRIGHTOBJ',
+                'NRS_MSASPEC', 'NIS_WFSS', 'NRC_GRISM']:
 
                 # Call the resample_spec step
                 resamp = self.resample_spec(input)


### PR DESCRIPTION
Reverted calwebb_spec2 to NOT call resample_spec for MIRI LRS fixed-slit exposures, because output is still currently garbage or blank. By skipping the step, the unresampled data are fed downstream to extract_1d, so that it can produce reasonable output for the extracted spectrum.