### PR TITLE
Revise tests for constructing tuple in fits_support.get_hdu

### DIFF
--- a/jwst/datamodels/fits_support.py
+++ b/jwst/datamodels/fits_support.py
@@ -135,9 +135,9 @@ def get_hdu(hdulist, hdu_name, index=None):
         hdu = hdulist[pair]
     except (KeyError, IndexError, AttributeError):
         try:
-            if index is None:
+            if isinstance(pair, six.string_types):
                 hdu = hdulist[(pair, 1)]
-            elif index == 0:
+            elif isinstance(pair, tuple) and index == 0:
                 hdu = hdulist[pair[0]]
             else:
                 raise


### PR DESCRIPTION
The function get_hdu first tries to get the hdu using the parameters passed to it. If this fails, it constructs a tuple (hdu_name, 1) on the hypothesis that the get failed becase the hdu_name was not
unique. This second try only makes sense if the hdu_name passed is a string, because all integers are unique. So the test to form the tuple now asks if hdu_name is a string.

The error was uncovered when testing a modification to astropy.io.fits that implements lazy loading. The new code throws a TypeError when it is passed a tuple of the form (int, int), which the get_hdu code does not handle. Since the new code will not create this kind of tuple, the change will no longer affect datamodels.