### PR TITLE
Superbias patch and version updates

### DIFF
--- a/jwst/cube_build/__init__.py
+++ b/jwst/cube_build/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import absolute_import
 from .cube_build_step import CubeBuildStep
 
-__version__ = '0.7.3'
+__version__ = '0.7.6'

--- a/jwst/flatfield/__init__.py
+++ b/jwst/flatfield/__init__.py
@@ -1,3 +1,3 @@
 from jwst.flatfield.flat_field_step import FlatFieldStep
 
-__version__ = '0.7.3'
+__version__ = '0.7.6'

--- a/jwst/pipeline/__init__.py
+++ b/jwst/pipeline/__init__.py
@@ -10,4 +10,4 @@ from .calwebb_coron3 import Coron3Pipeline
 from .calwebb_ami3 import Ami3Pipeline
 from .linear_pipeline import TestLinearPipeline
 
-__version__ = '0.7.4'
+__version__ = '0.7.6'

--- a/jwst/resample/__init__.py
+++ b/jwst/resample/__init__.py
@@ -2,4 +2,4 @@ from __future__ import absolute_import
 from .resample_step import ResampleStep
 from .resample_spec_step import ResampleSpecStep
 
-__version__ = '0.7.4'
+__version__ = '0.7.6'

--- a/jwst/superbias/__init__.py
+++ b/jwst/superbias/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import absolute_import
 from .superbias_step import SuperBiasStep
 
-__version__ = '0.7.0'
+__version__ = '0.7.6'

--- a/jwst/superbias/bias_sub.py
+++ b/jwst/superbias/bias_sub.py
@@ -108,6 +108,15 @@ def get_subarray(ref_model, sci_model):
     ref_x2 = ref_model.meta.subarray.xsize
     ref_y1 = ref_model.meta.subarray.ystart
     ref_y2 = ref_model.meta.subarray.ysize
+    if ref_x1 is None or ref_x2 is None or ref_y1 is None or ref_y2 is None:
+        if ref_model.data.shape[-1] == 2048 and ref_model.data.shape[-2] == 2048:
+            ref_x1 = 1
+            ref_x2 = 2048
+            ref_y1 = 1
+            ref_y2 = 2048
+        else:
+            log.error("Missing subarray corner/size keywords in ref file")
+            raise ValueError("Can't determine ref file readout properties")
     log.debug("ref xstart=%d, xsize=%d, ystart=%d, ysize=%d" % (ref_x1, ref_x2,
                ref_y1, ref_y2))
 


### PR DESCRIPTION
Updated the superbias step to allow it to handle the current batch of NIRCam superbias ref files that don't have SUBSTRTn and SUBSIZEn keywords in them. If the ref data are full-frame, use default values for these keywords.

Also updated the version numbers of a few steps that've been updated in rc6.