### PR TITLE
Put back the changes for issue #429.

### DIFF
--- a/jwst/flatfield/flat_field_step.py
+++ b/jwst/flatfield/flat_field_step.py
@@ -63,6 +63,16 @@ class FlatFieldStep(Step):
 
         # Retrieve the reference file name or names
         if is_NIRSpec:
+            exp_type = input_model.meta.exposure.type
+            if exp_type not in ["NRS_BRIGHTOBJ", "NRS_FIXEDSLIT",
+                                "NRS_IFU", "NRS_MSASPEC"]:
+                self.log.warning("Exposure type is %s; flat-fielding will be "
+                                 "skipped because it is not currently "
+                                 "supported for this mode.", exp_type)
+                result = input_model.copy()
+                result.meta.cal_step.flat_field = "SKIPPED"
+                input_model.close()
+                return result
             self.f_flat_filename = self.get_reference_file(input_model,
                                         'fflat')
             self.s_flat_filename = self.get_reference_file(input_model,


### PR DESCRIPTION
This checks for the case that for NIRSpec data, EXP_TYPE is not one of the supported types, and if it isn't supported the calibration switch will be set to SKIPPED and a copy of the input returned.  This is primarily to trap NRS_IMAGE or similar types.