### PR TITLE
Modify schema validation error handling

### DIFF
--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -168,16 +168,16 @@ class DataModel(properties.ObjectNode):
         self._asdf = asdf
         self._ctx = self
 
+        # if the input is from a file, set the filename attribute
+        if isinstance(init, six.string_types):
+            self.meta.filename = os.path.basename(init)
+
         # if the input model doesn't have a date set, use the current date/time
         if self.meta.date is None:
             self.meta.date = Time(datetime.datetime.now())
             if hasattr(self.meta.date, 'value'):
                 self.meta.date.format = 'isot'
                 self.meta.date = str(self.meta.date.value)
-
-        # if the input is from a file, set the filename attribute
-        if isinstance(init, six.string_types):
-            self.meta.filename = os.path.basename(init)
 
         # store the data model type, if not already set
         if hasattr(self.meta, 'model_type'):


### PR DESCRIPTION
Datamodels checks each time a metadata value is set and throws an error when the change fails to validate against the schema. It rolls back any change that fails to validate. This is problematic if the
original metadata is invalid, as when more than one metadata value is invalid, they cannot be fixed through datamodels as they can only be changed one at a time and each change will be rolled back because of the other invalid values. Datamodels has been changed to track if the metadata is valid and only throw an error if it changes from a valid to an invalid state. All the significant changes are located in the _validate method in properties.py. There is also a change in the ordering of the metadata set in model_base.__init__ to ensure the validation flag is set before the user's code makes its own modifications to the metadata.