### PR TITLE
Prevent srctype step from returning closed model

### DIFF
--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -1537,9 +1537,13 @@ properties:
             type: string
             fits_keyword: S_MSAFLG
           pathloss:
-            title: Pathloss step
+            title: Pathloss Correction
             type: string
             fits_keyword: S_PTHLOS
+          srctype:
+            title: Source Type Determination
+            type: string
+            fits_keyword: S_SRCTYP
           stack_psfs:
             title: Coronagraphic PSF Stacking
             type: string

--- a/jwst/srctype/srctype_step.py
+++ b/jwst/srctype/srctype_step.py
@@ -18,16 +18,17 @@ class SourceTypeStep(Step):
 
     def process(self, input):
 
-        with datamodels.open(input) as input_model:
+        input_model = datamodels.open(input)
 
-            # Call the source selection routine
-            result = set_source_type(input_model)
+        # Call the source selection routine
+        result = set_source_type(input_model)
 
-            if result is None:
-                result = input_model.copy()
-                result.meta.cal_step.srctype = 'SKIPPED'
-            else:
-                result.meta.cal_step.srctype = 'COMPLETE'
+        if result is None:
+            result = input_model.copy()
+            input_model.close()
+            result.meta.cal_step.srctype = 'SKIPPED'
+        else:
+            result.meta.cal_step.srctype = 'COMPLETE'
 
         return result
 


### PR DESCRIPTION
When running the srctype step standalone, it's possible in some circumstances for the input model to get modified in place, without a new model being created for output. The use of a "with datamodels.open" block was causing the updated input_model to be closed by the time it was returned, resulting in an error when stpipe tries to save the returned model to disk. Removing the "with" block and just opening the input model directly allows it to stay open for the return in those circumstances where it's been modified in-place.