### PR TITLE
Fixed error introduced with last Merger

### DIFF
--- a/jwst/cube_build/CubeCloud.py
+++ b/jwst/cube_build/CubeCloud.py
@@ -103,6 +103,7 @@ def MakePointCloudMIRI(self, input_model,
         xi,eta = coord.radec2std(Cube.Crval1, Cube.Crval2,ra,dec) # xi,eta in arc seconds
         coord1 = xi
         coord2 = eta
+        #print('xi eta',coord1,coord2,wave,xpix,ypix)
 
     ifile = np.zeros(flux.shape, dtype='int') + int(file_no)
 
@@ -245,7 +246,6 @@ def FindROI(self, Cube, spaxel, PointCloud):
 
     iprint = 0
     nn = len(PointCloud[0])
-#    nn = 100
 
     self.log.info('number of elements in PT %i',nn)
 
@@ -323,9 +323,9 @@ def FindROI(self, Cube, spaxel, PointCloud):
                     # for NIRSPEC find distance between PT and Spaxel Center 
                     # in xi,eta coordinate system
                     if(Cube.instrument == 'NIRSPEC'):
-                        d1 = (xi[ix] - coord1)/self.scale1
-                        d2 = (eta[iy] - coord2)/self.scale2
-                        d3 = (zlam[iz] - wave)/self.scalew
+                        d1 = (xi[ix] - coord1)/Cube.Cdelt1
+                        d2 = (eta[iy] - coord2)/Cube.Cdelt2
+                        d3 = (zlam[iz] - wave)/Cube.Cdelt3
                         weight_distance = math.sqrt(d1*d1 + d2*d2 + d3*d3)  
                         weight_distance = math.pow(weight_distance,self.weight_power)
 #________________________________________________________________________________
@@ -334,11 +334,11 @@ def FindROI(self, Cube, spaxel, PointCloud):
                         
                         # weighting - standard - distance based on xi,eta distance
                         if(self.weighting =='standard'):
-                            d1 = (xi[ix] - coord1)/self.scale1
-                            d2 = (eta[iy] - coord2)/self.scale2
-                            d3 = (zlam[iz] - wave)/self.scalew
-                            weight_distance = math.sqrt(d1*d1 + d2*d2 + d3*d3)
-                            weight_distance = math.pow(weight_distance,self.weight_power)
+                            d1 = (xi[ix] - coord1)/Cube.Cdelt1
+                            d2 = (eta[iy] - coord2)/Cube.Cdelt2
+                            d3 = (zlam[iz] - wave)/Cube.Cdelt3
+                            weight_distance_abs = math.sqrt(d1*d1 + d2*d2 + d3*d3)
+                            weight_distance = math.pow(weight_distance_abs,self.weight_power)
 
                         # For MIRI the distance between PT and Spaxel Center is
                         # in the alpha - beta cooridate system

--- a/jwst/cube_build/cube_build.py
+++ b/jwst/cube_build/cube_build.py
@@ -574,6 +574,7 @@ def FindCubeFlux(self, Cube, spaxel, PixelCloud):
                 ix = 0
                 for x in Cube.xcoord:
                     num = len(spaxel[icube].ipointcloud)
+
                     if(num > 0):
                         pointcloud_index = spaxel[icube].ipointcloud
                         weightpt = spaxel[icube].pointcloud_weight
@@ -584,7 +585,6 @@ def FindCubeFlux(self, Cube, spaxel, PixelCloud):
                         for j in range(num):
                             weight = weight + weightpt[j]
                             value = value + (weightpt[j] * pixelflux[j])
-
 #                            if(iz == 39 or iz == 40 ):
 #                                if(ix == 14 and iy == 16): 
 #                                    print('Checking ', icube, ix, iy, iz)
@@ -594,7 +594,8 @@ def FindCubeFlux(self, Cube, spaxel, PixelCloud):
 #                                    print('w', weightpt[j])
 #                                    print(' ',weightpt[j] * pixelflux[j])
 #                                    print('num',num)
-                                
+
+
                         if(weight != 0):
                             value = value / weight
                             spaxel[icube].flux = value

--- a/jwst/cube_build/cube_build_step.py
+++ b/jwst/cube_build/cube_build_step.py
@@ -173,20 +173,25 @@ class CubeBuildStep (Step):
             # Scale is 3 dimensions and is determined from default values InstrumentInfo.GetScale
         scale = cube_build.DetermineScale(Cube, InstrumentInfo)
 
+
             # if the user has set the scale of output cube use those values instead
         a_scale = scale[0]
-        if self.scale1 != 0:
+        if self.scale1 != 0.0:
             a_scale = self.scale1
 
         b_scale = scale[1]
-        if self.scale2 != 0:
+        if self.scale2 != 0.0:
             b_scale = self.scale2
 
         wscale = scale[2]
-        if self.scalew != 0:
+        if self.scalew != 0.0:
             wscale = self.scalew
 
+
         Cube.SetScale(a_scale, b_scale, wscale)
+        self.scale1 = Cube.Cdelt1
+        self.scale2 = Cube.Cdelt2
+        self.scalew = Cube.Cdelt3
 
         t0 = time.time()
 #________________________________________________________________________________


### PR DESCRIPTION
In the last cube_build merge I tweaked how a cube spaxel's flux was determined from the weighted input pixels. This change was so that this cube_build was more inline with what David Law had for his weighting function. The distance between the input pixel and spaxel is determined and now it is normalized by the plate scale (cube sample size) in each dimension. The code used the wrong normalization factor - this has been fixed with this pull request. 