### PR TITLE
Photom bug fix

### DIFF
--- a/jwst/photom/photom.py
+++ b/jwst/photom/photom.py
@@ -52,6 +52,7 @@ class DataSet(object):
         self.pupil = None
         if model.meta.instrument.pupil is not None:
             self.pupil = model.meta.instrument.pupil.upper()
+        self.grating = None
         if model.meta.instrument.grating is not None:
             self.grating = model.meta.instrument.grating.upper()
         self.slitnum = -1


### PR DESCRIPTION
Fixes a bug inadvertently created by last update to photom #568. This update makes sure that self.grating is initialized before it is referenced.