### PR TITLE
change API of make_output_wcs() from wcs list to model list

### DIFF
--- a/jwst/resample/resample_utils.py
+++ b/jwst/resample/resample_utils.py
@@ -25,7 +25,7 @@ DEFAULT_DOMAIN = {'lower': None,
                   'includes_upper': False}
 
 
-def make_output_wcs(wcslist):
+def make_output_wcs(input_models):
     """ Generate output WCS here based on footprints of all input WCS objects
     Parameters
     ----------
@@ -37,10 +37,18 @@ def make_output_wcs(wcslist):
         WCS object, with defined domain, covering entire set of input frames
 
     """
-    # wcslist = [i.meta.wcs for i in input_models]
-    # for w, i in zip(wcslist, input_models):
-    #     if w.domain is None:
-    #         w.domain = create_domain(w, i.data.shape)
+
+    # The API needing input_models instead of just wcslist is because
+    # currently the domain is not defined in any of imaging modes for NIRCam
+    # or NIRISS
+    #
+    # TODO: change the API to take wcslist instead of input_models and
+    #       remove the following block
+    wcslist = [i.meta.wcs for i in input_models]
+    for w, i in zip(wcslist, input_models):
+        if w.domain is None:
+            w.domain = create_domain(w, i.data.shape)
+
     output_frame = wcslist[0].output_frame
     naxes = wcslist[0].output_frame.naxes
     if naxes == 3:


### PR DESCRIPTION
The original implementation of this function accepted a list of
input models (or a model container) because it assumed that the
domain of the wcs objects was not populated.  And it turns out
this is true for the current wcs objects created be assign_wcs
for NIRCam.  No domain.  Meanwhile our mocked-up test data has
domains assigned, which is why our tests didn't fail.  Changing
the API back so that current NIRCam data works, until we fix
assign_wcs to add domains.