### PR TITLE
Removed statements which erroneously set some nan values to 0 during …

### DIFF
--- a/jwst/jump/twopoint_difference.py
+++ b/jwst/jump/twopoint_difference.py
@@ -63,9 +63,6 @@ def find_CRs(data, gdq, read_noise, rej_threshold, nframes):
         med_diffs[nans] = 0.
         first_diffs[nans] = 0.
 
-        nans = np.where(np.isnan(first_diffs))
-        first_diffs[nans] = 0.
-
         # Save initial estimate of the median slope for all pixels
         median_slopes[integration] = med_diffs
 


### PR DESCRIPTION
…jump detection. This fixes the problem noted by Mike Swam during testing in November 2016, in which the execution time of the jump step was nearly 2 hours, and resulted in certain reads (including saturated pixels) being erroneously flagged as CRs. This update fixes these problems (decreasing the execution for that dataset to less than 1 minute). @hbushouse 