### PR TITLE
update datamodels documentation

### DIFF
--- a/docs/datamodels/source/conf.py
+++ b/docs/datamodels/source/conf.py
@@ -28,7 +28,7 @@ import sys, os
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions += ['sphinx.ext.autodoc', 'sphinx.ext.intersphinx', 'sphinx.ext.mathjax']
+extensions += ['sphinx.ext.autodoc', 'sphinx.ext.intersphinx']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/datamodels/source/devel/attributes.rst
+++ b/docs/datamodels/source/devel/attributes.rst
@@ -46,8 +46,9 @@ input data array is 4-D data.  Pixel coordinates in the data extensions are
 
     - ``input_model.data.shape[0]``: number of integrations
     - ``input_model.data.shape[1]``: number of groups
-    - ``input_model.meta.exposure.nframes``: number of frames
-    - ``input_model.meta.exposure.groupgap``: group gap
+    - ``input_model.meta.exposure.nframes``: number of frames per group
+    - ``input_model.meta.exposure.groupgap``: number of frames dropped 
+        between groups
     - ``input_model.meta.subarray.xstart``: starting pixel in X (1-based)
     - ``input_model.meta.subarray.ystart``: starting pixel in Y (1-based)
     - ``input_model.meta.subarray.xsize``: number of columns

--- a/docs/datamodels/source/devel/attributes.rst
+++ b/docs/datamodels/source/devel/attributes.rst
@@ -17,34 +17,41 @@ List of current models
 The current models are as follows:
 
     `AmiLgModel`, `AsnModel`, `ContrastModel`,
-    `CubeModel`, `DarkModel`, `DrizParsModel`, `NircamDrizParsModel`,
-    `MiriImgDrizParsModel`, `DrizProductModel`, `FilterModel`,
+    `CubeModel`, `CubeFlatModel`, `DarkModel`, `DarkMIRIModel`,
+    `DrizParsModel`, `NircamDrizParsModel`, `MiriImgDrizParsModel`,
+    `DrizProductModel`, `FgsPhotomModel`, `FilterModel`,
     `FlatModel`, `FringeModel`, `GainModel`, `GLS_RampFitModel`,
-    `ImageModel`, `IPCModel`, `LastFrameModel`, `LinearityModel`,
-    `MaskModel`, `MIRIRampModel`, `MultiSlitModel`, `MultiSpecModel`,
-    `PhotomModel`, `NircamPhotomModel`, `NirissPhotomModel`,
-    `NirspecPhotomModel`, `MiriImgPhotomModel`, `MiriMrsPhotomModel`,
-    `RampModel`, `RampFitOutputModel`, `ReadnoiseModel`, `ResetModel`,
-    `SaturationModel`, `SpecModel`, `StrayLightModel`
+    `ImageModel`, `IPCModel`, `IRS2Model`, `LastFrameModel`, `LinearityModel`,
+    `MaskModel`, `MIRIRampModel`, `ModelContainer`,
+    `MultiExposureModel`, `MultiProductModel`, `MultiSlitModel`,
+    `MultiSpecModel`, `IFUCubeModel`, `PhotomModel`, `NircamPhotomModel`,
+    `NirissPhotomModel`, `NirspecPhotomModel`, `NirspecFSPhotomModel`,
+    `NRSFlatModel`, `NirspecFlatModel`, `NirspecQuadFlatModel`,
+    `MiriImgPhotomModel`, `MiriMrsPhotomModel`, `QuadModel`, `RampModel`,
+    `RampFitOutputModel`, `ReadnoiseModel`, `ReferenceCubeModel`,
+    `ReferenceFileModel`, `ReferenceImageModel`, `ReferenceQuadModel`,
+    `ResetModel`, `RSCDModel`, `SaturationModel`, `SpecModel`,
+    `StrayLightModel`
 
 Commonly used attributes
 ------------------------
 
-Here are a few model attributes that are used by many of the pipeline
-steps.  Note that, following FORTRAN and FITS conventions, the
-starting pixel numbers in X and Y are one-indexed.  Getting the number
-of integrations and the number of groups from the first and second
-axes assumes that the input data array is 4-D data.  Much of the
-jwst step code assumes that the data array is 4-D.
+Here are a few model attributes that are used by some of the pipeline
+steps.
 
-    - number of integrations = input_model.data.shape[0]
-    - number of groups = input_model.data.shape[1]
-    - number of frames = input_model.meta.exposure.nframes
-    - group gap = input_model.meta.exposure.groupgap
-    - starting pixel in X = input_model.meta.subarray.xstart
-    - starting pixel in Y = input_model.meta.subarray.ystart
-    - number of columns = input_model.meta.subarray.xsize
-    - number of rows = input_model.meta.subarray.ysize
+For uncalibrated data `_uncal.fits`.  Getting the number of integrations
+and the number of groups from the first and second axes assumes that the
+input data array is 4-D data.  Pixel coordinates in the data extensions are
+1-indexed as in FORTRAN and FITS headers, not 0-indexed as in Python.
+
+    - ``input_model.data.shape[0]``: number of integrations
+    - ``input_model.data.shape[1]``: number of groups
+    - ``input_model.meta.exposure.nframes``: number of frames
+    - ``input_model.meta.exposure.groupgap``: group gap
+    - ``input_model.meta.subarray.xstart``: starting pixel in X (1-based)
+    - ``input_model.meta.subarray.ystart``: starting pixel in Y (1-based)
+    - ``input_model.meta.subarray.xsize``: number of columns
+    - ``input_model.meta.subarray.ysize``: number of rows
 
 The `data`, `err`, `dq`, etc., attributes of most models are assumed to be
 numpy.ndarray arrays, or at least objects that have some of the attributes
@@ -61,26 +68,29 @@ is stored in a separate image extension).  Full-frame data for all other
 instruments have four columns or rows of reference pixels on each edge
 of the image.
 
-Model classes
--------------
-
-Base class
-''''''''''
+DataModel Base Class
+--------------------
 
 .. autoclass:: jwst.datamodels.DataModel
    :members:
 
-Concrete model classes
-''''''''''''''''''''''
+Specific Model Classes
+----------------------
 
 .. automodule:: jwst.datamodels
    :members: AmiLgModel, AsnModel, ContrastModel,
-    CubeModel, DarkModel, DrizParsModel, NircamDrizParsModel,
-    MiriImgDrizParsModel, DrizProductModel, FilterModel,
+    CubeModel, CubeFlatModel, DarkModel, DarkMIRIModel, DrizParsModel,
+    NircamDrizParsModel, MiriImgDrizParsModel,
+    DrizProductModel, FgsPhotomModel, FilterModel,
     FlatModel, FringeModel, GainModel, GLS_RampFitModel,
-    ImageModel, IPCModel, LastFrameModel, LinearityModel,
-    MaskModel, MIRIRampModel, MultiSlitModel, MultiSpecModel,
-    NircamPhotomModel, NirissPhotomModel,
-    NirspecPhotomModel, MiriImgPhotomModel, MiriMrsPhotomModel,
-    RampModel, RampFitOutputModel, ReadnoiseModel, ResetModel,
-    SaturationModel, SpecModel, StrayLightModel
+    ImageModel, IPCModel, IRS2Model, LastFrameModel, LinearityModel,
+    MaskModel, MIRIRampModel, ModelContainer,
+    MultiExposureModel, MultiProductModel, MultiSlitModel,
+    MultiSpecModel, IFUCubeModel, PhotomModel, NircamPhotomModel,
+    NirissPhotomModel, NirspecPhotomModel, NirspecFSPhotomModel,
+    NRSFlatModel, NirspecFlatModel, NirspecQuadFlatModel,
+    MiriImgPhotomModel, MiriMrsPhotomModel, QuadModel, RampModel,
+    RampFitOutputModel, ReadnoiseModel, ReferenceCubeModel,
+    ReferenceFileModel, ReferenceImageModel, ReferenceQuadModel,
+    ResetModel, RSCDModel, SaturationModel, SpecModel,
+    StrayLightModel

--- a/docs/datamodels/source/devel/metadata.rst
+++ b/docs/datamodels/source/devel/metadata.rst
@@ -9,13 +9,13 @@ observation was made::
 
     print(model.meta.observation.date)
 
-Metadata values are automatically type-checked when they are set.
-Therefore, setting a value that expects a number to a string will
-raise an exception::
+Metadata values are automatically type-checked against the schema when
+they are set. Therefore, setting a keyword which expects a number to a
+string will raise an exception::
 
     >>> from jwst.datamodels import ImageModel
-    >>> dm = ImageModel()
-    >>> dm.meta.target.ra = "foo"
+    >>> model = ImageModel()
+    >>> model.meta.target.ra = "foo"
     Traceback (most recent call last):
       File "<stdin>", line 1, in <module>
       File "site-packages/jwst.datamodels/schema.py", line 672, in __setattr__
@@ -26,7 +26,7 @@ raise an exception::
         raise ValueError(e.message)
     ValueError: 'foo' is not of type u'number'
 
-The set of available metadata elements is defined in a JSON Schema
+The set of available metadata elements is defined in a YAML Schema
 that ships with `jwst.datamodels`.
 
 There is also a utility method for finding elements in the metadata
@@ -52,8 +52,8 @@ databases, such as CRDS, where the path to the metadata element is
 most conveniently stored as a string.  The following two lines are
 equivalent::
 
-    print model['meta.observation.date']
-    print model.meta.observation.date
+    print(model['meta.observation.date'])
+    print(model.meta.observation.date)
 
 Working with lists
 ==================
@@ -69,20 +69,20 @@ list of transformation objects, each of which has a `type` (string)
 and a `coeff` (number) member.  We can assign elements to the list in
 the following equivalent ways::
 
-    >>> trans = dm.meta.transformations.item()
+    >>> trans = model.meta.transformations.item()
     >>> trans.type = 'SIN'
     >>> trans.coeff = 42.0
-    >>> dm.meta.transformations.append(trans)
+    >>> model.meta.transformations.append(trans)
 
-    >>> dm.meta.transformations.append({'type': 'SIN', 'coeff': 42.0})
+    >>> model.meta.transformations.append({'type': 'SIN', 'coeff': 42.0})
 
 When accessing the items of the list, the result is a normal metadata
 object where the attributes are type-checked::
 
-    >>> trans = dm.meta.transformations[0]
-    >>> print trans
+    >>> trans = model.meta.transformations[0]
+    >>> print(trans)
     <jwst.datamodels.schema.Transformations object at 0x123a810>
-    >>> print trans.type
+    >>> print(trans.type)
     SIN
     >>> trans.type = 42.0
     Traceback (most recent call last):
@@ -120,10 +120,10 @@ The following keywords have to do with validating n-dimensional arrays:
 - ``max_ndim``: The maximum number of dimensions of the array.
 
 - ``datatype``: For defining an array, ``datatype`` should be a string.
-For defining a table, it should be a list.
+  For defining a table, it should be a list.
 
 - **array**: ``datatype`` should be one of the following strings,
-representing fixed-length datatypes::
+  representing fixed-length datatypes::
 
   bool8, int8, int16, int32, int64, uint8, uint16, uint32,
   uint64, float16, float32, float64, float128, complex64,
@@ -136,8 +136,7 @@ Or, for fixed-length strings, an array ``[ascii, XX]`` where
 since this would make files less portable).
 
 - **table**: ``datatype`` should be a list of dictionaries.  Each
-element in the list defines a column and has the following
-keys:
+  element in the list defines a column and has the following keys:
 
   - ``datatype``: A string to select the type of the column.
     This is the same as the ``datatype`` for an array (as

--- a/docs/datamodels/source/devel/models.rst
+++ b/docs/datamodels/source/devel/models.rst
@@ -50,7 +50,7 @@ consumed::
 
   # Print out the data array.  It is allocated here on first access
   # and defaults to being filled with zeros.
-  print im.data
+  print(im.data)
 
 If you already have data in a numpy array, you can also create a model
 using that array by passing it in as a data keyword argument::
@@ -80,8 +80,8 @@ exiting the `with` block.
 
 ::
 
-    from jwst import models
-    with models.open("myimage.fits") as im:
+    from jwst import datamodels
+    with datamodels.open("myimage.fits") as im:
         assert isinstance(im, models.ImageModel)
 
 If you know the type of data stored in the file, or you want to ensure
@@ -89,8 +89,8 @@ that what is being loaded is of a particular type, use the constructor
 of the desired concrete class.  For example, if you want to ensure
 that the file being opened contains 2-dimensional image data::
 
-    from jwst.datamodels import ImageData
-    with ImageData("myimage.fits") as im:
+    from jwst.datamodels import ImageModel
+    with ImageModel("myimage.fits") as im:
         # raises exception if myimage.fits is not an image file
         pass
 
@@ -204,20 +204,20 @@ FITS keyword is used in the metadata tree::
 
 This information shows that instead of::
 
-    print hdulist[0].header['DATE-OBS']
+    print(hdulist[0].header['DATE-OBS'])
 
 use::
 
-    print model.meta.observation.date
+    print(model.meta.observation.date)
 
 Extra FITS keywords
 -------------------
 
-When loading arbitrary FITS files, there will inevitably be keywords
-that the schema doesn't know about.  These "extra" FITS keywords are
-put under the model in the `extra_fits` namespace.
+When loading arbitrary FITS files, there may be keywords that are not
+listed in the schema for that data model.  These "extra" FITS keywords
+are put under the model in the `_extra_fits` namespace.
 
-Under the `extra_fits` namespace is a section for each header data
+Under the `_extra_fits` namespace is a section for each header data
 unit, and under those are the extra FITS keywords.  For example, if
 the FITS file contains a keyword `FOO` in the primary header, its
 value can be obtained using::
@@ -226,3 +226,12 @@ value can be obtained using::
 
 This feature is useful to retain any extra keywords from input files
 to output products.
+
+To get a list of everything in `_extra_fits`::
+
+    model._extra_fits._instance
+
+returns a dictionary of of the instance at the model._extra_fits node.
+
+`_instance` can be used at any node in the tree to return a dictionary
+of rest of the tree structure at that node.

--- a/docs/datamodels/source/devel/models.rst
+++ b/docs/datamodels/source/devel/models.rst
@@ -82,7 +82,7 @@ exiting the `with` block.
 
     from jwst import datamodels
     with datamodels.open("myimage.fits") as im:
-        assert isinstance(im, models.ImageModel)
+        assert isinstance(im, datamodels.ImageModel)
 
 If you know the type of data stored in the file, or you want to ensure
 that what is being loaded is of a particular type, use the constructor
@@ -171,6 +171,17 @@ In place of `ImageModel`, use the type of data one expects to find in
 the file.  For example, if spectrographic data is expected, use
 `SpecModel`.  If it doesn't matter (perhaps the application is only
 sorting FITS files into categories) use the base class `DataModel`.
+
+An alternative is to use::
+
+    from jwst import datamodels
+    with datamodels.open("myfile.fits") as model:
+        ...
+
+The `datamodels.open()` method checks if the `DATAMODL` FITS keyword has
+been set, which records the DataModel that was used to create the file.
+If the keyword is not set, then `datamodels.open()` does its best to
+guess the best DataModel to use.
 
 Accessing data
 --------------


### PR DESCRIPTION
First attempt at updating datamodels documentation.  More to be done.  Current updates:

- added all the new datamodel types since Build 6
- examples use python 3 print() syntax now

