### PR TITLE
Fix labels in srctype docs

### DIFF
--- a/docs/srctype/source/conf.py
+++ b/docs/srctype/source/conf.py
@@ -42,7 +42,7 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = 'dq_init'
+project = 'srctype'
 copyright = '2012, STScI'
 
 # The version info for the project you're documenting, acts as replacement for
@@ -166,7 +166,7 @@ html_static_path = ['_static']
 #html_file_suffix = None
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'dq_initdoc'
+htmlhelp_basename = 'srctypedoc'
 
 
 # -- Options for LaTeX output --------------------------------------------------
@@ -185,7 +185,7 @@ latex_elements = {
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('index', 'dq_init.tex', 'JWST Science Calibration Pipeline: DQ Init',
+  ('index', 'srctype.tex', 'JWST Science Calibration Pipeline: Source Type',
    'STScI', 'manual'),
 ]
 
@@ -215,7 +215,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'dq_init', 'JWST Science Calibration Pipeline: DQ Init',
+    ('index', 'srctype', 'JWST Science Calibration Pipeline: Source Type',
      ['STScI'], 1)
 ]
 
@@ -229,8 +229,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('index', 'dq_init', 'JWST Science Calibration Pipeline: DQ Init',
-   'STScI', 'dq_init', 'JWST Science Calibration Pipeline: DQ Init',
+  ('index', 'srctype', 'JWST Science Calibration Pipeline: Source Type',
+   'STScI', 'srctype', 'JWST Science Calibration Pipeline: Source Type',
    'Miscellaneous'),
 ]
 


### PR DESCRIPTION
Changed labels/titles in srctype conf.py file. The word "dq_init" is now crossed out, with "srctype" written in crayon.