### PR TITLE
Add step class imports to skymatch and tweakreg

### DIFF
--- a/jwst/skymatch/__init__.py
+++ b/jwst/skymatch/__init__.py
@@ -6,6 +6,8 @@ This package provides support for sky background subtraction and equalization
 """
 from __future__ import (absolute_import, division, unicode_literals,
                         print_function)
+from .skymatch_step import SkyMatchStep
+
 import os
 import logging
 

--- a/jwst/tweakreg/__init__.py
+++ b/jwst/tweakreg/__init__.py
@@ -5,6 +5,8 @@ This package provides support for image alignment.
 """
 from __future__ import (absolute_import, division, unicode_literals,
                         print_function)
+from .tweakreg_step import TweakRegStep
+
 import os
 import logging
 


### PR DESCRIPTION
The __init__.py modules for the tweakreg and skymatch steps were missing an import of the step classes from their respective modules. This is needed in order to reference the step classes directly as "jwst.<step>.<StepClassName>", as is used in their .cfg files.

Fixes #633