### PR TITLE
Change clobber to overwrite; Astropy 1.3 depreciation

### DIFF
--- a/jwst/assign_wcs/tools/nirspec/compute_world_coordinates.py
+++ b/jwst/assign_wcs/tools/nirspec/compute_world_coordinates.py
@@ -84,7 +84,7 @@ def ifu_coords(fname, output=None):
     else:
         root = model.meta.filename.split('_')
         output = "".join([root[0], '_world_coordinates', '.fits'])
-    hdulist.writeto(output, clobber=True)
+    hdulist.writeto(output, overwrite=True)
     del hdulist
     model.close()
 
@@ -154,7 +154,7 @@ def compute_world_coordinates(fname, output=None):
     else:
         root = model.meta.filename.split('_')
         output = "".join([root[0], '_world_coordinates', '.fits'])
-    hdulist.writeto(output, clobber=True)
+    hdulist.writeto(output, overwrite=True)
     del hdulist
     model.close()
 
@@ -215,7 +215,7 @@ def imaging_coords(fname, output=None):
     else:
         root = model.meta.filename.split('_')
         output = "".join([root[0], '_world_coordinates', '.fits'])
-    hdulist.writeto(output, clobber=True)
+    hdulist.writeto(output, overwrite=True)
     del hdulist
     model.close()
 

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -267,7 +267,7 @@ class DataModel(properties.ObjectNode):
 
         # TODO: Support gzip-compressed fits
         if ext == '.fits':
-            kwargs.setdefault('clobber', True)
+            kwargs.setdefault('overwrite', True)
             self.to_fits(path, *args, **kwargs)
         elif ext == '.asdf':
             self.to_asdf(path, *args, **kwargs)

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -267,7 +267,9 @@ class DataModel(properties.ObjectNode):
 
         # TODO: Support gzip-compressed fits
         if ext == '.fits':
-            kwargs.setdefault('overwrite', True)
+            # TODO: remove 'clobber' check once depreciated fully in astropy
+            if 'clobber' not in kwargs:
+                kwargs.setdefault('overwrite', True)
             self.to_fits(path, *args, **kwargs)
         elif ext == '.asdf':
             self.to_asdf(path, *args, **kwargs)

--- a/jwst/datamodels/tests/test_fits.py
+++ b/jwst/datamodels/tests/test_fits.py
@@ -103,7 +103,7 @@ def test_from_scratch():
 
         dm.meta.instrument.name = 'NIRCAM'
 
-        dm.to_fits(TMP_FITS, clobber=True)
+        dm.to_fits(TMP_FITS, overwrite=True)
 
         with ImageModel.from_fits(TMP_FITS) as dm2:
             assert dm2.shape == (50, 50)
@@ -173,7 +173,7 @@ def test_extra_fits():
         assert 'BITPIX' not in _header_to_dict(dm.extra_fits.PRIMARY.header)
         assert _header_to_dict(dm.extra_fits.PRIMARY.header)['SCIYSTRT'] == 705
         dm2 = dm.copy()
-        dm2.to_fits(TMP_FITS, clobber=True)
+        dm2.to_fits(TMP_FITS, overwrite=True)
 
     with DataModel(TMP_FITS) as dm3:
         assert 'BITPIX' not in _header_to_dict(dm.extra_fits.PRIMARY.header)
@@ -221,7 +221,7 @@ def test_casting():
 def test_fits_comments():
     with ImageModel() as dm:
         dm.meta.subarray.xstart = 42
-        dm.save(TMP_FITS, clobber=True)
+        dm.save(TMP_FITS, overwrite=True)
 
     from astropy.io import fits
     hdulist = fits.open(TMP_FITS)
@@ -240,7 +240,7 @@ def test_fits_comments():
 
 def test_metadata_doesnt_override():
     with ImageModel() as dm:
-        dm.save(TMP_FITS, clobber=True)
+        dm.save(TMP_FITS, overwrite=True)
 
     from astropy.io import fits
     hdulist = fits.open(TMP_FITS, mode='update')
@@ -305,7 +305,7 @@ def test_table_with_metadata():
         ]
     with FluxModel(flux_table=flux_im) as datamodel:
         datamodel.meta.fluxinfo.exposure = 'Exposure info'
-        datamodel.save(TMP_FITS, clobber=True)
+        datamodel.save(TMP_FITS, overwrite=True)
         del datamodel
 
     from astropy.io import fits
@@ -379,7 +379,7 @@ def test_replace_table():
 
     m = DataModel(schema=schema_narrow)
     m.data = x
-    m.to_fits(TMP_FITS, clobber=True)
+    m.to_fits(TMP_FITS, overwrite=True)
 
     with fits.open(TMP_FITS) as hdulist:
         assert repr(list(x)) == repr(list(np.asarray(hdulist[1].data)))
@@ -389,7 +389,7 @@ def test_replace_table():
     with DataModel(TMP_FITS,
                    schema=schema_wide) as m:
         foo = m.data
-        m.to_fits(TMP_FITS2, clobber=True)
+        m.to_fits(TMP_FITS2, overwrite=True)
 
     with fits.open(TMP_FITS2) as hdulist:
         assert repr(list(x)) == repr(list(np.asarray(hdulist[1].data)))
@@ -401,7 +401,7 @@ def test_metadata_from_fits():
     from astropy.io import fits
 
     mask = np.array([[0, 1], [2, 3]])
-    fits.ImageHDU(data=mask, name='DQ').writeto(TMP_FITS, clobber=True)
+    fits.ImageHDU(data=mask, name='DQ').writeto(TMP_FITS, overwrite=True)
     with DataModel(init=TMP_FITS) as dm:
         dm.save(TMP_FITS2)
 
@@ -416,7 +416,7 @@ def test_metadata_from_fits():
 #     primary = fits.PrimaryHDU()
 #     hdulist.append(primary)
 #     hdulist[0].header['SUBSTRT1'] = 42.7
-#     hdulist.writeto(TMP_FITS, clobber=True)
+#     hdulist.writeto(TMP_FITS, overwrite=True)
 
 #     with DataModel(TMP_FITS) as dm:
 #         assert dm.meta.subarray.xstart == 42.7

--- a/jwst/datamodels/tests/test_history.py
+++ b/jwst/datamodels/tests/test_history.py
@@ -67,7 +67,7 @@ def test_history_from_fits():
     header = fits.Header()
     header['HISTORY'] = "First entry"
     header['HISTORY'] = "Second entry"
-    fits.writeto(TMP_FITS, np.array([]), header, clobber=True)
+    fits.writeto(TMP_FITS, np.array([]), header, overwrite=True)
 
     m = DataModel(TMP_FITS)
     assert m.history == [{'description': 'First entry'},

--- a/jwst/datamodels/tests/test_models.py
+++ b/jwst/datamodels/tests/test_models.py
@@ -113,7 +113,7 @@ def roundtrip(func):
 
 @roundtrip
 def test_from_fits_write(dm):
-    dm.to_fits(TMP_FITS, clobber=True)
+    dm.to_fits(TMP_FITS, overwrite=True)
     return DataModel.from_fits(TMP_FITS)
 
 
@@ -251,7 +251,7 @@ def test_multislit_from_image():
 
 def test_multislit_from_fits_image():
     with ImageModel((64, 64)) as im:
-        im.save(TMP_FITS, clobber=True)
+        im.save(TMP_FITS, overwrite=True)
 
     with MultiSlitModel(TMP_FITS) as ms:
         assert len(ms.slits) == 1
@@ -353,7 +353,7 @@ def test_relsens():
 
 def test_image_with_extra_keyword_to_multislit():
     with ImageModel(data=np.empty((32, 32))) as im:
-        im.save(TMP_FITS, clobber=True)
+        im.save(TMP_FITS, overwrite=True)
 
     from astropy.io import fits
     with fits.open(TMP_FITS, mode="update") as hdulist:
@@ -366,7 +366,7 @@ def test_image_with_extra_keyword_to_multislit():
                 ms.slits.append(ImageModel(data=np.empty((4, 4))))
             assert len(ms.slits) == 3
 
-            ms.save(TMP_FITS2, clobber=True)
+            ms.save(TMP_FITS2, overwrite=True)
 
     with MultiSlitModel(TMP_FITS2) as ms:
         assert len(ms.slits) == 3

--- a/jwst/datamodels/tests/test_schema.py
+++ b/jwst/datamodels/tests/test_schema.py
@@ -146,7 +146,7 @@ def test_ad_hoc_fits():
     with DataModel() as dm:
         dm.meta.foo = {'a': 42, 'b': ['a', 'b', 'c']}
 
-        dm.to_fits(TMP_FITS, clobber=True)
+        dm.to_fits(TMP_FITS, overwrite=True)
 
     with DataModel.from_fits(TMP_FITS) as dm2:
         assert dm2.meta.foo == {'a': 42, 'b': ['a', 'b', 'c']}
@@ -285,7 +285,7 @@ def test_table_array():
             (str('my_string'), str('S64'))
             ]
 
-        x.to_fits(TMP_FITS, clobber=True)
+        x.to_fits(TMP_FITS, overwrite=True)
 
     with DataModel(TMP_FITS, schema=table_schema) as x:
         table = x.table
@@ -421,7 +421,7 @@ def test_data_array():
         x.arr[2].data = array3
         del x.arr[1]
         assert len(x.arr) == 2
-        x.to_fits(TMP_FITS, clobber=True)
+        x.to_fits(TMP_FITS, overwrite=True)
 
     with DataModel(TMP_FITS, schema=data_array_schema) as x:
         assert len(x.arr) == 2
@@ -442,7 +442,7 @@ def test_data_array():
         assert len(x.arr) == 3
         del x.arr[1]
         assert len(x.arr) == 2
-        x.to_fits(TMP_FITS2, clobber=True)
+        x.to_fits(TMP_FITS2, overwrite=True)
 
     from astropy.io import fits
     with fits.open(TMP_FITS2) as hdulist:
@@ -535,7 +535,7 @@ def test_multislit_move_from_fits():
         hdu.ver = i + 1
         hdulist.append(hdu)
 
-    hdulist.writeto(TMP_FITS, clobber=True)
+    hdulist.writeto(TMP_FITS, overwrite=True)
 
     n = MultiSlitModel()
     with MultiSlitModel(TMP_FITS) as m:

--- a/jwst/datamodels/tests/test_wcs.py
+++ b/jwst/datamodels/tests/test_wcs.py
@@ -56,7 +56,7 @@ def test_wcs():
     wcs2 = dm2.get_fits_wcs()
     assert wcs2.wcs.crpix[0] == 42.0
 
-    dm2.to_fits(TMP_FITS, clobber=True)
+    dm2.to_fits(TMP_FITS, overwrite=True)
 
     with ImageModel(TMP_FITS) as dm3:
         wcs3 = dm3.get_fits_wcs()
@@ -69,7 +69,7 @@ def test_wcs():
 
     dm4 = ImageModel()
     dm4.set_fits_wcs(wcs3)
-    dm4.to_fits(TMP_FITS, clobber=True)
+    dm4.to_fits(TMP_FITS, overwrite=True)
 
     with ImageModel(TMP_FITS) as dm5:
         wcs5 = dm5.get_fits_wcs()

--- a/jwst/outlier_detection/flag_cr.py
+++ b/jwst/outlier_detection/flag_cr.py
@@ -275,7 +275,7 @@ def flag_cr(sci_image, blot_image, gain_image, readnoise_image, **pars):
     # outfilename = sci_image.meta.filename.split('.')[0] + '_dq.fits'
     # out_dq = datamodels.ImageModel()
     # out_dq.data = result_dq
-    # out_dq.to_fits(outfilename, clobber=True)
+    # out_dq.to_fits(outfilename, overwrite=True)
 
     # ######## Save the cosmic ray mask file to disk
     # _cr_file = np.zeros(input_image.shape, np.uint32)

--- a/jwst/stpipe/step.py
+++ b/jwst/stpipe/step.py
@@ -386,7 +386,7 @@ class Step(object):
                             output_file_name = join(self.output_dir, filename)
 
                         self.log.info('Saving file {0}'.format(output_file_name))
-                        result.save(output_file_name, clobber=True)
+                        result.save(output_file_name, overwrite=True)
 
             self.log.info(
                 'Step {0} done'.format(self.name))

--- a/jwst/stpipe/tests/data/mkdata.py
+++ b/jwst/stpipe/tests/data/mkdata.py
@@ -9,10 +9,10 @@ hdu2 = pyfits.ImageHDU(data, name='SCI')
 data = numpy.random.random((16, 16))
 hdu3 = pyfits.ImageHDU(data, name='SCI')
 hdulist = pyfits.HDUList([hdu1, hdu2, hdu3])
-hdulist.writeto(name, clobber=True)
+hdulist.writeto(name, overwrite=True)
 
 name = 'flat.fits'
 data = numpy.random.random((16, 16))
 hdu1 = pyfits.PrimaryHDU(data)
 hdulist = pyfits.HDUList([hdu1])
-hdulist.writeto(name, clobber=True)
+hdulist.writeto(name, overwrite=True)


### PR DESCRIPTION
The keyword `clobber` has been depreciated in Astropy 1.3 for io.fits.  The keyword `overwrite` is now preferred.  This PR updates all instances in the jwst package.