### PR TITLE
Remove stsci-jwst dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
         - MAIN_CMD='python setup.py'
         - CONDA_CHANNELS='http://ssb.stsci.edu/conda-dev'
         - CONDA_DEPENDENCIES='pytest jwst sphinx=1.3.5'
-        - CONDA_JWST_DEPENDENCIES='pytest stsci-jwst sphinx=1.3.5'
+        - CONDA_JWST_DEPENDENCIES='pytest jwst sphinx=1.3.5'
         - PIP_DEPENDENCIES=''
         - CRDS_SERVER_URL='https://jwst-crds.stsci.edu'
         - CRDS_PATH='/tmp/crds_cache'


### PR DESCRIPTION
I'm not sure how we missed this, but we're still pulling in `stsci-jwst`, so I'm removing it.