### PR TITLE
Change data type from int32 to uint32.

### DIFF
--- a/jwst/ramp_fitting/ramp_fit.py
+++ b/jwst/ramp_fitting/ramp_fit.py
@@ -439,7 +439,7 @@ def gls_ramp_fit(model,
         ampl_err_int = np.zeros(shape_ampl, dtype=np.float32)
 
     # Used for flagging pixels with UNRELIABLE_SLOPE.
-    temp_dq = np.zeros(imshape, dtype=np.int32)
+    temp_dq = np.zeros(imshape, dtype=np.uint32)
 
     # Get Pixel DQ array from input file. The incoming RampModel has uint8
     # PIXELDQ, but ramp fitting will update this array here by flagging


### PR DESCRIPTION
Temporary array dq_int has data type uint32, while temp_dq has data type
int32, and the code does a bitwise OR between dq_int and temp_dq.  This
used to work, but more recently (e.g. using Python 3.5.2 and numpy 1.11.3)
it fails because of the difference in data type.  Function gls_ramp_fit has
been modified to create temp_dq as data type uint32.  See #632.