### PR TITLE
Updating ramp fitting docs to use input read noise in units of DN, co…

### DIFF
--- a/docs/ramp_fitting/source/main.rst
+++ b/docs/ramp_fitting/source/main.rst
@@ -33,7 +33,9 @@ for all intervals for a given pixel, the final slope is determined as a weighted
 average from all intervals and is written to a file as the primary output 
 product.  In this output product, the 4-D GROUPDQ from all integrations is 
 compressed into 2-D, which is then merged (using a bitwise OR) with the input 
-2-D PIXELDQ to create the output PIXELDQ.
+2-D PIXELDQ to create the output PIXELDQ.  In addition, the output PIXELDQ array 
+is updated to have DQ flags set to NO_GAIN_VALUE and DO_NOT_USE for all pixels 
+that are non-positive or NaN in the gain array. 
 
 If the input exposure contains more than one integration, the resulting slope
 images from each integration are stored as a data cube in a second output data

--- a/docs/ramp_fitting/source/reference_files.rst
+++ b/docs/ramp_fitting/source/reference_files.rst
@@ -26,10 +26,9 @@ with ``EXTNAME=SCI``, which contains a 2-D floating-point array of gain values
 Read Noise Reference File Format
 --------------------------------
 The read noise reference file is a FITS file with a single IMAGE extension,
-with ``EXTNAME=SCI``, which contains a 2-D floating-point array of read noise values
-per pixel. The units of the read noise should be electrons and should be the
+with ``EXTNAME=SCI``, which contains a 2-D floating-point array of read noise 
+values per pixel. The units of the read noise should be DN and should be the 
 CDS (Correlated Double Sampling) read noise, i.e. the effective noise between
-any pair of non-destructive detector reads. The REFTYPE value is
-``READNOISE``.
+any pair of non-destructive detector reads. The REFTYPE value is ``READNOISE``.
 
 


### PR DESCRIPTION
…mpleting updates needed in support of issue #669. During development I noticed that some gain values had invalid values (0, negative, or NaN), so have also updated code (#688) to flag those pixels as DO_NOT_USE and NO_GAIN_VALUE in the output PIXELDQ array. Similar updates have already been made for jump detection (#681). @hbushouse 