### PR TITLE
Modify resample to use real WCS objects as in MIRI imaging.

### DIFF
--- a/jwst/datamodels/drizproduct.py
+++ b/jwst/datamodels/drizproduct.py
@@ -30,6 +30,3 @@ class DrizProductModel(model_base.DataModel):
 
         if relsens is not None:
             self.relsens = relsens
-
-    def assign_wcs(self, wcs):
-        self.meta.wcs = wcs

--- a/jwst/outlier_detection/blot_median.py
+++ b/jwst/outlier_detection/blot_median.py
@@ -20,18 +20,18 @@ def do_blot(median_model, input_models, **pars):
     # Initialize output product
     blot_models = datamodels.ModelContainer()
 
-    do_blot = gwcs_blot.GWCSBlot(median_model)
+    blot = gwcs_blot.GWCSBlot(median_model)
 
-    for input_img in input_models:
-        blot_model = input_img.copy()
-        blot_root = '_'.join(input_img.meta.filename.replace('.fits', '').split('_')[:-1])
-        blot_model.meta.filename = '{}_blot.fits'.format(blot_root)
+    for model in input_models:
+        blotted_median = model.copy()
+        blot_root = '_'.join(model.meta.filename.replace('.fits', '').split('_')[:-1])
+        blotted_median.meta.filename = '{}_blot.fits'.format(blot_root)
 
         # clean out extra data not related to blot result
-        blot_model.err = None
-        blot_model.dq = None
-        # apply blot to re-create input_img.data from median image
-        blot_model.data = do_blot.extract_image(input_img.meta.wcs,
-                                        interp=interp, sinscl=sinscl)
-        blot_models.append(blot_model)
+        blotted_median.err = None
+        blotted_median.dq = None
+        # apply blot to re-create model.data from median image
+        blotted_median.data = blot.extract_image(model, interp=interp,
+            sinscl=sinscl)
+        blot_models.append(blotted_median)
     return blot_models

--- a/jwst/outlier_detection/flag_cr.py
+++ b/jwst/outlier_detection/flag_cr.py
@@ -50,47 +50,6 @@ def do_detection(input_models, blot_models, ref_filename, **pars):
         flag_cr(image, blot, gain, rn, **pars)
 
 
-#def build_reffile_container_func(input_models, reftype):
-#    """
-#    Return a ModelContainer of reference file datamodels.
-#
-#    Parameters
-#    ----------
-#
-#    input_models: ModelContainer
-#        the science data, ImageModels in a ModelContainer
-#
-#    reftype: string
-#        type of reference file
-#
-#    Returns
-#    -------
-#
-#    a ModelContainer with corresponding reference files for each input model
-#    """
-#
-#    """
-#    model_mapping = {'gain':'GainModel', 'readnoise':'ReadnoiseModel'}
-#    module = importlib.import_module('..datamodels')
-#    model_name = model_mapping[reftype]
-#    ref_model = getattr(module, model_name)
-#    print("ref_model defined as: {} of type {}".format(ref_model, type(ref_model)))
-#    """
-#    q = Step()
-#    reffiles = [q.get_reference_file(im, reftype) for im in input_models]
-#
-#    # Check if all the ref files are the same.  If so build it by reading
-#    # the reference file just once.
-#    if len(set(reffiles)) <= 1:
-#        length = len(input_models)
-#        ref_list = [datamodels.open(reffiles[0])] * length
-#        #ref_list = [ref_model(reffiles[0])] * length
-#    else:
-#        ref_list = [datamodels.open(ref) for ref in reffiles]
-#        #ref_list = [ref_model(ref) for ref in reffiles]
-#    return datamodels.ModelContainer(ref_list)
-
-
 def buildMask(dqarr, bitvalue):
     """ Builds a bit-mask from an input DQ array and a bitvalue flag"""
 

--- a/jwst/pipeline/calwebb_image3.py
+++ b/jwst/pipeline/calwebb_image3.py
@@ -68,14 +68,17 @@ class Image3Pipeline(Pipeline):
             
             # Now clean up intermediate products which no are no longer needed
             for i in input_models:
-                if hasattr(i.meta,'tweakreg_catalog'):
-                    cname = i.meta.tweakreg_catalog.filename
-                    if os.path.exists(cname):
-                        os.remove(cname)
+                try:
+                    catalog_name = i.meta.tweakreg_catalog.filename
+                    os.remove(catalog_name)
+                except:
+                    pass
 
             log.info("Resampling ASN to create combined product: {}".format(input_models.meta.resample.output))
 
         # Setup output file name for subsequent use
+        # TODO: fix single resample to do what outlier detection does
+        # in updating meta.resample.*
         output_file = mk_prodname(self.output_dir,
             input_models.meta.resample.output, 'i2d')
         input_models.meta.resample.output = output_file

--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -63,8 +63,9 @@ class ResampleData(object):
 
         # Define output WCS based on all inputs, including a reference WCS
         self.output_wcs = resample_utils.make_output_wcs(self.input_models)
+
         self.blank_output = datamodels.DrizProductModel(self.output_wcs.data_size)
-        self.blank_output.assign_wcs(self.output_wcs)
+        self.blank_output.meta.wcs = self.output_wcs
 
         # Default to defining output models metadata as
         # a copy of the first input_model's metadata
@@ -179,7 +180,6 @@ class ResampleData(object):
                                 fillval=self.drizpars['fillval'])
 
             for n, img in enumerate(group):
-                wcslin_pscale = img.meta.wcs.forward_transform['cdelt1'].factor.value
                 exposure_times['start'].append(img.meta.exposure.start_time)
                 exposure_times['end'].append(img.meta.exposure.end_time)
 
@@ -187,8 +187,8 @@ class ResampleData(object):
                 if 'skybg' in img.meta._instance:
                     img.data -= img.meta.skybg
                     
-                outwcs_pscale = output_model.meta.wcs.forward_transform['cdelt1'].factor.value
-                wcslin_pscale = img.meta.wcs.forward_transform['cdelt1'].factor.value
+                outwcs_pscale = output_model.meta.wcsinfo.cdelt1
+                wcslin_pscale = img.meta.wcsinfo.cdelt1
 
                 inwht = build_driz_weight(img, wht_type=self.drizpars['wht_type'],
                                     good_bits=self.drizpars['good_bits'])
@@ -245,133 +245,3 @@ def build_driz_weight(model, wht_type=None, good_bits=None):
         # Create an identity input weight map
         inwht = np.ones(model.data.shape, dtype=model.data.dtype)
     return inwht
-
-def drizzle_image(insci, input_wcs, inwht,
-            output_wcs, outsci, outwht, outcon,
-            in_units='cps', wcsmap=None, **pars):
-    """ Core routine for performing 'drizzle' operation on a single input image
-        All input values will be Python objects such as ndarrays, instead of filenames
-        File handling (input and output) will be performed by calling routine.
-
-    Parameters
-    ----------
-    insci,inwht : ndarray,ndarray
-    outsci,outwht,outcon : ndarray,ndarray,ndarray
-    wcsmap : object
-    uniqid : int
-    expin : float
-    pix_ratio : float
-    pixfrac : float
-    kernel : str
-    fillval : str
-
-    Notes
-    ------
-    Modified from original code found in drizzlepac.adrizzle.
-    """
-    # Set various parameters needed for drizzling
-    uniqid = pars.get('uniqid', 1)
-    expin = pars.get('expin')
-    wcslin_pscale = pars.get('wcslin_pscale', 1.0)
-
-    pixfrac = pars.get('pixfrac', 1.0)
-    kernel = pars.get('kernel', 'square')
-    fillval = pars.get('fillval', 'INDEF')
-    stepsize = pars.get('stepsize', 10)
-
-    output_wcs_pscale = output_wcs.wcs_info['CDELT'][0]
-
-    # Insure that the fillval parameter gets properly interpreted for use with tdriz
-    if util.is_blank(fillval):
-        fillval = 'INDEF'
-    else:
-        fillval = str(fillval)
-
-    if in_units == 'cps':
-        expscale = 1.0
-    else:
-        expscale = expin
-
-    # Interpret wt_scl parameter
-    if pars['wt_scl'] == 'exptime':
-        wt_scl = expin
-    elif pars['wt_scl'] == 'expsq':
-        wt_scl = expin * expin
-    else:
-        wt_scl = float(pars['wt_scl'])
-
-    # Compute what plane of the context image this input would
-    # correspond to:
-    _planeid = int((uniqid - 1) / 32)
-    # Compute how many planes will be needed for the context image.
-    _nplanes = _planeid + 1
-
-    if outcon is not None and (outcon.ndim < 3 or (outcon.ndim == 3 and outcon.shape[0] < _nplanes)):
-        # convert context image to 3-D array and pass along correct plane for drizzling
-        if outcon.ndim == 3:
-            nplanes = outcon.shape[0] + 1
-        else:
-            nplanes = 1
-        # We need to expand the context image here to accomodate the addition of
-        # this new image
-        newcon = np.zeros((nplanes, output_wcs.naxis2, output_wcs.naxis1), dtype=np.int32)
-        # now copy original outcon arrays into new array
-        if outcon.ndim == 3:
-            for n in range(outcon.shape[0]):
-                newcon[n] = outcon[n].copy()
-        else:
-            newcon[0] = outcon.copy()
-    else:
-        if outcon is None:
-            outcon = np.zeros((1, output_wcs.naxis2, output_wcs.naxis1), dtype=np.int32)
-            _planeid = 0
-        newcon = outcon
-
-    # At this point, newcon will always be a 3-D array, so only pass in
-    # correct plane to drizzle code
-    outctx = newcon[_planeid]
-
-    pix_ratio = output_wcs_pscale / wcslin_pscale
-    """
-    if wcsmap is None and cdriz is not None:
-        log.info('Using WCSLIB-based coordinate transformation...')
-        log.info('stepsize = %s' % stepsize)
-        mapping = cdriz.DefaultWCSMapping(input_wcs,output_wcs,int(input_wcs.naxis1),int(input_wcs.naxis2),stepsize)
-    else:
-    """
-    #
-    ##Using the Python class for the WCS-based transformation
-    #
-    # Use user provided mapping function
-    log.info('Using coordinate transformation defined by user...')
-    if wcsmap is None:
-        wcsmap = AstroPyWCSMap
-        wmap = wcsmap(input_wcs, output_wcs)
-        mapping = wmap.forward
-    else:
-        mapping = wcsmap
-
-    _shift_fr = 'output'
-    _shift_un = 'output'
-    ystart = 0
-    nmiss = 0
-    nskip = 0
-    #
-    # This call to 'cdriz.tdriz' uses the new C syntax
-    #
-    _dny = insci.shape[0]
-    # Call 'drizzle' to perform image combination
-    if (insci.dtype > np.float32):
-        #WARNING: Input array recast as a float32 array
-        insci = insci.astype(np.float32)
-
-    _vers, nmiss, nskip = cdriz.tdriz(insci, inwht, outsci, outwht,
-        outctx, uniqid, ystart, 1, 1, _dny,
-        pix_ratio, 1.0, 1.0, 'center', pixfrac,
-        kernel, in_units, expscale, wt_scl,
-        fillval, nmiss, nskip, 1, mapping)
-
-    if nmiss > 0:
-        log.warning('! %s points were outside the output image.' % nmiss)
-    if nskip > 0:
-        log.debug('! Note, %s input lines were skipped completely.' % nskip)

--- a/jwst/resample/resample_spec.py
+++ b/jwst/resample/resample_spec.py
@@ -119,13 +119,13 @@ class ResampleSpecData(object):
         ref_model = datamodels.DrizParsModel(self.ref_filename)
         # look for row that applies to this set of input data models
         # NOTE:
-        # This logic could be replaced by a method added to the DrizParsModel 
+        # This logic could be replaced by a method added to the DrizParsModel
         # object to select the correct row based on a set of selection params
         row = None
         drizpars = ref_model.drizpars_table
 
         filter_match = False # flag to support wild-card rows in drizpars table
-        for n, filt, num in zip(range(1, drizpars.numimages.shape[0] + 1), 
+        for n, filt, num in zip(range(1, drizpars.numimages.shape[0] + 1),
             drizpars.filter, drizpars.numimages):
             # only remember this row if no exact match has already been made for
             # the filter. This allows the wild-card row to be anywhere in the
@@ -181,11 +181,11 @@ class ResampleSpecData(object):
             if np.isnan(row[x_center]):
                 xpos.append(np.nan)
             else:
-                f = interpolate.interp1d(row[x_center-sz+1:x_center+sz],
-                    x[y_center, x_center-sz+1:x_center+sz])
+                f = interpolate.interp1d(row[x_center - sz + 1:x_center + sz],
+                    x[y_center, x_center - sz + 1:x_center + sz])
                 xpos.append(f(lam[y_center, x_center]))
-        x_arg = np.array(xpos)[~np.isnan(lam[:,x_center])]
-        y_arg = y[~np.isnan(lam[:,x_center]),x_center]
+        x_arg = np.array(xpos)[~np.isnan(lam[:, x_center])]
+        y_arg = y[~np.isnan(lam[:,x_center]), x_center]
         # slit_coords, spect0 = refwcs(x_arg, y_arg, output='numericals_plus')
         slit_ra, slit_dec, slit_spec_ref = refwcs(x_arg, y_arg)
         slit_coords = SkyCoord(ra=slit_ra, dec=slit_dec, unit=u.deg)
@@ -295,7 +295,7 @@ class ResampleSpecData(object):
 
         # Get the slit size at the center of the dispersion
         sky_coords = SkyCoord(ra=ra, dec=dec, unit=u.deg)
-        slit_coords = sky_coords[int(sky_coords.shape[0]/2)]
+        slit_coords = sky_coords[int(sky_coords.shape[0] / 2)]
         slit_angular_size = slit_coords[0].separation(slit_coords[-1])
         log.debug('Slit angular size: {0}'.format(slit_angular_size.arcsec))
 
@@ -316,7 +316,7 @@ class ResampleSpecData(object):
         spatial_scale = slit_angular_size / slit_coords.shape[0]
         log.debug('Spatial scale: {0}'.format(spatial_scale.arcsec))
         tcenter = int((dx1 - dx0) / 2)
-        trace = lam[:,tcenter]
+        trace = lam[:, tcenter]
         trace = trace[~np.isnan(trace)]
         spectral_scale = np.abs((trace[-1] - trace[0]) / trace.shape[0])
         log.debug('spectral scale: {0}'.format(spectral_scale))

--- a/jwst/resample/resample_spec_step.py
+++ b/jwst/resample/resample_spec_step.py
@@ -1,4 +1,4 @@
-from __future__ import (division, print_function, unicode_literals, 
+from __future__ import (division, print_function, unicode_literals,
     absolute_import)
 
 from ..stpipe import Step, cmdline
@@ -34,9 +34,9 @@ class ResampleSpecStep(Step):
     reference_file_types = ['drizpars']
 
     def process(self, input):
-        
+
         with datamodels.open(input) as self.input_models:
-            
+
             # Single input model, single resample output
             if not isinstance(self.input_models, datamodels.ModelContainer):
                 s = datamodels.ModelContainer()
@@ -44,7 +44,7 @@ class ResampleSpecStep(Step):
                 self.input_models = s
 
             self.driz_filename = self.get_reference_file(self.input_models[0], 'drizpars')
-            
+
             # Multislits get converted to a ModelContainer per slit
             if all([isinstance(i, datamodels.MultiSlitModel) for i in self.input_models]):
                 log.info('Converting MultiSlit to ModelContainer')
@@ -83,7 +83,7 @@ class ResampleSpecStep(Step):
                     result = self.step.output_models[0]
                 else:
                     result = self.step.output_models
-        
+
         result.meta.cal_step.resample = 'COMPLETE'
         return result
 

--- a/jwst/resample/resample_step.py
+++ b/jwst/resample/resample_step.py
@@ -64,9 +64,9 @@ class ResampleStep(Step):
             output_model = self.step.output_models[0]
         else:
             output_model = self.step.output_models
-            
+
         output_model.meta.cal_step.resample = "COMPLETE"
-        
+
         return output_model
 
 


### PR DESCRIPTION
The commit includes many changes to the codebase for resample
and the code it depends on.  They are:
 - Modify resample to use new API for wcs_from_footprints() from
   PR #676
 - Add compute_output_transform() function. Needs more generalization.
 - Remove ambiguously-named method `assign_wcs` from DrizProductModel
 - Clean syntax in blot_median
 - Modify API for GWCSBlot.extract_image to take a datamodel instead
   of just a WCS object, so pixel scale can be pulled from CDELT.
 - Fix bug in Image3Pipeline where tweakreg_catalog cleanup fails
   when the `--steps.tweakreg_catalog.skip=True` flag is used.
 - Scaling params in resample are pulled from CDELT now instead of
   the WCS transform.
 - Clean up PEP8 issues throughout the code.