### PR TITLE
Change MIRI MRS flux calibration scheme

### DIFF
--- a/jwst/datamodels/image.py
+++ b/jwst/datamodels/image.py
@@ -26,11 +26,14 @@ class ImageModel(model_base.DataModel):
 
     relsens : numpy array
         The relative sensitivity table.
+
+    relsens2d: numpy array
+        The relative sensitivty 2D array.
     """
     schema_url = "image.schema.yaml"
 
     def __init__(self, init=None, data=None, dq=None, err=None, relsens=None,
-                 zeroframe=None, area=None, **kwargs):
+                 relsens2d=None, zeroframe=None, area=None, **kwargs):
         super(ImageModel, self).__init__(init=init, **kwargs)
 
         if data is not None:
@@ -44,6 +47,9 @@ class ImageModel(model_base.DataModel):
 
         if relsens is not None:
             self.relsens = relsens
+
+        if relsens2d is not None:
+            self.relsens2d = relsens2d
 
         if zeroframe is not None:
             self.zeroframe = zeroframe

--- a/jwst/datamodels/photom.py
+++ b/jwst/datamodels/photom.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, unicode_literals, division, print_function
 
 from . import model_base
+from .dynamicdq import dynamic_mask
 
 __all__ = ['PhotomModel']
 
@@ -142,18 +143,47 @@ class MiriMrsPhotomModel(PhotomModel):
     init : any
         Any of the initializers supported by `~jwst.datamodels.DataModel`.
 
-    phot_table : numpy array
-        A table-like object containing row selection criteria made up
-        of instrument mode parameters and photometric conversion
-        factors associated with those modes.
+    data : numpy array
+        An array-like object containing the pixel-by-pixel conversion values
+        in units of DN / sec / mJy / pixel.
+
+    err : numpy array
+        An array-like object containing the uncertainties in the conversion
+        values, in the same units as the data array.
+
+    dq : numpy array
+        An array-like object containing bit-encoded data quality flags,
+        indicating problem conditions for values in the data array.
+
+    dq_def : numpy array
+        A table-like object containing the data quality definitions table.
+
+    pixsiz : numpy array
+        An array-like object containing pixel-by-pixel size values, in units of
+        square arcseconds (arcsec^2).
     """
     schema_url = "mirmrs_photom.schema.yaml"
 
-    def __init__(self, init=None, phot_table=None, **kwargs):
+    def __init__(self, init=None, data=None, err=None, dq=None, dq_def=None,
+                 pixsiz=None, **kwargs):
         super(MiriMrsPhotomModel, self).__init__(init=init, **kwargs)
 
-        if phot_table is not None:
-            self.phot_table = phot_table
+        if data is not None:
+            self.data = data
+
+        if err is not None:
+            self.err = err
+
+        if dq is not None:
+            self.dq = dq
+
+        if dq_def is not None:
+            self.dq_def = dq_def
+
+        if pixsiz is not None:
+            self.pixsiz = pixsiz
+
+        self.dq = dynamic_mask(self)
 
 class FgsPhotomModel(PhotomModel):
     """

--- a/jwst/datamodels/schemas/image.schema.yaml
+++ b/jwst/datamodels/schemas/image.schema.yaml
@@ -30,6 +30,11 @@ allOf:
       datatype: float32
     relsens:
       $ref: relsens.schema.yaml
+    relsens2d:
+      title: Sensitivity array
+      fits_hdu: RELSENS2D
+      default: 1.0
+      datatype: float32
 - type: object
   properties:
     pathloss_pointsource:

--- a/jwst/datamodels/schemas/mirmrs_photom.schema.yaml
+++ b/jwst/datamodels/schemas/mirmrs_photom.schema.yaml
@@ -3,22 +3,30 @@ allOf:
 - $ref: photom.schema.yaml
 - type: object
   properties:
-    phot_table:
-      title: Photometric flux conversion factors table
-      fits_hdu: PHOTOM
-      datatype:
-      - name: band
-        datatype: [ascii, 12]
-      - name: photmjsr
-        datatype: float32
-      - name: uncertainty
-        datatype: float32
-      - name: nelem
-        datatype: int16
-      - name: wavelength
-        shape: [50]
-        datatype: float32
-      - name: relresponse
-        shape: [50]
-        datatype: float32
+    data:
+      title: Flux conversion array
+      fits_hdu: SCI
+      default: 1.0
+      ndim: 2
+      datatype: float32
+    err:
+      title: Uncertainty array
+      fits_hdu: ERR
+      default: 0.0
+      ndim: 2
+      datatype: float32
+    dq:
+      title: Data quality array
+      fits_hdu: DQ
+      default: 0
+      ndim: 2
+      datatype: uint32
+    dq_def:
+      $ref: dq_def.schema.yaml
+    pixsiz:
+      title: Pixel size array
+      fits_hdu: PIXSIZ
+      default: 1.0
+      ndim: 2
+      datatype: float32
 $schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/photom/photom_step.py
+++ b/jwst/photom/photom_step.py
@@ -7,8 +7,9 @@ from .. import datamodels
 
 class PhotomStep(Step):
     """
-    PhotomStep: Module for extraction photom conversion factor(s)
-        and writing them to input header
+    PhotomStep: Module for loading photometric conversion infomation from
+        reference files and attaching or applying them to the input science
+        data model
     """
 
     reference_file_types = ['photom', 'area']
@@ -20,8 +21,8 @@ class PhotomStep(Step):
         except IOError:
             self.log.error('Input can not be opened as a Model.')
 
-        # Open input as correct type
-        if isinstance(dm, datamodels.CubeModel): # _integ.fits product: 3D array
+        # Report the detected type of input model
+        if isinstance(dm, datamodels.CubeModel): # integration product: 3D array
             self.log.debug('Input is a CubeModel for a multiple integ file.')
         elif isinstance(dm, datamodels.ImageModel):  # standard product: 2D array
             self.log.debug('Input is an ImageModel.')
@@ -45,8 +46,8 @@ class PhotomStep(Step):
             return result
 
         # Do the correction
-        ff_a = photom.DataSet(dm, phot_filename, area_filename)
-        output_obj = ff_a.do_all()
+        phot = photom.DataSet(dm, phot_filename, area_filename)
+        output_obj = phot.do_all()
 
         output_obj.meta.cal_step.photom = 'COMPLETE'
 


### PR DESCRIPTION
First set of major updates to implement #611. This changes the operation of the photom step for MIRI MRS exposures such that instead of reading a table of wavelength-dependent flux conversion values from the photom reference file, it loads the new style MRS photom ref file that includes a 2D array of sensitivity factors and a 2D array of pixel sizes.

The MRS photom data model and schema were updated to accommodate the new contents of the reference file. The portion of the photom step that handles MRS exposures was updated to divide the input pixel (SCI and ERR arrays) values by both the sensitivity factors and the pixel size array. Checks and logic have been included to handle NaN's and zeros in both the sensitivity and pixel size arrays, such that those values are reset to 1.0 and corresponding pixels in the science DQ array are set to NON_SCIENCE (because all of those pixels in the reference file arrays are those that lie outside of IFU slices.

In addition to applying the flux conversion to the science data, the combined sensitivity and pixel size arrays are also attached to the science product, in a new array (FITS extension) called "RELSENS2D". The ImageModel data model was updated to include the RELSENS2D array/extension.

One additional update that's still needed is to make use of BUNIT keywords in the SCI and ERR arrays of the science product to correctly reflect the new units of the data.