### PR TITLE
Add handling of BUNIT keyword in data extension headers

### DIFF
--- a/jwst/datamodels/schemas/bunit.schema.yaml
+++ b/jwst/datamodels/schemas/bunit.schema.yaml
@@ -1,0 +1,17 @@
+allOf:
+- type: object
+  properties:
+    meta:
+      type: object
+      properties:
+        bunit_data:
+          title: physical units of the array values
+          type: string
+          fits_hdu: SCI
+          fits_keyword: BUNIT
+        bunit_err:
+          title: physical units of the array values
+          type: string
+          fits_hdu: ERR
+          fits_keyword: BUNIT
+$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/cube.schema.yaml
+++ b/jwst/datamodels/schemas/cube.schema.yaml
@@ -1,5 +1,6 @@
 allOf:
 - $ref: core.schema.yaml
+- $ref: bunit.schema.yaml
 - type: object
   properties:
     data:

--- a/jwst/datamodels/schemas/ifucube.schema.yaml
+++ b/jwst/datamodels/schemas/ifucube.schema.yaml
@@ -1,5 +1,6 @@
 allOf:
 - $ref: core.schema.yaml
+- $ref: bunit.schema.yaml
 - type: object
   properties:
     meta:

--- a/jwst/datamodels/schemas/image.schema.yaml
+++ b/jwst/datamodels/schemas/image.schema.yaml
@@ -1,5 +1,6 @@
 allOf:
 - $ref: core.schema.yaml
+- $ref: bunit.schema.yaml
 - type: object
   properties:
     data:

--- a/jwst/datamodels/schemas/miri_ramp.schema.yaml
+++ b/jwst/datamodels/schemas/miri_ramp.schema.yaml
@@ -1,5 +1,6 @@
 allOf:
 - $ref: core.schema.yaml
+- $ref: bunit.schema.yaml
 - type: object
   properties:
     data:

--- a/jwst/datamodels/schemas/multislit.schema.yaml
+++ b/jwst/datamodels/schemas/multislit.schema.yaml
@@ -1,5 +1,6 @@
 allOf:
 - $ref: core.schema.yaml
+- $ref: bunit.schema.yaml
 - type: object
   properties:
     slits:

--- a/jwst/datamodels/schemas/quad.schema.yaml
+++ b/jwst/datamodels/schemas/quad.schema.yaml
@@ -1,5 +1,6 @@
 allOf:
 - $ref: core.schema.yaml
+- $ref: bunit.schema.yaml
 - type: object
   properties:
     data:

--- a/jwst/datamodels/schemas/ramp.schema.yaml
+++ b/jwst/datamodels/schemas/ramp.schema.yaml
@@ -1,5 +1,6 @@
 allOf:
 - $ref: core.schema.yaml
+- $ref: bunit.schema.yaml
 - type: object
   properties:
     data:

--- a/jwst/photom/photom.py
+++ b/jwst/photom/photom.py
@@ -347,6 +347,10 @@ class DataSet(object):
             # Retrieve the scalar conversion factor from the reference data
             conv_factor = ftab.meta.photometry.conversion_megajanskys
 
+            # Update BUNIT values for the science data and err
+            self.input.meta.bunit_data = 'mJy/arcsec^2'
+            self.input.meta.bunit_err = 'mJy/arcsec^2'
+
         if conv_factor is not None:
             return float(conv_factor)
         else:


### PR DESCRIPTION
Adding BUNIT keywords in the extension headers of science data models that use "data (SCI)" and "err (ERR)" arrays. Also updated the MIRI MRS portion of the photom step to update the BUNIT values after applying the new flux calibration scheme to the data (see #611 and #694).

The BUNIT keyword definitions can't belong to the core schema, because that's currently inherited by all data models, even those that don't use "SCI" and "ERR" extensions in their products. Including them in the core causes empty SCI and ERR extensions to be created in those FITS products, just so the BUNIT keyword value can be recorded. So I've put the definitions, for now, in a separate schema file ("bunit.schema.yaml"), which is then imported into the half-dozen or so science data model schemas in which they're needed.

This is a work in progress and is subject to revision, especially with regard to #697. Comments or suggestions about any aspect of this are welcome.