### PR TITLE
Add NullHandler to loggers

### DIFF
--- a/jwst/datamodels/dynamicdq.py
+++ b/jwst/datamodels/dynamicdq.py
@@ -5,6 +5,7 @@ from . import dqflags
 import logging
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
+log.addHandler(logging.NullHandler())
 
 def dynamic_mask(input_model):
     #

--- a/jwst/datamodels/fits_support.py
+++ b/jwst/datamodels/fits_support.py
@@ -31,6 +31,7 @@ from . import util
 import logging
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
+log.addHandler(logging.NullHandler())
 
 
 __all__ = ['to_fits', 'from_fits', 'fits_hdu_name', 'get_hdu']

--- a/jwst/datamodels/properties.py
+++ b/jwst/datamodels/properties.py
@@ -20,6 +20,7 @@ from . import util
 import logging
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
+log.addHandler(logging.NullHandler())
 
 __all__ = ['ObjectNode', 'ListNode']
 

--- a/jwst/datamodels/util.py
+++ b/jwst/datamodels/util.py
@@ -14,6 +14,7 @@ from jwst.associations import AssociationError
 import logging
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
+log.addHandler(logging.NullHandler())
 
 
 def open(init=None, extensions=None, **kwargs):


### PR DESCRIPTION
This suppresses a warning message about no handler found when running tests.