### PR TITLE
Fix photom handling of MIRI MRS ref file flags

### DIFF
--- a/jwst/photom/photom.py
+++ b/jwst/photom/photom.py
@@ -316,7 +316,7 @@ class DataSet(object):
 
             # Reset conversion and pixel size values with DQ=NON_SCIENCE to 1,
             # so no conversion is applied
-            where_bad = np.bitwise_and(ftab.dq, dqflags.pixel['NON_SCIENCE'])
+            where_bad = np.where(ftab.dq == dqflags.pixel['NON_SCIENCE'])
             ftab.data[where_bad] = 1.0
             ftab.pixsiz[where_bad] = 1.0
 

--- a/jwst/photom/photom.py
+++ b/jwst/photom/photom.py
@@ -316,9 +316,9 @@ class DataSet(object):
 
             # Reset conversion and pixel size values with DQ=NON_SCIENCE to 1,
             # so no conversion is applied
-            where_bad = np.where(ftab.dq == dqflags.pixel['NON_SCIENCE'])
-            ftab.data[where_bad] = 1.0
-            ftab.pixsiz[where_bad] = 1.0
+            where_dq = np.bitwise_and(ftab.dq, dqflags.pixel['NON_SCIENCE'])
+            ftab.data[where_dq > 0] = 1.0
+            ftab.pixsiz[where_dq > 0] = 1.0
 
             # Reset NaN's in conversion array to 1
             where_nan = np.isnan(ftab.data)


### PR DESCRIPTION
There is a flaw in the logic in the new MRS portion of the calc_miri function in the photom step where pixels flagged as 'NON_SCIENCE' in the reference file DQ array are used to reset the reference data arrays to 1. The flawed logic was inadvertently using the flag value of 512 to reset pixel values in line 512 of the data arrays. The numpy "where" logic has been fixed to handle this properly. 