### PR TITLE
Don't use order for NIRISS imaging-mode photom

### DIFF
--- a/docs/photom/source/main.rst
+++ b/docs/photom/source/main.rst
@@ -3,28 +3,38 @@ Description
 
 The photom step loads information into a data product that allows for the
 conversion of count rates to absolute flux units. The flux conversion
-information is read from the photometric reference table. The exact nature
-of the information that's stored in the reference table and loaded into the
-science data product depends on the observing mode.
+information is read from the photometric reference file. The exact nature
+of the information that's stored in the reference file and loaded into the
+science data product depends on the instrument mode.
 
-The photom reference table contains one row of information for each
-combination of exposure parameters that defines a particular observing mode,
+For most instrument modes the photom reference file contains a table of
+exposure parameters that define various observing modes and the flux
+conversion data for each of those modes. The table contains one row for each
+allowed combination of exposure parameters,
 such as detector, filter, pupil, and grating. The photom step searches the
-reference table for the row that matches the parameters of the exposure and
-then copies the information from that table row into the science product.
+table for the row that matches the parameters of the science exposure and
+then copies the calibration information from that table row into the science
+product.
 
-The flux conversion information in each table row includes a scalar conversion
+For the MIRI MRS mode, the photom reference file contains arrays of sensitivity
+factors and pixel sizes that are copied into the science product and also
+applied to the SCI and ERR arrays of the science product.
+
+For the table-based reference files, the calibration information in each row
+includes a scalar conversion
 constant, as well as optional arrays of wavelength and relative response
 (as a function of wavelength). The scalar conversion constant in a selected
 table row is copied into the keyword PHOTMJSR in the primary header of the
 science product. The value of PHOTMJSR can then be used to convert data from
-units of counts/sec to MJy/steradian. The step also computes, on the fly,
+units of DN/sec to MJy/steradian. The step also computes, on the fly,
 the equivalent conversion factor for converting the data to units of
 microJy/square-arcsecond and stores this value in the header keyword PHOTUJA2.
 
 If the photom step finds that the wavelength and relative response arrays are
-populated in the selected row, it copies those arrays to a table extension
-called "RELSENS" in the science data product.
+populated in the selected table row, it copies those arrays to a table extension
+called "RELSENS" in the science data product. For the MIRI MRS mode, the
+sensitivity factors and pixel size arrays are multiplied together and copied to
+an image extension called "RELSENS2D" in the science data product.
 
 For multiple-integration datasets, the photom step can take either of these as 
 input: a dataset containing the slope results for each integration in the 
@@ -33,16 +43,16 @@ of averaging over all integrations.
 
 Finally, if the science data are from an imaging mode, which is determined
 from the value of the EXP_TYPE keyword, the data from a pixel area map
-reference file will also be loaded into the science data product. The 2-D
+reference file will also be loaded into the science data product. The 2D
 data array from the pixel area map will be copied into an image extension
 called "AREA" in the science data product. For imaging mode exposures, the
 values of the PIXAR_SR and PIXAR_A2 keywords in the photom reference table
 will also be copied into keywords of the same name in the primary header of
 the science data product.
 
-Note that throughout all of this process the pixel values of the science data
-product are not actually changed. All of the reference data is simply attached
-to the science data product in some way.
+Note that, except for MIRI MRS exposures, the pixel values of the science data
+product are not actually changed by the photom step. All of the reference data
+is simply attached to the science data product in some way.
 
 Upon successful completion of this step, the status keyword S_PHOTOM will be
 set to COMPLETE.

--- a/docs/photom/source/reference_files.rst
+++ b/docs/photom/source/reference_files.rst
@@ -10,10 +10,10 @@ Selection criteria for photom reference files varies a bit from instrument
 to instrument:
 
 * FGS: Instrument and Detector
-* MIRI: Instrument and Detector
+* MIRI: Instrument, Detector, and Band
 * NIRCam: Instrument and Detector
 * NIRISS: Instrument and Detector
-* NIRSpec: Instrument and EXP_TYPE
+* NIRSpec: Instrument and Exp_type
 
 A row of data within the table that matches the mode of the science exposure
 is selected by the photom step based on criteria that are instrument mode
@@ -21,23 +21,28 @@ dependent. The current row selection criteria are:
 
 * FGS: No selection criteria (table contains a single row)
 * MIRI:
-   - Imager: Filter and Subarray
-   - IFUs: Band
+   - Imager (includes LRS): Filter and Subarray
+   - MRS: Does not use table-based reference file
 * NIRCam: Filter and Pupil
-* NIRISS: Filter, Pupil, and Order number
+* NIRISS:
+   - Imaging: Filter and Pupil
+   - Spectroscopic: Filter, Pupil, and Order number
 * NIRSpec:
    - Fixed Slits: Filter, Grating, and Slit name
    - IFU and MSA: Filter and Grating
 
 PHOTOM Reference File Format
 ----------------------------
-Photom reference files are FITS format with a single BINTABLE extension.  The
-primary data unit is always empty.  The columns of the table vary with 
-instrument according to the selection criteria listed above. The first few
-columns always correspond to the selection criteria, such as Filter and
+Photom reference files are FITS format with an empty primary data unit.
+The table-based photom files used for all instruments modes other than
+MIRI MRS have a single TABLE extension.
+The columns of the table vary with 
+instrument mode according to the selection criteria listed above. The first few
+columns always correspond to the row selection criteria, such as Filter and
 Pupil, or Filter and Grating. The remaining columns contain the data relevant
 to the photometric conversion and consist of PHOTMJSR, UNCERTAINTY, NELEM,
-WAVELENGTH, and RELRESPONSE.
+WAVELENGTH, and RELRESPONSE. The table column names and data types are
+listed below.
 
 * FILTER (string) - MIRI, NIRCam, NIRISS, NIRSpec
 * PUPIL (string) - NIRCam, NIRISS
@@ -45,17 +50,40 @@ WAVELENGTH, and RELRESPONSE.
 * GRATING (string) - NIRSpec
 * SLIT (string) - NIRSpec Fixed-Slit
 * SUBARRAY (string) - MIRI Imager/LRS
-* BAND (string) - MIRI MRS
 * PHOTMJSR (float) - all instruments
 * UNCERTAINTY (float) - all instruments
 * NELEM (int) - if NELEM > 0, then NELEM entries are read from each of the
   WAVELENGTH and RELRESPONSE arrays
-* WAVELENGTH (float 1-D array)
-* RELRESPONSE (float 1-D array)
+* WAVELENGTH (float 1D array)
+* RELRESPONSE (float 1D array)
 
 The primary header of the photom reference file contains the keywords PIXAR_SR
 and PIXAR_A2, which give the average pixel area in units of steradians and
 square arcseconds, respectively.
+
+The MIRI MRS photom reference files contain the following FITS extensions:
+
+* SCI  IMAGE  2D float
+* ERR  IMAGE  2D float
+* DQ   IMAGE  2D unsigned-integer
+* DQ_DEF  TABLE
+* PIXSIZ  IMAGE  2D float
+
+The SCI extension contains a 2D array of spectral sensitivity factors
+corresponding to each pixel in a 2D MRS slice image. The sensitivity factors
+are in units of DN/sec/mJy/pixel. The ERR extension contains a 2D array of
+uncertainties for the SCI values, in the same units. The DQ extension
+contains a 2D array of bit-encoded data quality flags for the SCI values.
+The DQ_DEF extension contains a table listing the definitions of the values
+used in the DQ array. The PIXSIZ extension contains a 2D array of pixel
+sizes, in units of square-arcsec.
+
+The SCI and PIXSIZ array values are both divided into the science product
+SCI and ERR arrays, yielding image pixels that are units of mJy/sq-arcsec.
+
+Scalar PHOTMJSR and PHOTUJA2 values are stored in primary header keywords
+in the MIRI MRS photom reference files and are copied into the science
+product header by the photom step.
 
 AREA CRDS Selection Criteria
 ------------------------------

--- a/jwst/photom/photom.py
+++ b/jwst/photom/photom.py
@@ -237,20 +237,32 @@ class DataSet(object):
 
         # Simple ImageModels
         else:
+
+            # Hardwire the science data order number to 1 for now
             order = 1
 
             # Locate matching row in reference file
             for tabdata in ftab.phot_table:
-
                 ref_filter = tabdata['filter'].strip().upper()
                 ref_pupil = tabdata['pupil'].strip().upper()
                 ref_order = tabdata['order']
 
-                # Find matching values of FILTER, PUPIL, ORDER
-                if (self.filter == ref_filter and self.pupil == ref_pupil
-                    and order == ref_order):
-                    conv_factor = self.photom_io(tabdata)
-                    break
+                # Spectroscopic mode
+                if self.exptype in ['NIS_SOSS', 'NIS_WFSS']:
+
+                    # Find matching values of FILTER, PUPIL, and ORDER
+                    if (self.filter == ref_filter and self.pupil == ref_pupil
+                        and order == ref_order):
+                        conv_factor = self.photom_io(tabdata)
+                        break
+
+                # Imaging mode
+                else:
+
+                    # Find matching values of FILTER and PUPIL
+                    if (self.filter == ref_filter and self.pupil == ref_pupil):
+                        conv_factor = self.photom_io(tabdata)
+                        break
 
             if conv_factor is not None:
                 return float(conv_factor)


### PR DESCRIPTION
The NIRISS function in the photom step has been updated to fix the issue described in #677. Briefly, the function now only uses Order as a photom table row selector for the NIRISS spectral modes and does not use it for NIRISS imaging mode exposures.

The photom step docs have been updated to account for this change, as well as updates to the photom step handling for MIRI MRS mode.