### PR TITLE
Keyword was being compared with lower-case value; see issue #710.

### DIFF
--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -1084,7 +1084,7 @@ def do_extract1d(input_model, refname, smoothing_length, bkg_order):
         elif isinstance(input_model, datamodels.IFUCubeModel):
 
             try:
-                source_type = input_model.meta.target.source_type
+                source_type = input_model.meta.target.source_type.lower()
             except AttributeError:
                 source_type = "unknown"
             output_model = ifu.ifu_extract1d(input_model, refname, source_type)

--- a/jwst/extract_1d/ifu.py
+++ b/jwst/extract_1d/ifu.py
@@ -220,6 +220,10 @@ def extract_ifu(input_model, source_type, extract_params):
             if outer_bkg is None:
                 outer_bkg = min(inner_bkg * math.sqrt(2.),
                                 smaller_axis / 2. - 1.)
+            if inner_bkg <= 0. or outer_bkg <= 0. or inner_bkg >= outer_bkg:
+                log.debug("Turning background subtraction off, due to "
+                          "the values of inner_bkg and outer_bkg.")
+                subtract_background = False
         width = None
         height = None
         theta = None
@@ -232,11 +236,9 @@ def extract_ifu(input_model, source_type, extract_params):
             height = smaller_axis / 2.
         theta = extract_params['theta'] * math.pi / 180.
         radius = None
+        subtract_background = False
         inner_bkg = None
         outer_bkg = None
-
-    if inner_bkg <= 0. or outer_bkg <= 0. or inner_bkg >= outer_bkg:
-        subtract_background = False
 
     log.debug("IFU 1-D extraction parameters:")
     log.debug("  x_center = %s", str(x_center))


### PR DESCRIPTION
For IFU data, keyword SRCTYPE is read to determine whether the target
is a point source or extended.  The keyword values were assumed to be
either "point" or "extended"; they are, but upper case.

For an extended source with the IFU, background subtraction is not
supposed to be done.  The code now explicitly turns off background
subtraction for IFU data.