### PR TITLE
Photom update for AREA=N/A

### DIFF
--- a/jwst/photom/photom.py
+++ b/jwst/photom/photom.py
@@ -626,7 +626,7 @@ class DataSet(object):
             conv_factor = 0.0
 
         if area_fname is not None: # Load and save the pixel area info
-            if 'IMAGE' in self.exptype:
+            if 'IMAGE' in self.exptype and area_fname != 'N/A':
                 result = self.save_area_info(ftab, area_fname)
 
         # Store the conversion factors in the meta data


### PR DESCRIPTION
Encountered a NIRCam case from exp_type=NRC_TSIMAGE that did not have a valid AREA reference file in CRDS, which led to an error when save_area_info tried to open a file called 'N/A'. Added check for 'N/A' in the value of the area ref file name before calling save_area_info.