### PR TITLE
Updates to skymatch docs

### DIFF
--- a/docs/skymatch/source/index.rst
+++ b/docs/skymatch/source/index.rst
@@ -1,16 +1,16 @@
-Welcome to skymatch documentation!
-==================================
+JWST Science Calibration Pipeline: Sky Matching
+================================================
 
 Contents:
 
 .. toctree::
    :maxdepth: 2
 
+   skymatch_step
    skymatch
    skyimage
-   region
    skystatistics
-   skymatch_step
+   region
 
 Indices and tables
 ==================

--- a/docs/skymatch/source/skyimage.rst
+++ b/docs/skymatch/source/skyimage.rst
@@ -1,5 +1,5 @@
 ***************************************************************
-SkyImage (chip outline on the sky) management for image mosaic.
+SkyImage (chip outline on the sky) management for image mosaic
 ***************************************************************
 
 .. moduleauthor:: Mihai Cara <help@stsci.edu>

--- a/docs/skymatch/source/skymatch.rst
+++ b/docs/skymatch/source/skymatch.rst
@@ -1,6 +1,6 @@
-******************************
-Sky matching for image mosaic.
-******************************
+********************************
+Sky matching for an image mosaic
+********************************
 
 .. moduleauthor:: Mihai Cara <help@stsci.edu>
 

--- a/docs/skymatch/source/skymatch_step.rst
+++ b/docs/skymatch/source/skymatch_step.rst
@@ -1,6 +1,15 @@
 *****************************************************
-JWST pipeline step for sky matching for image mosaic.
+JWST skymatch pipeline step 
 *****************************************************
+
+Description
+===========
+
+The skymatch step compares the signal levels in the overlap regions
+of a set of images and computes the signal offsets for each image
+that will minimize the residuals across the entire set. By default
+the sky value computed for each image is recorded, but not actually
+subtracted from the images.
 
 .. moduleauthor:: Mihai Cara <help@stsci.edu>
 

--- a/docs/skymatch/source/skystatistics.rst
+++ b/docs/skymatch/source/skystatistics.rst
@@ -1,6 +1,6 @@
-************************************
-Sky statistics functions for skypac.
-************************************
+*************************************
+Sky statistics functions for skymatch
+*************************************
 
 .. moduleauthor:: Mihai Cara <help@stsci.edu>
 


### PR DESCRIPTION
A few minor updates to skymatch docs, including fixing the file name of "skimage.rst" to "skyimage.rst". This is the first round of updates needed for skymatch docs so that they include more user-level descriptive information, as is done for other pipeline step docs.