### PR TITLE
Set validate flag to True

### DIFF
--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -156,7 +156,7 @@ class DataModel(properties.ObjectNode):
             else:
                 asdf = fits_support.from_fits(hdulist, self._schema,
                                               extensions=self._extensions,
-                                              validate=False,
+                                              validate=True,
                                               pass_invalid_values=self._pass_invalid_values)
                 self._files_to_close.append(hdulist)
         else:


### PR DESCRIPTION
The validate flag controls whether a warning message is sent when a
fits keyword fails to validate. It was changed from False, as CRDS
relies on the validation.