### PR TITLE
ModelContainer grouping

### DIFF
--- a/jwst/datamodels/container.py
+++ b/jwst/datamodels/container.py
@@ -247,8 +247,8 @@ class ModelContainer(model_base.DataModel):
                                 model_attrs[8].lower()]))
                 model.meta.group_id = group_id
             except:
-                w = 'One or more datamodels is missing correct metadata. ' + \
-                    'Grouping will not be correct.'
+                w = '`{}` is missing'.format(model.meta.filename) + \
+                    ' metadata. Grouping by exposure may not be correct.'
                 warnings.warn(w, RuntimeWarning, stacklevel=2)
                 model.meta.group_id = None
 

--- a/jwst/datamodels/container.py
+++ b/jwst/datamodels/container.py
@@ -22,20 +22,26 @@ class ModelContainer(model_base.DataModel):
     """
     A container for holding DataModels.
 
+    This functions like a list for holding DataModel objects.  It can be
+    iterated through like a list, DataModels within the container can be
+    addressed by index, and the datamodels can be grouped into a list of
+    lists for grouped looping, useful for NIRCam where grouping together
+    all detectors of a given exposure is useful for some pipeline steps.
+
     Parameters
     ----------
     init : file path, list of DataModels, or None
 
         - file path: initialize from an association table
 
-        - list: a list of any DataModel models
+        - list: a list of DataModels of any type
 
         - None: initializes an empty `ModelContainer` instance, to which
-          DataModel models can added via the ``append()`` method.
+          DataModels can added via the ``append()`` method.
 
     Examples
     --------
-    >>> c = ModelContainer('example_asn.json')
+    >>> c = datamodels.ModelContainer('example_asn.json')
     >>> c[0]    # the first DataModel in the container
     >>> c.models_grouped    # a list of the DataModels grouped by exposure
     """
@@ -146,7 +152,7 @@ class ModelContainer(model_base.DataModel):
         Parameters
         ----------
         filepath : str
-            The path to an ASN file.
+            The path to an association file.
         """
 
         filepath = op.abspath(op.expanduser(op.expandvars(filepath)))
@@ -203,23 +209,17 @@ class ModelContainer(model_base.DataModel):
             result.append(group[0].meta.group_id)
         return result
 
-    def save(self, filename_not_used, path=None, *args, **kwargs):
+    def save(self, path=None, *args, **kwargs):
         """
         Write out models in container to FITS or ASDF.
 
         Parameters
         ----------
 
-        filename_not_used : string
-            this first argument is ignored in this implementation of the
-            save method.  It is used by the pipeline steps to save individual
-            files, but that is not applicable here.  Instead, we use the path
-            arg below and read the filename output from the meta tag in each
-            file in the container.
-
         path : string
-            directory to write out files.  Defaults to current working dir.
-            If directory does not exist, it creates it.
+            Directory to write out files.  Defaults to current working dir.
+            If directory does not exist, it creates it.  Filenames are pulled
+            from `.meta.filename` of each datamodel in the container.
         """
         if path is None:
             path = os.getcwd()

--- a/jwst/datamodels/tests/test_models.py
+++ b/jwst/datamodels/tests/test_models.py
@@ -375,11 +375,11 @@ def test_image_with_extra_keyword_to_multislit():
 def container():
     with ModelContainer(ASN_FILE) as c:
         for m in c:
-            m.meta.observation.program_number = '1'
+            m.meta.observation.program_number = '0001'
             m.meta.observation.observation_number = '1'
             m.meta.observation.visit_number = '1'
             m.meta.observation.visit_group = '1'
-            m.meta.observation.sequence_id = '1'
+            m.meta.observation.sequence_id = '01'
             m.meta.observation.activity_id = '1'
             m.meta.observation.exposure_number = '1'
             m.meta.instrument.name = 'NIRCAM'
@@ -396,11 +396,24 @@ def test_modelcontainer_indexing(container):
     assert isinstance(container[0], DataModel)
 
 
-def test_modelcontainer_grouping(container):
+def test_modelcontainer_group1(container):
     for group in container.models_grouped:
+        assert len(group) == 2
         for model in group:
-            assert isinstance(model, DataModel)
+            pass
+
+
+def test_modelcontainer_group2(container):
+    container[0].meta.observation.exposure_number = '2'
+    for group in container.models_grouped:
+        assert len(group) == 1
+        for model in group:
+            pass
+    container[0].meta.observation.exposure_number = '1'
 
 
 def test_modelcontainer_group_names(container):
-    pass
+    assert len(container.group_names) == 1
+    container[0].meta.observation.exposure_number = '2'
+    assert len(container.group_names) == 2
+    container[0].meta.observation.exposure_number = '1'

--- a/jwst/datamodels/tests/test_models.py
+++ b/jwst/datamodels/tests/test_models.py
@@ -19,22 +19,19 @@ import numpy as np
 from numpy.testing.decorators import knownfailureif
 from numpy.testing import assert_array_equal
 
-from .. import DataModel, ImageModel, QuadModel, MultiSlitModel, open
+from .. import (DataModel, ImageModel, QuadModel, MultiSlitModel,
+                ModelContainer)
+from ..util import open
 from .. import schema
 
 
-FITS_FILE = None
-TMP_FITS = None
-TMP_YAML = None
-TMP_JSON = None
-TMP_DIR = None
-TMP_FITS2 = None
+ROOT_DIR = os.path.join(os.path.dirname(__file__), 'data')
+FITS_FILE = os.path.join(ROOT_DIR, 'test.fits')
+ASN_FILE = os.path.join(ROOT_DIR, 'association.json')
 
 
 def setup():
     global FITS_FILE, TMP_DIR, TMP_FITS, TMP_YAML, TMP_JSON, TMP_FITS2
-    ROOT_DIR = os.path.join(os.path.dirname(__file__), 'data')
-    FITS_FILE = os.path.join(ROOT_DIR, 'test.fits')
 
     TMP_DIR = tempfile.mkdtemp()
     TMP_FITS = os.path.join(TMP_DIR, 'tmp.fits')
@@ -372,3 +369,38 @@ def test_image_with_extra_keyword_to_multislit():
         assert len(ms.slits) == 3
         for slit in ms.slits:
             assert slit.data.shape == (4, 4)
+
+
+@pytest.fixture(scope="module")
+def container():
+    with ModelContainer(ASN_FILE) as c:
+        for m in c:
+            m.meta.observation.program_number = '1'
+            m.meta.observation.observation_number = '1'
+            m.meta.observation.visit_number = '1'
+            m.meta.observation.visit_group = '1'
+            m.meta.observation.sequence_id = '1'
+            m.meta.observation.activity_id = '1'
+            m.meta.observation.exposure_number = '1'
+            m.meta.instrument.name = 'NIRCAM'
+            m.meta.instrument.channel = 'SHORT'
+        yield c
+
+
+def test_modelcontainer_iteration(container):
+    for model in container:
+        assert model.meta.filename == 'test.fits'
+
+
+def test_modelcontainer_indexing(container):
+    assert isinstance(container[0], DataModel)
+
+
+def test_modelcontainer_grouping(container):
+    for group in container.models_grouped:
+        for model in group:
+            assert isinstance(model, DataModel)
+
+
+def test_modelcontainer_group_names(container):
+    pass

--- a/jwst/resample/resample_step.py
+++ b/jwst/resample/resample_step.py
@@ -32,7 +32,8 @@ class ResampleStep(Step):
     def process(self, input):
 
         input_models = datamodels.open(input)
-        if type(input_models) != type(datamodels.ModelContainer()): # single exposure
+        # If single input, insert into a ModelContainer
+        if input_models.__class__ is not datamodels.ModelContainer:
             s = datamodels.ModelContainer()
             s.append(input_models)
             s.assign_group_ids()


### PR DESCRIPTION
This PR makes grouping more robust.

- No more unexpected grouping based on filename
- Grouping is strictly done based on `meta` keywords of input datamodels, i.e. for what we expect from NIRCam data
- Warnings are produced if the `meta` keywords are not populated
- Several new unit tests now test ModelContainer generally and grouping specifically