### PR TITLE
Make calwebb_spec2 skip non-science members

### DIFF
--- a/jwst/pipeline/calwebb_spec2.py
+++ b/jwst/pipeline/calwebb_spec2.py
@@ -71,7 +71,13 @@ class Spec2Pipeline(Pipeline):
         for member in input_table.asn['members']:
 
             input_file = member['expname']
-            self.log.info(' Working on input %s ...', input_file)
+
+            # Skip processing of non-science members
+            if member['exptype'].upper() != 'SCIENCE':
+                self.log.info('Skipping non-science input %s', input_file)
+                continue
+
+            self.log.info('Working on input %s ...', input_file)
             input = datamodels.open(input_file)
             exp_type = input.meta.exposure.type
 
@@ -208,7 +214,7 @@ class Spec2Pipeline(Pipeline):
             x1d_output.close()
 
         # We're done
-        log.info('... ending calwebb_spec2')
+        log.info('Ending calwebb_spec2')
 
         return
 


### PR DESCRIPTION
Modified the calwebb_spec2 pipeline to skip processing for non-science members listed in the association table, in order to accommodate entries for things like target acq's and NIRSpec autowave and autoflat exposures, which get listed in the ASN, but don't need processing (at least not yet).

Fixes #382.