### PR TITLE
New twopoint_difference routine from M. Regan

### DIFF
--- a/jwst/jump/tests/test_twopoint_difference.py
+++ b/jwst/jump/tests/test_twopoint_difference.py
@@ -424,6 +424,6 @@ def setup_cube(ngroups,readnoise=10):
     return data, gdq, nframes, read_noise, rej_threshold
 
 
-if __name__ == '__main__':
-    pytest.main(['-x', 'test_find_CRs_mwr.py'])
+#if __name__ == '__main__':
+#    pytest.main(['-x', 'test_find_CRs_mwr.py'])
 #   # pytest.main(['test_find_CRs_mwr.py'])

--- a/jwst/jump/tests/test_twopoint_difference.py
+++ b/jwst/jump/tests/test_twopoint_difference.py
@@ -1,0 +1,429 @@
+from ..twopoint_difference import find_CRs
+import numpy as np
+import pytest
+from ...datamodels import dqflags
+
+#@pytest.mark.skip(reason="testing skipping")
+def test_noCRs_NoFlux():
+    ngroups=5
+    data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups)
+    assert(0 == np.max(find_CRs(data,gdq,read_noise,rej_threshold,nframes))) # no CR found
+
+#@pytest.mark.skip
+def test_5grps_cr3_NoFlux():
+    ngroups=5
+    data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups)
+
+    data[0, 0:2, 100, 100] = 10.0
+    data[0, 2:5, 100, 100] = 1000
+    medianDiff = find_CRs(data, gdq, read_noise, rej_threshold, nframes)
+    assert(4 == np.max(gdq)) #a CR was found
+    assert(2 == np.argmax(gdq[0,:,100,100])) #find the CR in the expected group
+
+#@pytest.mark.skip("testing skipping")
+def test_5grps_cr2_NoFlux():
+    ngroups=5
+    data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups)
+
+    data[0, 0, 100, 100] = 10.0
+    data[0, 1:6, 100, 100] = 1000
+    medianDiff = find_CRs(data, gdq, read_noise, rej_threshold, nframes)
+    assert(4 == np.max(gdq)) #a CR was found
+    assert(1 == np.argmax(gdq[0,:,100,100])) #find the CR in the expected group
+
+#@pytest.mark.skip("testing skipping")
+def test_5grps_cr2_NegJumpFlux():
+    ngroups=5
+    data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups)
+
+    data[0, 0, 100, 100] = 1000.0
+    data[0, 1:6, 100, 100] = 10
+    medianDiff = find_CRs(data, gdq, read_noise, rej_threshold, nframes)
+    assert(4 == np.max(gdq)) #a CR was found
+    assert(1 == np.argmax(gdq[0,:,100,100])) #find the CR in the expected group
+
+#@pytest.mark.skip("testing skipping")
+def test_3grps_cr2_NoFlux():
+    ngroups=3
+    data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups)
+    data[0, 0, 100, 100] = 10.0
+    data[0, 1:4, 100, 100] = 1000
+    print("test data "+repr(data[0,:,100,100]))
+    medianDiff = find_CRs(data, gdq, read_noise, rej_threshold, nframes)
+    print(repr(gdq[0, :, 100, 100]))
+    print("calculated median diff of pixel is ", medianDiff[0, 100, 100])
+    assert(4 == np.max(gdq)) #a CR was found
+    #    assert(1,np.argmax(gdq[0,:,100,100])) #find the CR in the expected group
+    assert(np.array_equal([0, 4, 0], gdq[0, :, 100, 100]))
+
+
+#@pytest.mark.skip("testing skipping")
+def test_4grps_cr2_NoFlux():
+    ngroups=4
+    data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups)
+    data[0, 0, 100, 100] = 10.0
+    data[0, 1:4, 100, 100] = 1000
+    medianDiff = find_CRs(data, gdq, read_noise, rej_threshold, nframes)
+    assert(4 == np.max(gdq)) #a CR was found
+    assert(1 == np.argmax(gdq[0,:,100,100])) #find the CR in the expected group
+
+#@pytest.mark.skip("testing skipping")
+def test_5grps_cr2_nframe2():
+    ngroups=5
+    data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups)
+    nframes=2
+    data[0, 0, 100, 100] = 10.0
+    data[0, 1, 100, 100] = 500
+    data[0, 2, 100, 100] = 1002
+    data[0, 3, 100, 100] = 1001
+    data[0, 4, 100, 100] = 1005
+    medianDiff = find_CRs(data, gdq, read_noise, rej_threshold, nframes)
+    print("calculated median diff of pixel is ", medianDiff[0, 100, 100])
+    print(repr(gdq[0, :, 100, 100]))
+    assert(4 == np.max(gdq)) #a CR was found
+    assert(np.array_equal([0,4,4,0,0], gdq[0, :, 100, 100]) )
+
+@pytest.mark.xfail
+def test_4grps_twocrs_2nd_4th():
+    ngroups=4
+    data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups)
+    nframes=1
+    data[0, 0, 100, 100] = 10.0
+    data[0, 1, 100, 100] = 60
+    data[0, 2, 100, 100] = 60
+    data[0, 3, 100, 100] = 115
+    medianDiff = find_CRs(data, gdq, read_noise, rej_threshold, nframes)
+    print("calculated median diff of pixel is ", medianDiff[0, 100, 100])
+    print(repr(gdq[0, :, 100, 100]))
+    assert(4 == np.max(gdq)) #a CR was found
+    assert(np.array_equal([0,4,0,4] , gdq[0, :, 100, 100]) )
+
+#@pytest.mark.skip("testing skipping")
+def test_5grps_twocrs_2nd_5th():
+    ngroups=5
+    data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups)
+    nframes=1
+    data[0, 0, 100, 100] = 10.0
+    data[0, 1, 100, 100] = 60
+    data[0, 2, 100, 100] = 60
+    data[0, 3, 100, 100] = 60
+    data[0, 4, 100, 100] = 115
+    medianDiff = find_CRs(data, gdq, read_noise, rej_threshold, nframes)
+    print("calculated median diff of pixel is ", medianDiff[0, 100, 100])
+    assert(4 == np.max(gdq)) #a CR was found
+    assert(np.array_equal([0,4,0,0,4] ,gdq[0, :, 100, 100]) )
+
+#@pytest.mark.skip("testing skipping")
+def test_5grps_twocrs_2nd_5thbig():
+    ngroups=5
+    data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups)
+    nframes=1
+    data[0, 0, 100, 100] = 10.0
+    data[0, 1, 100, 100] = 60
+    data[0, 2, 100, 100] = 60
+    data[0, 3, 100, 100] = 60
+    data[0, 4, 100, 100] = 2115
+    medianDiff = find_CRs(data, gdq, read_noise, rej_threshold, nframes)
+    print("calculated median diff of pixel is ", medianDiff[0, 100, 100])
+    assert(4 == np.max(gdq)) #a CR was found
+    assert(np.array_equal([0,4,0,0,4] , gdq[0, :, 100, 100]) )
+
+#@pytest.mark.skip("testing skipping")
+def test_10grps_twocrs_2nd_8th_big():
+    ngroups=10
+    data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups)
+    nframes=1
+    data[0, 0, 100, 100] = 10.0
+    data[0, 1, 100, 100] = 60
+    data[0, 2, 100, 100] = 60
+    data[0, 3, 100, 100] = 60
+    data[0, 4, 100, 100] = 60
+    data[0, 5, 100, 100] = 60
+    data[0, 6, 100, 100] = 60
+    data[0, 7, 100, 100] = 2115
+    data[0, 8, 100, 100] = 2115
+    data[0, 9, 100, 100] = 2115
+    medianDiff = find_CRs(data, gdq, read_noise, rej_threshold, nframes)
+    print("calculated median diff of pixel is ", medianDiff[0, 100, 100])
+    assert(4 == np.max(gdq)) #a CR was found
+    assert(np.array_equal([0,4,0,0,0,0,0,4,0,0] , gdq[0, :, 100, 100]) )
+
+#@pytest.mark.skip("testing skipping")
+def test_10grps_twocrs_10percenthit():
+    ngroups=10
+    data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups)
+    nframes=2
+    data[0:200, 0, 100, 100] = 10.0
+    data[0:200, 1, 100, 100] = 60
+    data[0:200, 2, 100, 100] = 60
+    data[0:200, 3, 100, 100] = 60
+    data[0:200, 4, 100, 100] = 60
+    data[0:200, 5, 100, 100] = 60
+    data[0:200, 6, 100, 100] = 60
+    data[0:200, 7, 100, 100] = 2115
+    data[0:200, 8, 100, 100] = 2115
+    data[0:200, 9, 100, 100] = 2115
+    medianDiff = find_CRs(data, gdq, read_noise, rej_threshold, nframes)
+    print("calculated median diff of pixel is ", medianDiff[0, 100, 100])
+    assert(4 == np.max(gdq)) #a CR was found
+    assert(np.array_equal([0,4,0,0,0,0,0,4,0,0] , gdq[0, :, 100, 100]) )
+
+#@pytest.mark.skip("testing skipping")
+def test_5grps_twocrs_2nd_5thbig_nframes2():
+    ngroups=5
+    data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups,readnoise=10*np.sqrt(2))
+    nframes=2
+    data[0, 0, 100, 100] = 10.0
+    data[0, 1, 100, 100] = 60
+    data[0, 2, 100, 100] = 60
+    data[0, 3, 100, 100] = 60
+    data[0, 4, 100, 100] = 2115
+    medianDiff = find_CRs(data, gdq, read_noise, rej_threshold, nframes)
+    print("calculated median diff of pixel is ", medianDiff[0, 100, 100])
+    assert(4 == np.max(gdq)) #a CR was found
+    assert(np.array_equal([0,4,0,0,4] , gdq[0, :, 100, 100]) )
+
+
+#@pytest.mark.skip("testing skipping")
+def test_6grps_twocrs_2nd_5th():
+    ngroups=6
+    data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups)
+    nframes=1
+    data[0, 0, 100, 100] = 10.0
+    data[0, 1, 100, 100] = 60
+    data[0, 2, 100, 100] = 60
+    data[0, 3, 100, 100] = 60
+    data[0, 4, 100, 100] = 115
+    data[0, 5, 100, 100] = 115
+    medianDiff = find_CRs(data, gdq, read_noise, rej_threshold, nframes)
+    print("calculated median diff of pixel is ",medianDiff[0,100,100])
+    assert(4 == np.max(gdq)) #a CR was found
+    assert(np.array_equal([0,4,0,0,4,0] , gdq[0, :, 100, 100]) )
+
+#@pytest.mark.skip("testing skipping")
+def test_6grps_twocrs_2nd_5th_nframes2():
+    ngroups=6
+    data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups,readnoise=10*np.sqrt(2))
+    nframes=2
+    data[0, 0, 100, 100] = 10.0
+    data[0, 1, 100, 100] = 60
+    data[0, 2, 100, 100] = 60
+    data[0, 3, 100, 100] = 60
+    data[0, 4, 100, 100] = 115
+    data[0, 5, 100, 100] = 115
+    medianDiff = find_CRs(data, gdq, read_noise, rej_threshold, nframes)
+    assert(4 == np.max(gdq)) #a CR was found
+    assert(np.array_equal([0,4,0,0,4,0] , gdq[0, :, 100, 100]) )
+
+#@pytest.mark.skip("testing skipping")
+def test_6grps_twocrs_twopixels_nframes2():
+    ngroups=6
+    data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups,readnoise=10*np.sqrt(2))
+    nframes=2
+    data[0, 0, 100, 100] = 10.0
+    data[0, 1, 100, 100] = 60
+    data[0, 2, 100, 100] = 60
+    data[0, 3, 100, 100] = 60
+    data[0, 4, 100, 100] = 115
+    data[0, 5, 100, 100] = 115
+    data[0, 0, 200, 100] = 10.0
+    data[0, 1, 200, 100] = 10.0
+    data[0, 2, 200, 100] = 60
+    data[0, 3, 200, 100] = 60
+    data[0, 4, 200, 100] = 115
+    data[0, 5, 200, 100] = 115
+    medianDiff = find_CRs(data, gdq, read_noise, rej_threshold, nframes)
+    assert(4 == np.max(gdq)) #a CR was found
+    print("100 100 dq",repr(gdq[0,:,100,100]))
+    print("200 100 dq",repr(gdq[0,:,200,100]))
+    assert(np.array_equal([0,4,0,0,4,0] , gdq[0, :, 100, 100]) )
+    assert(np.array_equal([0, 0, 4, 0, 4, 0] , gdq[0, :, 200, 100]))
+
+#@pytest.mark.skip("testing skipping")
+def test_5grps_cr2_negslope():
+    ngroups = 5
+    data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups)
+    nframes = 1
+    data[0, 0, 100, 100] = 100.0
+    data[0, 1, 100, 100] = 0
+    data[0, 2, 100, 100] = -200
+    data[0, 3, 100, 100] = -260
+    data[0, 4, 100, 100] = -360
+    medianDiff = find_CRs(data, gdq, read_noise, rej_threshold, nframes)
+    print("calculated median diff of pixel is ", medianDiff[0, 100, 100])
+    assert(4 == np.max(gdq))  # a CR was found
+    assert(np.array_equal([0, 0, 4, 0, 0] , gdq[0, :, 100, 100]))
+
+def test_6grps_1CR():
+    ngroups = 6
+    data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups,readnoise=10)
+    nframes = 1
+    data[0, 0, 100, 100] = 0
+    data[0, 1, 100, 100] = 10
+    data[0, 2, 100, 100] = 21
+    data[0, 3, 100, 100] = 33
+    data[0, 4, 100, 100] = 46
+    data[0, 5, 100, 100] = 1146
+    medianDiff = find_CRs(data, gdq, read_noise, rej_threshold, nframes)
+    print("calculated median diff of pixel is ", medianDiff[0, 100, 100])
+    assert(11 == medianDiff[0, 100, 100])
+
+def test_7grps_1CR():
+    ngroups = 7
+    data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups,readnoise=10)
+    nframes = 1
+    data[0, 0, 100, 100] = 0
+    data[0, 1, 100, 100] = 10
+    data[0, 2, 100, 100] = 21
+    data[0, 3, 100, 100] = 33
+    data[0, 4, 100, 100] = 46
+    data[0, 5, 100, 100] = 60
+    data[0, 6, 100, 100] = 1160
+    medianDiff = find_CRs(data, gdq, read_noise, rej_threshold, nframes)
+    print("calculated median diff of pixel is ", medianDiff[0, 100, 100])
+    assert(11.5 == medianDiff[0, 100, 100])
+
+def test_5grps_noCR():
+    ngroups = 6
+    data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups,readnoise=10)
+    nframes = 1
+    data[0, 0, 100, 100] = 0
+    data[0, 1, 100, 100] = 10
+    data[0, 2, 100, 100] = 21
+    data[0, 3, 100, 100] = 33
+    data[0, 4, 100, 100] = 46
+    medianDiff = find_CRs(data, gdq, read_noise, rej_threshold, nframes)
+    print("calculated median diff of pixel is ", medianDiff[0, 100, 100])
+    assert(11 == medianDiff[0, 100, 100])
+
+def test_6grps_noCR():
+    ngroups = 6
+    data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups,readnoise=10)
+    nframes = 1
+    data[0, 0, 100, 100] = 0
+    data[0, 1, 100, 100] = 10
+    data[0, 2, 100, 100] = 21
+    data[0, 3, 100, 100] = 33
+    data[0, 4, 100, 100] = 46
+    data[0, 5, 100, 100] = 60
+    medianDiff = find_CRs(data, gdq, read_noise, rej_threshold, nframes)
+    print("calculated median diff of pixel is ", medianDiff[0, 100, 100])
+    assert(11.5 == medianDiff[0, 100, 100])
+
+
+#@pytest.mark.skip("testing skipping")
+def test_10grps_cr2_gt3sigma():
+    ngroups = 10
+    crmag=16
+    data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups,readnoise=5)
+    nframes = 1
+    data[0, 0, 100, 100] = 0
+    data[0, 1:11, 100, 100] = crmag
+    medianDiff = find_CRs(data, gdq, read_noise, rej_threshold, nframes)
+    assert(4 == np.max(gdq))  # a CR was found
+    assert(np.array_equal([0, 4, 0, 0, 0,0,0,0,0,0] , gdq[0, :, 100, 100]))
+
+#@pytest.mark.skip(reason="testing skipping")
+def test_10grps_cr2_3sigma_noCR():
+    ngroups = 10
+    crmag=15
+    data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups,readnoise=5)
+    nframes = 1
+    data[0, 0, 100, 100] = 0
+    data[0, 1:11, 100, 100] = crmag
+    medianDiff = find_CRs(data, gdq, read_noise, rej_threshold, nframes)
+    assert(0 == np.max(gdq))  # a CR was found
+    assert(np.array_equal([0, 0, 0, 0, 0,0,0,0,0,0] , gdq[0, :, 100, 100]))
+
+#@pytest.mark.skip(reason="testing skipping")
+def test_10grps_cr2_gt3sigma_2frames():
+    ngroups = 10
+    crmag=16
+    data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups,readnoise=5*np.sqrt(2))
+    nframes = 2
+    data[0, 0, 100, 100] = 0
+    data[0, 1:11, 100, 100] = crmag
+    medianDiff = find_CRs(data, gdq, read_noise, rej_threshold, nframes)
+    assert(4 == np.max(gdq))  # a CR was found
+    assert(np.array_equal([0, 4, 0, 0, 0,0,0,0,0,0] , gdq[0, :, 100, 100]))
+
+#@pytest.mark.skip("testing skipping")
+def test_10grps_cr2_3sigma_2frames_noCR():
+    ngroups = 10
+    crmag=15
+    data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups,readnoise=5*np.sqrt(2))
+    nframes = 2
+    data[0, 0, 100, 100] = 0
+    data[0, 1:11, 100, 100] = crmag
+    medianDiff = find_CRs(data, gdq, read_noise, rej_threshold, nframes)
+    assert(0 == np.max(gdq))  # a CR was found
+    assert(np.array_equal([0, 0, 0, 0, 0, 0, 0, 0, 0, 0] , gdq[0, :, 100, 100]))
+
+#@pytest.mark.skip(reason="testing skipping")
+def test_10grps_noCR_2pixels_sigma0():
+    ngroups = 10
+    crmag = 15
+    data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups, readnoise=5 * np.sqrt(2))
+    nframes=1
+    data[0, 0, 100, 100] = crmag
+    data[0, 1:11, 100, 100] = crmag
+    read_noise[500, 500] = 0.0
+    read_noise[600, 600] = 0.0
+    medianDiff = find_CRs(data, gdq, read_noise, rej_threshold, nframes)
+    assert(0 == np.max(gdq))  # no CR was found
+
+def test_5grps_Satat4_CRat3():
+    ngroups = 5
+    crmag = 1000
+    data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups, readnoise=5 * np.sqrt(2))
+    nframes=1
+    data[0, 0, 100, 100] = 10000
+    data[0, 1, 100, 100] = 30000
+    data[0, 2, 100, 100] = 60000
+    data[0, 3, 100, 100] = 61000
+    data[0, 4, 100, 100] = 61000
+    gdq[0, 3, 100, 100] = dqflags.group['SATURATED']
+    gdq[0, 4, 100, 100] = dqflags.group['SATURATED']
+    medianDiff = find_CRs(data, gdq, read_noise, rej_threshold, nframes)
+   # assert(4 == np.max(gdq))  # no CR was found
+    assert (np.array_equal([0, 0, dqflags.group['JUMP_DET'],dqflags.group['SATURATED'], dqflags.group['SATURATED']], gdq[0, :, 100, 100]))
+
+
+#@pytest.mark.skip
+def test_10grps_Satat8_CRsat3and6():
+    ngroups = 10
+    crmag = 1000
+    data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups, readnoise=5 * np.sqrt(2))
+    nframes=1
+    data[0, 0, 100, 100] = 0
+    data[0, 1, 100, 100] = 5000
+    data[0, 2, 100, 100] = 15000 #CR
+    data[0, 3, 100, 100] = 20000
+    data[0, 4, 100, 100] = 25000
+    data[0, 5, 100, 100] = 40000 #CR
+    data[0, 6, 100, 100] = 45000
+    data[0, 7:11, 100, 100] = 61000
+    gdq[0, 7:11, 100, 100] = dqflags.group['SATURATED']
+    medianDiff = find_CRs(data, gdq, read_noise, rej_threshold, nframes)
+   # assert(4 == np.max(gdq))  # no CR was found
+    assert (np.array_equal([0, 0, dqflags.group['JUMP_DET'], 0, 0, dqflags.group['JUMP_DET'],
+                            0,dqflags.group['SATURATED'],dqflags.group['SATURATED'],dqflags.group['SATURATED']], gdq[0, :, 100, 100]))
+
+
+def setup_cube(ngroups,readnoise=10):
+    nints = 1
+    nrows = 2048
+    ncols = 2048
+    rej_threshold = 3
+    nframes = 1
+    data = np.zeros(shape=(nints, ngroups, nrows, ncols), dtype=np.float32)
+    read_noise = np.zeros(shape=(nrows, ncols), dtype=np.float32)
+    read_noise[:, :] = readnoise
+    primary_gdq = np.zeros(shape=(nints, ngroups, nrows, ncols), dtype=np.int32)
+    gdq = np.zeros(shape=(nints, ngroups, nrows, ncols), dtype=np.int32)
+    return data, gdq, nframes, read_noise, rej_threshold
+
+
+if __name__ == '__main__':
+    pytest.main(['-x', 'test_find_CRs_mwr.py'])
+#   # pytest.main(['test_find_CRs_mwr.py'])

--- a/jwst/jump/twopoint_difference.py
+++ b/jwst/jump/twopoint_difference.py
@@ -1,4 +1,4 @@
-'''
+"""
 Two-Point Difference method for finding outliers in a 3-d ramp data cube.
 
 The scheme used in this variation of the method uses numpy array methods
@@ -9,7 +9,7 @@ that are already known to contain an outlier, to look for any additional
 outliers and set the appropriate DQ mask for all outliers in the pixel.
 
 This is MUCH faster than doing all the work on a pixel-by-pixel basis.
-'''
+"""
 
 import logging
 import numpy as np
@@ -23,6 +23,7 @@ log.setLevel(logging.DEBUG)
 HUGE_NUM = np.finfo(np.float32).max
 
 def find_CRs(data, gdq, read_noise, rej_threshold, nframes):
+
     """
     Find CRs/Jumps in each integration within the input data array.
 
@@ -38,7 +39,7 @@ def find_CRs(data, gdq, read_noise, rej_threshold, nframes):
     median_slopes = np.zeros((nints, nrows, ncols), dtype=np.float32)
 
     # Square the read noise values, for use later
-    read_noise_2 = read_noise*read_noise
+    read_noise_2 = read_noise * read_noise
 
     # Reset saturated values in input data array to NaN, so they don't get
     # used in any of the subsequent calculations
@@ -53,15 +54,22 @@ def find_CRs(data, gdq, read_noise, rej_threshold, nframes):
 
         # Compute first differences of adjacent groups up the ramp
         first_diffs = np.diff(rdata, axis=2)
+        nans = np.where(np.isnan(first_diffs))
+        first_diffs[nans] = 100000.
 
-        # Compute median of the first differences for all pixels
-        med_diffs = np.nanmedian(first_diffs, axis=2)
+        positive_first_diffs = np.abs(first_diffs)
+        diffsum = positive_first_diffs.sum
 
-        # Zero-out results for pixels that have NaN's in all groups so they
-        # don't cause trouble in later calculations
-        nans = np.where(np.isnan(med_diffs))
-        med_diffs[nans] = 0.
-        first_diffs[nans] = 0.
+        # Make all the first diffs for saturated groups be equal to
+        # 100,000 to put them above the good values in the sorted index
+        matching_array = np.ones(shape=(positive_first_diffs.shape[0],
+                                        positive_first_diffs.shape[1],
+                                        positive_first_diffs.shape[2])) * 100000
+        sat_groups = (positive_first_diffs == matching_array)
+        number_sat_groups = (sat_groups * 1).sum(axis=2)
+        ndiffs = ngroups - 1
+        sort_index = np.argsort(positive_first_diffs)
+        med_diffs = return_clipped_median(ndiffs, number_sat_groups, positive_first_diffs, sort_index)
 
         # Save initial estimate of the median slope for all pixels
         median_slopes[integration] = med_diffs
@@ -71,124 +79,106 @@ def find_CRs(data, gdq, read_noise, rej_threshold, nframes):
         # differences can be biased by CRs/jumps, we use the median signal
         # for computing the poisson noise. Here sigma correctly has the
         # read noise taking into account the fact that multiple frames were
-        # averaged into each group./
+        # averaged into each group.
         poisson_noise = np.sqrt(np.abs(med_diffs))
-        sigma = np.sqrt(poisson_noise*poisson_noise + read_noise_2/nframes)
+        sigma = np.sqrt(poisson_noise * poisson_noise + read_noise_2 / nframes)
 
         # Reset sigma to exclude pixels with both readnoise and signal=0
         wh_sig = np.where(sigma == 0.)
         if len(wh_sig[0] > 0):
-            log.debug('Twopt found %d pixels with sigma=0' %(len(wh_sig[0])))
-            log.debug(' which will be reset so that no jump will be detected')
+            log.debug('Twopt found %d pixels with sigma=0' % (len(wh_sig[0])))
+            log.debug('which will be reset so that no jump will be detected')
             sigma[wh_sig] = HUGE_NUM
 
         # Compute distance of each sample from the median in units of sigma;
         # note that the use of "abs" means we'll detect both positive and
         # negative outliers
-        ratio = np.abs(first_diffs - med_diffs[:,:,np.newaxis])/sigma[:,:,np.newaxis]
-
-        # Sort the ratios, as they will be checked against the threshold
-        # from greatest->least
-        sortindx = np.argsort(ratio)
+        ratio = np.abs(first_diffs - med_diffs[:, :, np.newaxis]) / sigma[:, :, np.newaxis]
 
         # Find the group index of the max outlier in each pixel
         # (the RHS is identical to the previous versions:
         #  max_index = np.nanargmax (ratio, axis=2)
-        max_index1 = sortindx[:,:,ngroups-2]
+        max_index1 = sort_index[:, :, ngroups - 2]
 
         # Get indices of highest values (may be outliers) that are above the
         # rejection threshold
         r, c = np.indices(max_index1.shape)
-        r1, c1 = np.where(ratio[r, c, max_index1] > rej_threshold)
-        total_1 = len(r1)
+        row1, col1 = np.where(ratio[r, c, max_index1 - number_sat_groups] > rej_threshold)
+        log.debug('From highest outlier Twopt found %d pixels with at least one CR' % (len(row1)))
+        number_pixels_with_cr = len(row1)
+        for j in range(number_pixels_with_cr):
+            pixel_masked_diffs = first_diffs[row1[j], col1[j]]
+            pixel_rn2 = read_noise_2[row1[j], col1[j]]
+            pixel_sat_groups = number_sat_groups[row1[j], col1[j]]
+            sorted_index_of_cr = max_index1[row1[j], col1[j]] - pixel_sat_groups
 
-        log.debug('From highest outlier Twopt found %d pixels with at least one CR' % (len(r1)))
-
-        # Find the group index of the 2nd highest outlier in each pixel
-        max_index2 = sortindx[:,:,ngroups-3]
-
-        # Get indices of the 2nd highest values above the rejection threshold
-        r2, c2 = np.where(ratio[r,c,max_index2] > rej_threshold)
-
-        if nframes>1:  # Use 2nd highest outliers if nframes>1
-            # Combine both sets of rows,columns for outliers above threshold
-            rboth = np.concatenate((r1,r2))
-            cboth = np.concatenate((c1,c2))
-            log.debug('From 2nd highest outlier Twopt found %d pixels with at least one CR' % (len(r2)))
-        else:
-            rboth = r1.copy()
-            cboth = c1.copy()
-
-        total_both = len(rboth)  
-
-        # Loop over pixels that have an outlier, checking to see if they have
-        # more than 1 outlier
-        for j in range(total_both):
-            # Get the row/col indexes of current pixel with an outlier.
-            # From the concatenate() above, the initial total_1 values (r1,c1)
-            # correspond to the highest outlier, and the remaining values
-            # (r2,c2) correspond to the 2nd highest outlier.
-            row, col = rboth[j], cboth[j]
-            masked_diffs = first_diffs[row, col]
-            rn2 = read_noise_2[row, col]
-
-            # Create a saturation mask based on NaN's in the first_diffs
-            sat_mask = np.isfinite(masked_diffs)
-
-            # Create a CR mask and initialize with the max outlier;
+            # Create a CR mask and set 1st CR to be found
             # cr_mask=0 designates a CR
-            cr_mask = np.ones(masked_diffs.shape, dtype=bool)
+            pixel_cr_mask = np.ones(pixel_masked_diffs.shape, dtype=bool)
+            number_CRs_found = 1
+            pixel_sorted_index = sort_index[row1[j], col1[j], :]
+            pixel_cr_mask[pixel_sorted_index[ndiffs - pixel_sat_groups - 1]] = 0
+            new_CR_found = True
 
-            if j < total_1:   # Set mask for the highest outlier
-                cr_mask[ max_index1[row, col]] = 0
-            else:  # It's the 2nd highest
-                cr_mask[ max_index2[row, col]] = 0
+            # Loop over all the found CRs and see if there is more than one CR, setting the mask as you go
+            while new_CR_found and ((ndiffs - number_CRs_found - pixel_sat_groups) > 1):
+                new_CR_found = False
+                pixel_med_diff = return_clipped_median(ndiffs, number_CRs_found + pixel_sat_groups,
+                                                       pixel_masked_diffs, pixel_sorted_index)
+                poisson_noise = np.sqrt(np.abs(pixel_med_diff))
+                sigma = np.sqrt(poisson_noise * poisson_noise + pixel_rn2 / nframes)
+                ratio = np.abs(pixel_masked_diffs - pixel_med_diff) / sigma
+                pixel_sorted_ratio = ratio[pixel_sorted_index[:]]
 
-            # Now iteratively search for and reject additional outliers for
-            # this pixel
-            iter = 1
-            while iter:
-                # Recompute the masked median, noise, and ratios for this pixel
-                med = np.median(masked_diffs[cr_mask*sat_mask])
-                poisson_noise = np.sqrt(np.abs(med))
-                sigma = np.sqrt(poisson_noise*poisson_noise + rn2/nframes)
+                # Check if largest remaining difference is above threshold
+                if ratio[pixel_sorted_index[ndiffs - number_CRs_found - pixel_sat_groups - 1]] > rej_threshold:
+                    new_CR_found = True
+                    pixel_cr_mask[pixel_sorted_index[ndiffs - number_CRs_found - pixel_sat_groups - 1]] = 0
+                    number_CRs_found += 1
 
-                ratio = np.abs(masked_diffs - med)/sigma
- 
-                # Get a list of group indexes sorted from largest to smallest
-                # deviation from the median
-                sortindx = np.argsort(ratio)[::-1]
+            # Found all CRs. Set CR flags in input DQ array for this pixel
+            gdq[integration, 1:, row1[j], col1[j]] = \
+                np.bitwise_or(gdq[integration, 1:, row1[j], col1[j]],
+                              dqflags.group['JUMP_DET'] * np.invert(pixel_cr_mask))
 
-                # Check through the list to see if any qualify as an outlier.
-                # (since they are sorted, once these don't exceed the threshold
-                # you are done with this pixel)
-                
-                for i in sortindx:
-                    # If already masked, continue to next index
-                    if not cr_mask[i]*sat_mask[i]:
-                        continue
-
-                    # If above threshold, set a CR mask and iterate on this pixel
-                    elif ratio[i] > rej_threshold:
-                        cr_mask[i] = 0
-                        iter = 1
-                        break
-
-                    # If not above threshold, we're done with this pixel
-                    else:
-                        iter = 0
-                        break
-
-            # Set CR flags in input DQ array for this pixel
-            gdq[integration, 1:, row, col] = np.bitwise_or \
-                              (gdq[integration, 1:, row, col],
-                               dqflags.group['JUMP_DET']*np.invert(cr_mask))
-            
             # Save the CR-cleaned median slope for this pixel
-            median_slopes[integration, row, col] = med
+            if not new_CR_found: # the loop ran at least one time
+                median_slopes[integration, row1[j], col1[j]] = pixel_med_diff
 
         # Next pixel with an outlier (j loop)
-
     # Next integration (integration loop)
 
     return median_slopes
+
+
+def return_clipped_median(num_differences, diffs_to_ignore, differences, sorted_index):
+
+    """
+    This routine will return the clipped median for the input array or pixel.
+    It will ignore the input number of largest differences. At a minimum this
+    is at least one plus the number of saturated values, to avoid the median being biased
+    by a cosmic ray. As cosmic rays are found, the diffs_to_ignore will increase.
+    """
+
+    # ignore largest value and number of CRs found when finding new median
+
+    if sorted_index.ndim > 1:
+
+        # always exclude the highest value
+        pixel_med_index = sorted_index[:, :, int((num_differences - 1) / 2)] # always exclude the highest value
+        row, col = np.indices(pixel_med_index.shape)
+
+        # in addition decrease the index by 1 for every two diffs_to_ignore, these will be saturated values in this case
+        pixel_med_diff = differences[row, col, pixel_med_index - ((diffs_to_ignore) / 2).astype(int)]
+        if (num_differences - 1) % 2 == 0:  # even
+            pixel_med_index2 = sorted_index[:, :, int((num_differences - 1) / 2) - 1]
+            pixel_med_diff = (pixel_med_diff + differences[row, col, pixel_med_index2 - ((diffs_to_ignore) / 2).astype(int)]) / 2.0
+
+    else:
+        pixel_med_index = sorted_index[int(((num_differences - 1 - diffs_to_ignore) / 2))]
+        pixel_med_diff = differences[pixel_med_index]
+        if (num_differences - diffs_to_ignore - 1) % 2 == 0:  # even
+            pixel_med_index2 = sorted_index[int((num_differences - 1 - diffs_to_ignore) / 2) - 1]
+            pixel_med_diff = (pixel_med_diff + differences[pixel_med_index2]) / 2.0
+
+    return pixel_med_diff


### PR DESCRIPTION
In PR #581 Mike Regan provided us with an updated and optimized version of the twopoint_different routine used in the jump step. The version included here has had just slight modifications for working within the jwst package environment and just a bit of cosmetic changes. The routine has been tested and compared against the previous version of twopoint_difference and has been found to not only run 2-3x times faster than the previous version, but also properly handles all corner cases of things like saturated groups. It also uses the approach of the original creators of the algorithm in terms of not including the largest outlier of all groups (regardless of whether or not it's above the rejection threshold) when computing the median of group differences.