### PR TITLE
calspec2: add exptype to asn template

### DIFF
--- a/jwst/pipeline/calwebb_spec2.py
+++ b/jwst/pipeline/calwebb_spec2.py
@@ -229,7 +229,8 @@ class Lvl2Input(object):
 
     template = {"asn_pool": "",
                 "members": [
-                  {"expname": ""}
+                  {"expname": "",
+                   "exptype": ""}
                  ]
                 }
 
@@ -263,3 +264,4 @@ class Lvl2Input(object):
         self.asn = self.template
         self.asn['asn_pool'] = ''
         self.asn['members'][0]['expname'] = self.filename
+        self.asn['members'][0]['exptype'] = 'science'


### PR DESCRIPTION
This fixes a bug that I inadvertently introduced in #747, in which calspec2 checks the value of the "exptype" attribute in the association. For single file/model input, the exptype attribute of the asn was not defined. It is now, and is set to a default of "science."