### PR TITLE
Calwebb_ami3 updates for product naming

### DIFF
--- a/jwst/pipeline/calwebb_ami3.py
+++ b/jwst/pipeline/calwebb_ami3.py
@@ -12,7 +12,7 @@ from ..ami import ami_average_step
 from ..ami import ami_normalize_step
 
 
-__version__ = "1.1"
+__version__ = "1.2"
 
 # Define logging
 import logging
@@ -40,7 +40,7 @@ class Ami3Pipeline(Pipeline):
 
     def process(self, input):
 
-        log.info('Starting calwebb_ami3 ...')
+        log.info('Starting calwebb_ami3')
 
         # Load the input association table
         with open(input, 'r') as input_fh:
@@ -50,17 +50,9 @@ class Ami3Pipeline(Pipeline):
         prod = asn['products'][0]
 
         # Construct lists of all the PSF and science target members
-        psf_files = []
-        targ_files = []
-        for member in prod['members']:
-            if member['exptype'].upper() == 'PSF':
-                psf_files.append(member['expname'])
-                log.info('reference psf file {0} = {1}'.format(len(psf_files),
-                          member['expname']))
-            if member['exptype'].upper() == 'SCIENCE':
-                targ_files.append(member['expname'])
-                log.info('target file {0} = {1}'.format(len(targ_files),
-                          member['expname']))
+        # so that we know what we've been given to work with
+        psf_files = [m['expname'] for m in prod['members'] if m['exptype'].upper() =='PSF']
+        targ_files = [m['expname'] for m in prod['members'] if m['exptype'].upper() =='SCIENCE']
 
         # Make sure we found some science target members
         if len(targ_files) == 0:
@@ -84,7 +76,7 @@ class Ami3Pipeline(Pipeline):
             result = self.ami_analyze(input_file)
 
             # Save the LG analysis results to a file
-            output_file = mk_filename(self.output_dir, input_file, 'lg')
+            output_file = mk_filename(self.output_dir, input_file, 'ami')
             self.log.info('Saving LG results to %s', output_file)
             result.save(output_file)
 
@@ -102,7 +94,7 @@ class Ami3Pipeline(Pipeline):
 
             # Save the results to a file, if requested
             if self.save_averages:
-                output_file = mk_prodname(self.output_dir, prod['name'], 'lgavgr')
+                output_file = mk_prodname(self.output_dir, prod['psf_name'], 'amiavg')
                 self.log.info('Saving averaged PSF results to %s', output_file)
                 psf_avg.save(output_file)
 
@@ -113,7 +105,7 @@ class Ami3Pipeline(Pipeline):
 
             # Save the results to a file, if requested
             if self.save_averages:
-                output_file = mk_prodname(self.output_dir, prod['name'], 'lgavgt')
+                output_file = mk_prodname(self.output_dir, prod['name'], 'amiavg')
                 self.log.info('Saving averaged target results to %s', output_file)
                 targ_avg.save(output_file)
 
@@ -124,7 +116,7 @@ class Ami3Pipeline(Pipeline):
             result = self.ami_normalize(targ_avg, psf_avg)
 
             # Save the result
-            output_file = mk_prodname(self.output_dir, prod['name'], 'lgnorm')
+            output_file = mk_prodname(self.output_dir, prod['name'], 'aminorm')
             self.log.info('Saving normalized result to %s', output_file)
             result.save(output_file)
             result.close()


### PR DESCRIPTION
Updated calwebb_ami3 pipeline to use new product suffixes for output files ("lg" -> "ami"), and use a new entry in the ASN table called "psf_name" for constructing the file name of the averaged PSF fringe data, so that the file name is based on the PSF target name rather than the science target name.