### PR TITLE
Fix assign_wcs for expected units (arcsec) for NIRISS imaging distortion

### DIFF
--- a/jwst/assign_wcs/niriss.py
+++ b/jwst/assign_wcs/niriss.py
@@ -133,9 +133,7 @@ def imaging(input_model, reference_files):
 
 def imaging_distortion(input_model, reference_files):
     distortion = AsdfFile.open(reference_files['distortion']).tree['model']
-    # Convert to arcsec
-    transform = distortion | Scale(1/60) & Scale(1/60)
-    return transform
+    return distortion
 
 
 exp_type2transform = {'nis_image': imaging,

--- a/jwst/assign_wcs/niriss.py
+++ b/jwst/assign_wcs/niriss.py
@@ -133,7 +133,9 @@ def imaging(input_model, reference_files):
 
 def imaging_distortion(input_model, reference_files):
     distortion = AsdfFile.open(reference_files['distortion']).tree['model']
-    return distortion
+    # Convert to deg.  Output of distortion model is in arcsec.
+    transform = distortion | Scale(1/3600) & Scale(1/3600)
+    return transform
 
 
 exp_type2transform = {'nis_image': imaging,


### PR DESCRIPTION
Current and future WCS distortion reffiles for NIRISS imaging mode produce units of arcsec.  We had treated them as units in arcmin before.