### PR TITLE
Change error handling in datamodels

### DIFF
--- a/jwst/datamodels/fits_support.py
+++ b/jwst/datamodels/fits_support.py
@@ -529,7 +529,7 @@ def _load_from_schema(hdulist, schema, tree, error_if_invalid,
     if error_if_invalid and invalid_keywords:
         msgfmt = "fits keywords are not valid: {0}"
         msg = msgfmt.format(','.join(list(invalid_keywords)))
-        raise properties.ValidationError(msg)
+        raise jsonschema.ValidationError(msg)
     return known_keywords, known_datas
 
 

--- a/jwst/datamodels/fits_support.py
+++ b/jwst/datamodels/fits_support.py
@@ -468,15 +468,13 @@ def _schema_has_fits_hdu(schema):
     return has_fits_hdu[0]
 
 
-def _load_from_schema(hdulist, schema, tree, error_if_invalid,
-                      pass_invalid_values):
-    invalid_keywords = set()
+def _load_from_schema(hdulist, schema, tree, pass_invalid_values):
     known_keywords = {}
     known_datas = set()
+    invalid_values = set()
 
     def callback(schema, path, combiner, ctx, recurse):
         result = None
-
         if 'fits_keyword' in schema:
             fits_keyword = schema['fits_keyword']
             result = _fits_keyword_loader(
@@ -491,18 +489,15 @@ def _load_from_schema(hdulist, schema, tree, error_if_invalid,
                     asdf_schema.validate(result, schema=temp_schema)
                 except jsonschema.ValidationError:
                     result = str(result)
-                    if len(result) > 55:
-                        result = result[0:56] + " ..."
                     msgfmt = "'{0}' is not valid in '{1}'"
                     msg = msgfmt.format(result, fits_keyword)
                     warnings.warn(msg, properties.ValidationWarning)
-                    if pass_invalid_values:
-                        properties.put_value(path, result, tree)
-                    else:
-                        invalid_keywords.add(fits_keyword)
+                    if not pass_invalid_values:
+                        invalid_values.add(fits_keyword)
+                        
                 else:
                     properties.put_value(path, result, tree)
-
+                    
         elif 'fits_hdu' in schema and (
                 'max_ndim' in schema or 'ndim' in schema or 'datatype' in schema):
             result = _fits_array_loader(
@@ -512,8 +507,17 @@ def _load_from_schema(hdulist, schema, tree, error_if_invalid,
                     '$schema':
                     'http://stsci.edu/schemas/asdf-schema/0.1.0/asdf-schema'}
                 temp_schema.update(schema)
-                asdf_schema.validate(result, schema=temp_schema)
-                properties.put_value(path, result, tree)
+                try:
+                    asdf_schema.validate(result, schema=temp_schema)
+                except jsonschema.ValidationError:
+                    fits_hdu = schema['fits_hdu']
+                    msgfmt = "'{0}' is not valid"
+                    msg = msgfmt.format(fits_hdu)
+                    warnings.warn(msg, properties.ValidationWarning)
+                    if not pass_invalid_values:
+                        invalid_values.add(fits_keyword)
+                else:
+                    properties.put_value(path, result, tree)
 
         if schema.get('type') == 'array':
             has_fits_hdu = _schema_has_fits_hdu(schema)
@@ -526,9 +530,9 @@ def _load_from_schema(hdulist, schema, tree, error_if_invalid,
                 return True
 
     mschema.walk_schema(schema, callback)
-    if error_if_invalid and invalid_keywords:
-        msgfmt = "fits keywords are not valid: {0}"
-        msg = msgfmt.format(','.join(list(invalid_keywords)))
+    if len(invalid_values) > 0:
+        msgfmt = "fits data is not valid: {0}"
+        msg = msgfmt.format(','.join(list(invalid_values)))
         raise jsonschema.ValidationError(msg)
     return known_keywords, known_datas
 
@@ -570,12 +574,11 @@ def _load_history(hdulist, tree):
         history.append(HistoryEntry({'description': entry}))
 
 
-def from_fits(hdulist, schema, extensions, error_if_invalid,
-              pass_invalid_values):
+def from_fits(hdulist, schema, extensions, pass_invalid_values):
     ff = fits_embed.AsdfInFits.open(hdulist, extensions=extensions)
 
     known_keywords, known_datas = _load_from_schema(
-        hdulist, schema, ff.tree, error_if_invalid, pass_invalid_values)
+        hdulist, schema, ff.tree, pass_invalid_values)
     _load_extra_fits(hdulist, known_keywords, known_datas, ff.tree)
     _load_history(hdulist, ff.tree)
 

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -40,8 +40,8 @@ class DataModel(properties.ObjectNode, nddata_base.NDDataBase):
     """
     schema_url = "core.schema.yaml"
 
-    def __init__(self, init=None, schema=None, extensions=None, 
-                 warn_if_invalid=True, pass_invalid_values=False):
+    def __init__(self, init=None, schema=None, extensions=None,
+                 error_if_invalid=False, pass_invalid_values=False):
         """
         Parameters
         ----------
@@ -72,9 +72,6 @@ class DataModel(properties.ObjectNode, nddata_base.NDDataBase):
         extensions: classes extending the standard set of extensions, optional.
             If an extension is defined, the prefix used should be 'url'.
 
-        warn_if_invalid: If true, a value that does not validate against the 
-            schema generates a warning message. If false, the message is logged.
-            
         pass_invalid_values: If true, values that do not validate the schema can
             be read and written.
         """
@@ -96,7 +93,7 @@ class DataModel(properties.ObjectNode, nddata_base.NDDataBase):
         # Set model properties to hold paramaters controlling 
         # validation error handling
         self._pass_invalid_values = pass_invalid_values
-        self._warn_if_invalid = warn_if_invalid
+        self._error_if_invalid = error_if_invalid
 
         # Construct the path to the schema files
         filename = os.path.abspath(inspect.getfile(self.__class__))
@@ -150,7 +147,7 @@ class DataModel(properties.ObjectNode, nddata_base.NDDataBase):
             is_shape = True
         elif isinstance(init, fits.HDUList):
             asdf = fits_support.from_fits(init, self._schema, extensions,
-                                          warn_if_invalid, pass_invalid_values)
+                                          error_if_invalid, pass_invalid_values)
                                           
         elif isinstance(init, six.string_types):
             if isinstance(init, bytes):
@@ -166,7 +163,7 @@ class DataModel(properties.ObjectNode, nddata_base.NDDataBase):
                         "File does not appear to be a FITS or ASDF file.")
             else:
                 asdf = fits_support.from_fits(hdulist, self._schema, 
-                                              extensions, warn_if_invalid,
+                                              extensions, error_if_invalid,
                                               pass_invalid_values)
                 self._files_to_close.append(hdulist)
         else:

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -9,7 +9,6 @@ import datetime
 import inspect
 import os
 import sys
-import warnings
 
 import numpy as np
 
@@ -41,8 +40,8 @@ class DataModel(properties.ObjectNode, nddata_base.NDDataBase):
     """
     schema_url = "core.schema.yaml"
 
-    def __init__(self, init=None, schema=None, extensions=None,
-                 pass_invalid_values=False):
+    def __init__(self, init=None, schema=None, extensions=None, 
+                 warn_if_invalid=True, pass_invalid_values=False):
         """
         Parameters
         ----------
@@ -73,19 +72,38 @@ class DataModel(properties.ObjectNode, nddata_base.NDDataBase):
         extensions: classes extending the standard set of extensions, optional.
             If an extension is defined, the prefix used should be 'url'.
 
-        pass_invalid_values: If True, values that do not validate the schema can
-            be read and written, but with a warning message
+        warn_if_invalid: If true, a value that does not validate against the 
+            schema generates a warning message. If false, the message is logged.
+            
+        pass_invalid_values: If true, values that do not validate the schema can
+            be read and written.
         """
-        filename = os.path.abspath(inspect.getfile(self.__class__))
-        base_url = os.path.join(
-            os.path.dirname(filename), 'schemas', '')
-
+        # Set the extensions
         if extensions is None:
             extensions = jwst_extensions[:]
         else:
             extensions.extend(jwst_extensions)
         self._extensions = extensions
 
+        # Override value of pass_invalid value if environment value set
+        if "PASS_INVALID_VALUES" in os.environ:
+            pass_invalid_values = os.environ["PASS_INVALID_VALUES"]
+            try:
+                pass_invalid_values = bool(int(pass_invalid_values))
+            except ValueError:
+                pass_invalid_values = False
+    
+        # Set model properties to hold paramaters controlling 
+        # validation error handling
+        self._pass_invalid_values = pass_invalid_values
+        self._warn_if_invalid = warn_if_invalid
+
+        # Construct the path to the schema files
+        filename = os.path.abspath(inspect.getfile(self.__class__))
+        base_url = os.path.join(
+            os.path.dirname(filename), 'schemas', '')
+
+        # Load the schema files
         if schema is None:
             schema_path = os.path.join(base_url, self.schema_url)
             extension_list = asdf_extension.AsdfExtensionList(self._extensions)
@@ -94,15 +112,8 @@ class DataModel(properties.ObjectNode, nddata_base.NDDataBase):
 
         self._schema = mschema.flatten_combiners(schema)
 
-        if "PASS_INVALID_VALUES" in os.environ:
-            pass_invalid_values = os.environ["PASS_INVALID_VALUES"]
-            try:
-                self._pass_invalid_values = bool(int(pass_invalid_values))
-            except ValueError:
-                self._pass_invalid_values = False
-        else:
-            self._pass_invalid_values = pass_invalid_values
-
+        # Determine what kind of input we have (init) and execute the
+        # proper code to intiailize the model
         self._files_to_close = []
         is_array = False
         is_shape = False
@@ -138,10 +149,9 @@ class DataModel(properties.ObjectNode, nddata_base.NDDataBase):
             asdf = AsdfFile()
             is_shape = True
         elif isinstance(init, fits.HDUList):
-            asdf = fits_support.from_fits(init, self._schema,
-                                          extensions=self._extensions,
-                                          validate=False,
-                                          pass_invalid_values=self._pass_invalid_values)
+            asdf = fits_support.from_fits(init, self._schema, extensions,
+                                          warn_if_invalid, pass_invalid_values)
+                                          
         elif isinstance(init, six.string_types):
             if isinstance(init, bytes):
                 init = init.decode(sys.getfilesystemencoding())
@@ -155,15 +165,16 @@ class DataModel(properties.ObjectNode, nddata_base.NDDataBase):
                     raise IOError(
                         "File does not appear to be a FITS or ASDF file.")
             else:
-                asdf = fits_support.from_fits(hdulist, self._schema,
-                                              extensions=self._extensions,
-                                              validate=True,
-                                              pass_invalid_values=self._pass_invalid_values)
+                asdf = fits_support.from_fits(hdulist, self._schema, 
+                                              extensions, warn_if_invalid,
+                                              pass_invalid_values)
                 self._files_to_close.append(hdulist)
         else:
             raise ValueError(
                 "Can't initialize datamodel using {0}".format(str(type(init))))
 
+        # Initialize object fields as determined fro the code above
+        
         self._shape = shape
         self._instance = asdf.tree
         self._asdf = asdf
@@ -195,6 +206,7 @@ class DataModel(properties.ObjectNode, nddata_base.NDDataBase):
                     "no primary array in its schema")
             setattr(self, primary_array_name, init)
 
+        # TODO this code looks useless
         if is_shape:
             getattr(self, self.get_primary_array_name())
 

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -41,7 +41,7 @@ class DataModel(properties.ObjectNode, nddata_base.NDDataBase):
     schema_url = "core.schema.yaml"
 
     def __init__(self, init=None, schema=None, extensions=None,
-                 error_if_invalid=False, pass_invalid_values=False):
+                 error_if_invalid=True, pass_invalid_values=False):
         """
         Parameters
         ----------
@@ -72,6 +72,9 @@ class DataModel(properties.ObjectNode, nddata_base.NDDataBase):
         extensions: classes extending the standard set of extensions, optional.
             If an extension is defined, the prefix used should be 'url'.
 
+        error_if_invalid: If true, throw an error when model does not validate
+            against the schema. If false, generate a warning message instead.
+            
         pass_invalid_values: If true, values that do not validate the schema can
             be read and written.
         """

--- a/jwst/datamodels/properties.py
+++ b/jwst/datamodels/properties.py
@@ -7,6 +7,7 @@ import copy
 import numpy as np
 import jsonschema
 import collections
+import warnings
 
 from astropy.extern import six
 from astropy.utils.compat.misc import override__dir__
@@ -144,6 +145,8 @@ def _get_schema_for_index(schema, i):
     else:
         return items
 
+class ValidationWarning(Warning):
+    pass
 
 class Node(object):
     def __init__(self, instance, schema, ctx):
@@ -152,22 +155,40 @@ class Node(object):
         self._schema['$schema'] = 'http://stsci.edu/schemas/asdf-schema/0.1.0/asdf-schema'
         self._ctx = ctx
 
+    def _report(self, value, attr=None):
+        if value is None:
+            if attr is None:
+                msg = "is not valid list operation"
+            else:
+                msgfmt = "'{0}' is not valid to delete"
+                msg = msgfmt.format(attr)
+        else:
+            value = str(value)
+            if len(value) > 55:
+                value = value[:56] + " ..."
+
+            if attr is None:
+                msgfmt = "'{0}' is not valid"
+                msg = msgfmt.format(value)
+            else:
+                msgfmt = "'{0}' is not valid in '{1}'"
+                msg = msgfmt.format(value, attr)
+                
+        if self._ctx._warn_if_invalid:
+            warnings.warn(msg, ValidationWarning)
+        else:
+            log.warning(msg)
+
     def _validate(self):
         instance = yamlutil.custom_tree_to_tagged_tree(
             self._instance, self._ctx._asdf)
         try:
-            previously_invalid = self._ctx._has_invalid_values
-        except AttributeError:
-            previously_invalid = False
-        try:
             schema.validate(instance, schema=self._schema)
-            self._ctx._has_invalid_values = False
+            valid = True
         except jsonschema.ValidationError:
-            self._ctx._has_invalid_values = True
-            if  previously_invalid or self._ctx._pass_invalid_values:
-                pass
-            else:
-                raise
+            valid = False
+        self._ctx._has_invalid_values = not valid          
+        return valid
 
     @property
     def instance(self):
@@ -220,19 +241,21 @@ class ObjectNode(Node):
                 val = _make_default(attr, schema, self._ctx)
             val = _cast(val, schema)
             old_val = self._instance.get(attr, None)
-            self._instance[attr] = val
             try:
-                self._validate()
-            except jsonschema.ValidationError:
-                # Revert the transaction
-                msgfmt = "'{0}' is not valid to write to '{1}'"
-                log.warning(msgfmt.format(val, attr))
-                self._ctx._has_invalid_values = False
-                if old_val is None:
-                    del self._instance[attr]
-                else:
-                    self._instance[attr] = old_val
-                raise
+                previously_invalid = self._ctx._has_invalid_values
+            except AttributeError:
+                previously_invalid = False
+
+            self._instance[attr] = val
+            if not self._validate():
+                self._report(val, attr)
+                # Revert the transaction 
+                if not self._ctx._pass_invalid_values and not previously_invalid:
+                    self._ctx._has_invalid_values = False
+                    if old_val is None:
+                        del self._instance[attr]
+                    else:
+                        self._instance[attr] = old_val
 
     def __delattr__(self, attr):
         if attr.startswith('_'):
@@ -240,18 +263,22 @@ class ObjectNode(Node):
         else:
             old_val = self._instance.get(attr, None)
             try:
+                previously_invalid = self._ctx._has_invalid_values
+            except AttributeError:
+                previously_invalid = False
+
+            try:
                 del self._instance[attr]
             except KeyError:
                 raise AttributeError(
                     "Attribute '{0}' missing".format(attr))
-            try:
-                self._validate()
-            except jsonschema.ValidationError:
+            if not self._validate():
+                self._report(None, attr)
                 # Revert the transaction
-                self._ctx._has_invalid_values = False
-                if old_val is not None:
-                    self._instance[attr] = old_val
-                raise
+                if not self._ctx._pass_invalid_values and not previously_invalid:
+                    self._ctx._has_invalid_values = False
+                    if old_val is not None:
+                        self._instance[attr] = old_val
 
     def __hasattr__(self, attr):
         return (attr in self._instance or
@@ -285,11 +312,13 @@ class ListNode(Node):
     def __setitem__(self, i, val):
         schema = _get_schema_for_index(self._schema, i)
         self._instance[i] = _cast(val, schema)
-        self._validate()
+        if not self._validate():
+            self._report(val)
 
     def __delitem__(self, i):
         del self._instance[i]
-        self._validate()
+        if not self._validate():
+            self._report(None)
 
     def __getslice__(self, i, j):
         if isinstance(self._schema['items'], list):
@@ -307,31 +336,37 @@ class ListNode(Node):
         parts = [_cast(x, _get_schema_for_index(self._schema, k))
                  for (k, x) in enumerate(parts)]
         self._instance[i:j] = _unmake_node(other)
-        self._validate()
+        if not self._validate():
+            self._report(None)
 
     def __delslice__(self, i, j):
         del self._instance[i:j]
-        self._validate()
-
+        if not self._validate():
+            self._report(None)
+            
     def append(self, item):
         schema = _get_schema_for_index(self._schema, len(self._instance))
         self._instance.append(_cast(item, schema))
-        self._validate()
+        if not self._validate():
+            self._report(item)
 
     def insert(self, i, item):
         schema = _get_schema_for_index(self._schema, i)
         self._instance.insert(i, _cast(item, schema))
-        self._validate()
+        if not self._validate():
+            self._report(item)
 
     def pop(self, i=-1):
         schema = _get_schema_for_index(self._schema, 0)
         x = self._instance.pop(i)
-        self._validate()
+        if not self._validate():
+            self._report(None)
         return _make_node(x, schema, self._ctx)
 
     def remove(self, item):
         self._instance.remove(item)
-        self._validate()
+        if not self._validate():
+            self._report(None)
 
     def count(self, item):
         return self._instance.count(item)
@@ -341,12 +376,14 @@ class ListNode(Node):
 
     def reverse(self):
         self._instance.reverse()
-        self._validate()
+        if not self._validate():
+            self._report(None)
 
     def sort(self, *args, **kwargs):
         self._instance.sort(*args, **kwargs)
-        self._validate()
-
+        if not self._validate():
+            self._report(None)
+            
     def extend(self, other):
         for part in _unmake_node(other):
             self.append(part)
@@ -354,7 +391,8 @@ class ListNode(Node):
     def item(self, **kwargs):
         assert isinstance(self._schema['items'], dict)
         obj = ObjectNode(kwargs, self._schema['items'], self._ctx)
-        obj._validate()
+        if not obj._validate():
+            self._report(None)
         return obj
 
 def put_value(path, value, tree):

--- a/jwst/datamodels/properties.py
+++ b/jwst/datamodels/properties.py
@@ -145,9 +145,6 @@ def _get_schema_for_index(schema, i):
     else:
         return items
 
-class ValidationError(Exception):
-    pass
-
 class ValidationWarning(Warning):
     pass
 
@@ -177,10 +174,10 @@ class Node(object):
                 msgfmt = "'{0}' is not valid in '{1}'"
                 msg = msgfmt.format(value, attr)
                 
-            if self._ctx._error_if_invalid:
-                raise ValidationError(msg)
-            else:
-                warnings.warn(msg, ValidationWarning)
+        if self._ctx._error_if_invalid:
+            raise jsonschema.ValidationError(msg)
+        else:
+            warnings.warn(msg, ValidationWarning)
 
 
     def _validate(self):

--- a/jwst/datamodels/properties.py
+++ b/jwst/datamodels/properties.py
@@ -174,10 +174,10 @@ class Node(object):
                 msgfmt = "'{0}' is not valid in '{1}'"
                 msg = msgfmt.format(value, attr)
                 
-        if self._ctx._error_if_invalid:
-            raise jsonschema.ValidationError(msg)
-        else:
+        if self._ctx._pass_invalid_values:
             warnings.warn(msg, ValidationWarning)
+        else:
+            raise jsonschema.ValidationError(msg)
 
 
     def _validate(self):
@@ -244,12 +244,11 @@ class ObjectNode(Node):
 
             self._instance[attr] = val
             if not self._validate():
-                # Revert the transaction 
-                if not self._ctx._pass_invalid_values:
-                    if old_val is None:
-                        del self._instance[attr]
-                    else:
-                        self._instance[attr] = old_val
+                # Revert the change
+                if old_val is None:
+                    del self._instance[attr]
+                else:
+                    self._instance[attr] = old_val
 
                 self._report(val, attr)
                 
@@ -265,10 +264,9 @@ class ObjectNode(Node):
                 raise AttributeError(
                     "Attribute '{0}' missing".format(attr))
             if not self._validate():
-                # Revert the transaction
-                if not self._ctx._pass_invalid_values:
-                    if old_val is not None:
-                        self._instance[attr] = old_val
+                # Revert the change
+                if old_val is not None:
+                    self._instance[attr] = old_val
                         
                 self._report(None, attr)
 


### PR DESCRIPTION
Error handling is now controlled by two keyword parameters in the __init__ method, error_if_invalid and pass_invalid_values. Both are false by default. Error_if_invalid is new.

If error_if_invalid is true, datamodels throws a ValidationError if a fits file does not validate against the schema. It raises a ValidationWarning if error_if_invalid is false. To convert the warning message to a log file message, call "logging.captureWarnings(True)". Datamodels will delay throwing an error when reading a fits file until all the data is checked so that a mesaage is printed for all problems with validation. Howerever, an error will be generated whenever a value is modified after reading, as the code has no way of knowing how many changes will be made.

If pass_invalid_values is true, datamodels will permit changes to the files which do not validate. If it is false, invalid changes will be rolled back.  An error will be generated even if pass_invalid_values is true if error_if_invalid is also true, the keywords are independent of one another.

The default case, where both keyword parameters are false, is most likely what you want. Invalid changes generate a warning mmessage and the change is rolled back.