### PR TITLE
Update jump step default rejection threshold

### DIFF
--- a/jwst/pipeline/jump.cfg
+++ b/jwst/pipeline/jump.cfg
@@ -1,5 +1,5 @@
 name = "jump"
 class = "jwst.jump.JumpStep"
-rejection_threshold = 5.0
+rejection_threshold = 4.0
 do_yintercept = False
 yint_threshold = 1.0


### PR DESCRIPTION
Updated the default value of the rejection_threshold parameter in the jump.cfg file from 5.0 to 4.0, so that it matches the default value set in the jump_step.py module. Fixes #706.