### PR TITLE
WIP: Fix problems with bounding_box

### DIFF
--- a/jwst/assign_wcs/fgs.py
+++ b/jwst/assign_wcs/fgs.py
@@ -63,8 +63,16 @@ def imaging(input_model, reference_files):
 
 def imaging_distortion(input_model, reference_files):
     distortion = AsdfFile.open(reference_files['distortion']).tree['model']
-    # Convert to arcsec
-    transform = distortion | models.Scale(1/60) & models.Scale(1/60)
+    # Convert to deg
+    transform = distortion | models.Scale(1 / 3600) & models.Scale(1 / 3600)
+
+    try:
+        bb = transform.bounding_box
+    except NotImplementedError:
+        shape = input_model.data.shape
+        # Note: Since bounding_box is attached to the model here it's in reverse order.
+        transform.bounding_box = ((shape[1] - 0.5, shape[0] - 0.5),
+                                  (shape[1] - 0.5 , shape[0] - 0.5))
     return transform
 
 

--- a/jwst/assign_wcs/fgs.py
+++ b/jwst/assign_wcs/fgs.py
@@ -71,8 +71,8 @@ def imaging_distortion(input_model, reference_files):
     except NotImplementedError:
         shape = input_model.data.shape
         # Note: Since bounding_box is attached to the model here it's in reverse order.
-        transform.bounding_box = ((shape[1] - 0.5, shape[0] - 0.5),
-                                  (shape[1] - 0.5 , shape[0] - 0.5))
+        transform.bounding_box = ((-0.5, shape[1] - 0.5),
+                                  (-0.5 , shape[0] - 0.5))
     return transform
 
 

--- a/jwst/assign_wcs/miri.py
+++ b/jwst/assign_wcs/miri.py
@@ -165,8 +165,8 @@ def lrs(input_model, reference_files):
     y0 = lrsdata[:, 4]
     x1 = lrsdata[:, 5]
 
-    bb = ((x0.min() + zero_point[0], x1.max() + zero_point[0]),
-          (y0.min() + zero_point[1], y0.max() + zero_point[1]))
+    bb = ((x0.min() - 0.5 + zero_point[0], x1.max() + 0.5 + zero_point[0]),
+          (y0.min() - 0.5 + zero_point[1], y0.max() + 0.5 + zero_point[1]))
     # Find the ROW of the zero point which should be the [1] of zero_point
     row_zero_point = zero_point[1]
 

--- a/jwst/assign_wcs/miri.py
+++ b/jwst/assign_wcs/miri.py
@@ -69,7 +69,7 @@ def imaging(input_model, reference_files):
     except NotImplementedError:
         shape = input_model.data.shape
         # Note: Since bounding_box is attached to the model here it's in reverse order.
-        distortion.bounding_box = ((-0.5, shape[0] - 0.5), (3.5, shape[0] - 0.5))
+        distortion.bounding_box = ((-0.5, shape[1] - 0.5), (3.5, shape[0] - 0.5))
 
     # Create the pipeline
     pipeline = [(detector, distortion),

--- a/jwst/assign_wcs/nircam.py
+++ b/jwst/assign_wcs/nircam.py
@@ -50,8 +50,8 @@ def imaging_distortion(input_model, reference_files):
     except NotImplementedError:
         shape = input_model.data.shape
         # Note: Since bounding_box is attached to the model here it's in reverse order.
-        transform.bounding_box = ((shape[1] - 0.5, shape[0] - 0.5),
-                                  (shape[1] - 0.5 , shape[0] - 0.5))
+        transform.bounding_box = ((-0.5, shape[1] - 0.5),
+                                  (-0.5 , shape[0] - 0.5))
     return transform
 
 

--- a/jwst/assign_wcs/nircam.py
+++ b/jwst/assign_wcs/nircam.py
@@ -43,7 +43,15 @@ def imaging(input_model, reference_files):
 def imaging_distortion(input_model, reference_files):
     distortion = AsdfFile.open(reference_files['distortion']).tree['model']
     # Convert to deg - output of distortion models is in arcsec.
-    transform = distortion | Scale(1/3600) & Scale(1/3600)
+    transform = distortion | Scale(1 / 3600) & Scale(1 / 3600)
+
+    try:
+        bb = transform.bounding_box
+    except NotImplementedError:
+        shape = input_model.data.shape
+        # Note: Since bounding_box is attached to the model here it's in reverse order.
+        transform.bounding_box = ((shape[1] - 0.5, shape[0] - 0.5),
+                                  (shape[1] - 0.5 , shape[0] - 0.5))
     return transform
 
 

--- a/jwst/assign_wcs/niriss.py
+++ b/jwst/assign_wcs/niriss.py
@@ -141,8 +141,8 @@ def imaging_distortion(input_model, reference_files):
     except NotImplementedError:
         shape = input_model.data.shape
         # Note: Since bounding_box is attached to the model here it's in reverse order.
-        distortion.bounding_box = ((shape[1] - 0.5, shape[0] - 0.5),
-                                   (shape[1] - 0.5 , shape[0] - 0.5))
+        distortion.bounding_box = ((-0.5, shape[1] - 0.5),
+                                  (-0.5 , shape[0] - 0.5))
     return transform
 
 

--- a/jwst/assign_wcs/niriss.py
+++ b/jwst/assign_wcs/niriss.py
@@ -134,7 +134,15 @@ def imaging(input_model, reference_files):
 def imaging_distortion(input_model, reference_files):
     distortion = AsdfFile.open(reference_files['distortion']).tree['model']
     # Convert to deg.  Output of distortion model is in arcsec.
-    transform = distortion | Scale(1/3600) & Scale(1/3600)
+    transform = distortion | Scale(1 / 3600) & Scale(1 / 3600)
+
+    try:
+        bb = distortion.bounding_box
+    except NotImplementedError:
+        shape = input_model.data.shape
+        # Note: Since bounding_box is attached to the model here it's in reverse order.
+        distortion.bounding_box = ((shape[1] - 0.5, shape[0] - 0.5),
+                                   (shape[1] - 0.5 , shape[0] - 0.5))
     return transform
 
 

--- a/jwst/assign_wcs/nirspec.py
+++ b/jwst/assign_wcs/nirspec.py
@@ -841,11 +841,11 @@ def compute_bounding_box(slit2detector, wavelength_range, slit_ymin=-.5, slit_ym
     y_range = np.hstack((y_range_low, y_range_high))
     # add 10 px margin
     # The -1 is technically because the output of slit2detector is 1-based coordinates.
-    x0 = int(max(0, x_range.min() -1 -10))
-    x1 = int(min(2047, x_range.max() -1 + 10))
+    x0 = max(0, x_range.min() -1 -10)
+    x1 = min(2047, x_range.max() -1 + 10)
     # add 2 px margin
-    y0 = int(y_range.min() -1 -2)
-    y1 = int(y_range.max() -1 + 2)
+    y0 = y_range.min() -1 -2
+    y1 = y_range.max() -1 + 2
 
     bounding_box = ((x0, x1), (y0, y1))
     return bounding_box

--- a/jwst/assign_wcs/tools/nirspec/compute_world_coordinates.py
+++ b/jwst/assign_wcs/tools/nirspec/compute_world_coordinates.py
@@ -14,6 +14,7 @@ import os.path
 import numpy as np
 from astropy.io import fits
 from gwcs import wcstools
+from gwcs.utils import _toindex
 from .... import datamodels
 from ... import nirspec
 
@@ -53,7 +54,7 @@ def ifu_coords(fname, output=None):
     hdulist.append(phdu)
     output_frame = ifu_slits[0].available_frames[-1]
     for i, slit in enumerate(ifu_slits):
-        x, y = wcstools.grid_from_domain(slit.domain)
+        x, y = wcstools.grid_from_bounding_box(slit.bounding_box, (1, 1), center=True)
         ## 1-based coordinates expected
         # ra, dec, lam = slit(x + 1, y + 1)
         ra, dec, lam = slit(x, y)
@@ -67,8 +68,8 @@ def ifu_coords(fname, output=None):
         imhdu.header['PLANE4'] = 'slit_y, relative to center (0, 0)'
         imhdu.header['SLIT'] = "SLIT_{0}".format(i)
         # -1 and +1 are to express this in 1-based coordinates
-        imhdu.header['CRVAL1'] = model.meta.subarray.xstart -1 + slit.domain[0]['lower'] + 1
-        imhdu.header['CRVAL2'] = model.meta.subarray.xstart -1 + slit.domain[1]['lower'] + 1
+        imhdu.header['CRVAL1'] = model.meta.subarray.xstart -1 + int(_toindex(slit.bounding_box[0][0])) + 1
+        imhdu.header['CRVAL2'] = model.meta.subarray.xstart -1 + int(_toindex(slit.bounding_box[1][0])) + 1
         # Input coordinates will be 1-based.
         imhdu.header['CRPIX1'] = 1
         imhdu.header['CRPIX2'] = 1
@@ -125,7 +126,7 @@ def compute_world_coordinates(fname, output=None):
         # xstart, xend = slit.xstart - 1, slit.xstart -1 + slit.xsize
         # ystart, yend = slit.ystart - 1, slit.ystart -1 + slit.ysize
         # y, x = np.mgrid[ystart: yend, xstart: xend]
-        x, y = wcstools.grid_from_domain(slit.domain)
+        x, y = wcstools.grid_from_bounding_box(slit.bounding_box, step=(1, 1), center=True)
         ra, dec, lam = slit.meta.wcs(x, y)
         detector2slit = slit.meta.wcs.get_transform('detector', 'slit_frame')
 
@@ -189,8 +190,8 @@ def imaging_coords(fname, output=None):
     phdu.header['data'] = 'world coordinates'
     hdulist.append(phdu)
     output_frame = model.available_frames[-1]
-    domain = model.meta.wcs.domain
-    x, y = wcstools.grid_from_domain(domain)
+    bb = model.meta.wcs.bounding_box
+    x, y = wcstools.grid_from_bounding_box(bb, step=(1, 1), center=True)
     ra, dec, lam = slit(x + 1, y + 1)
     world_coordinates = np.array([lam, ra, dec])
     imhdu = fits.ImageHDU(data=world_coordinates)
@@ -199,8 +200,8 @@ def imaging_coords(fname, output=None):
     imhdu.header['PLANE3'] = '{0}_y, deg'.format(output_frame)
     imhdu.header['SLIT'] = "SLIT_{0}".format(i)
     # add the overall subarray offset
-    imhdu.header['CRVAL1'] = model.meta.subarray.xstart -1 + domain[0]['lower']
-    imhdu.header['CRVAL2'] = model.meta.subarray.ystart -1 + domain[1]['lower']
+    imhdu.header['CRVAL1'] = model.meta.subarray.xstart -1 + int(_toindex(bb[0][0]))
+    imhdu.header['CRVAL2'] = model.meta.subarray.ystart -1 + int(_toindex(bb[1][0]))
     # Input coordinates will be 1-based.
     imhdu.header['CRPIX1'] = 1
     imhdu.header['CRPIX2'] = 1

--- a/jwst/extract_2d/extract_2d.py
+++ b/jwst/extract_2d/extract_2d.py
@@ -8,6 +8,8 @@ import copy
 import numpy as np
 from astropy.io import fits
 from astropy.modeling.models import Shift
+from gwcs.utils import _toindex
+
 from .. import datamodels
 from asdf import AsdfFile
 from ..assign_wcs import nirspec
@@ -57,18 +59,19 @@ def extract2d(input_model, which_subarray=None):
             ext_dq = input_model.dq[ylo: yhi, xlo: xhi].copy()
             new_model = datamodels.ImageModel(data=ext_data, err=ext_err, dq=ext_dq)
             shape = ext_data.shape
-            bounding_box= ((0, shape[1] -1), (0, shape[0]) - 1)
+            bounding_box= ((0, shape[1] - 1), (0, shape[0] - 1))
             slit_wcs.bounding_box = bounding_box
             new_model.meta.wcs = slit_wcs
             output_model.slits.append(new_model)
             # set x/ystart values relative to the image (screen) frame.
             # The overall subarray offset is recorded in model.meta.subarray.
             nslit = len(output_model.slits) - 1
+            xlo_ind, xhi_ind, ylo_ind, yhi_ind = _toind((xlo, xhi, ylo, yhi)).astype(np.int)
             output_model.slits[nslit].name = str(slit.name)
-            output_model.slits[nslit].xstart = xlo + 1
-            output_model.slits[nslit].xsize = xhi - xlo
-            output_model.slits[nslit].ystart = ylo + 1
-            output_model.slits[nslit].ysize = yhi - ylo
+            output_model.slits[nslit].xstart = xlo_ind + 1
+            output_model.slits[nslit].xsize = xhi_ind - xloind
+            output_model.slits[nslit].ystart = ylo_ind + 1
+            output_model.slits[nslit].ysize = yhi_ind - ylo_ind
             if exp_type.lower() == 'nrs_msaspec':
                 output_model.slits[nslit].source_id = int(slit.source_id)
                 output_model.slits[nslit].source_name = slit.source_name


### PR DESCRIPTION
I will keep this open for a while and keep fixing problems as they surface.

`extract_2d`:
- Fixed how `xstart`, `ystart` are reset. Since `bounding_box` uses the edge of the pixel instead of the center, the values need to be converted to the center of the pixel + 1.

`assign_wcs`:
- Added a `bounding_box` to the miri imager. Convert from arcsec to deg since the new ref files are in arcsec.
- The LRS bounding_box uses the edge of the pixel now.
- Added a `bounding_box` to NIRISS imaging.
- Added `bounding_box` to NIRSPEC.
- Added `bounding_box` to FGS. Convert from arcsec to deg since the new ref files are in arcsec.
- Added `bounding_box` to NIRCAM.
