### PR TITLE
Remove TARGID from datamodels core schema

### DIFF
--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -205,10 +205,6 @@ properties:
             title: Type of target (fixed, moving, generic)
             type: string
             fits_keyword: TARGTYPE
-          id:
-            title: Target id used in PPS DB queries
-            type: string
-            fits_keyword: TARGID
           ra:
             title: Target RA at mid time of exposure
             type: number


### PR DESCRIPTION
Deleted TARGID (target.id) entry from core schema. Fixes #686.