### PR TITLE
fix order of inputs in lrs bounding_box

### DIFF
--- a/jwst/assign_wcs/fgs.py
+++ b/jwst/assign_wcs/fgs.py
@@ -71,8 +71,8 @@ def imaging_distortion(input_model, reference_files):
     except NotImplementedError:
         shape = input_model.data.shape
         # Note: Since bounding_box is attached to the model here it's in reverse order.
-        transform.bounding_box = ((-0.5, shape[1] - 0.5),
-                                  (-0.5 , shape[0] - 0.5))
+        transform.bounding_box = ((-0.5, shape[0] - 0.5),
+                                  (-0.5 , shape[1] - 0.5))
     return transform
 
 

--- a/jwst/assign_wcs/miri.py
+++ b/jwst/assign_wcs/miri.py
@@ -203,7 +203,7 @@ def lrs(input_model, reference_files):
               models.Shift(xshift, name='xshift1') & \
               models.Shift(yshift, name='yshift2') & models.Shift(xshift, name='xshift2') & \
               models.Identity(2) | radec_t2d & lrs_wav_model
-    det2world.bounding_box = bb
+    det2world.bounding_box = bb[::-1]
     # Now the actual pipeline.
     pipeline = [(detector, det2world),
                 (world, None)

--- a/jwst/assign_wcs/miri.py
+++ b/jwst/assign_wcs/miri.py
@@ -69,7 +69,7 @@ def imaging(input_model, reference_files):
     except NotImplementedError:
         shape = input_model.data.shape
         # Note: Since bounding_box is attached to the model here it's in reverse order.
-        distortion.bounding_box = ((-0.5, shape[1] - 0.5), (3.5, shape[0] - 0.5))
+        distortion.bounding_box = ((-0.5, shape[0] - 0.5), (3.5, shape[1] - 0.5))
 
     # Create the pipeline
     pipeline = [(detector, distortion),

--- a/jwst/assign_wcs/nircam.py
+++ b/jwst/assign_wcs/nircam.py
@@ -50,8 +50,8 @@ def imaging_distortion(input_model, reference_files):
     except NotImplementedError:
         shape = input_model.data.shape
         # Note: Since bounding_box is attached to the model here it's in reverse order.
-        transform.bounding_box = ((-0.5, shape[1] - 0.5),
-                                  (-0.5 , shape[0] - 0.5))
+        transform.bounding_box = ((-0.5, shape[0] - 0.5),
+                                  (-0.5 , shape[1] - 0.5))
     return transform
 
 

--- a/jwst/assign_wcs/niriss.py
+++ b/jwst/assign_wcs/niriss.py
@@ -1,4 +1,4 @@
-xfrom __future__ import (absolute_import, unicode_literals, division,
+from __future__ import (absolute_import, unicode_literals, division,
                         print_function)
 
 import logging

--- a/jwst/assign_wcs/niriss.py
+++ b/jwst/assign_wcs/niriss.py
@@ -1,4 +1,4 @@
-from __future__ import (absolute_import, unicode_literals, division,
+xfrom __future__ import (absolute_import, unicode_literals, division,
                         print_function)
 
 import logging
@@ -141,8 +141,8 @@ def imaging_distortion(input_model, reference_files):
     except NotImplementedError:
         shape = input_model.data.shape
         # Note: Since bounding_box is attached to the model here it's in reverse order.
-        distortion.bounding_box = ((-0.5, shape[1] - 0.5),
-                                  (-0.5 , shape[0] - 0.5))
+        distortion.bounding_box = ((-0.5, shape[0] - 0.5),
+                                  (-0.5 , shape[1] - 0.5))
     return transform
 
 

--- a/jwst/extract_2d/extract_2d.py
+++ b/jwst/extract_2d/extract_2d.py
@@ -66,7 +66,7 @@ def extract2d(input_model, which_subarray=None):
             # set x/ystart values relative to the image (screen) frame.
             # The overall subarray offset is recorded in model.meta.subarray.
             nslit = len(output_model.slits) - 1
-            xlo_ind, xhi_ind, ylo_ind, yhi_ind = _toind((xlo, xhi, ylo, yhi)).astype(np.int)
+            xlo_ind, xhi_ind, ylo_ind, yhi_ind = _toindex((xlo, xhi, ylo, yhi)).astype(np.int)
             output_model.slits[nslit].name = str(slit.name)
             output_model.slits[nslit].xstart = xlo_ind + 1
             output_model.slits[nslit].xsize = xhi_ind - xloind


### PR DESCRIPTION
Wcs.bounding_box is in reverse order compared to model.bounding_box.