### PR TITLE
Skip persistence step in calwebb_sloper

### DIFF
--- a/jwst/pipeline/calwebb_sloper.cfg
+++ b/jwst/pipeline/calwebb_sloper.cfg
@@ -22,7 +22,7 @@ save_calibrated_ramp = False
       [[dark_current]]
         config_file = dark_current.cfg
       [[persistence]]
-        config_file = persistence.cfg
+        skip = True
       [[jump]]
         config_file = jump.cfg
       [[ramp_fit]]


### PR DESCRIPTION
The persistence step was recently updated to include definitions of 3 new types of reference files that aren't in CRDS yet, so all executions of calwebb_sloper cause a CRDS prefetch error when trying to find suitable ref files for those new types. So I've temporarily hardwired the calwebb_sloper.cfg to skip the persistence step, which also skips the CRDS prefetch.