### PR TITLE
Add NIRISS wheel position keywords

### DIFF
--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -367,6 +367,14 @@ properties:
             title: GWA TILT (avg/calib) temperature [K]
             type: number
             fits_keyword: GWA_TILT
+          filter_position:
+            title: NIRISS filter wheel position
+            type: number
+            fits_keyword: FWCPOS
+          pupil_position:
+            title: NIRISS pupil wheel position
+            type: number
+            fits_keyword: PWCPOS
       exposure:
         title: Exposure parameters
         type: object


### PR DESCRIPTION
The keyword dictionary was updated for Build 7 to include 2 new wheel position keywords for NIRISS:

FWCPOS is the filter wheel position
PWCPOS is the pupil wheel position

as documented in https://jira.stsci.edu/browse/JWSTKD-13?jql=project%20%3D%20JWSTKD

Added these same keyword entries to the core schema. They are available as meta attributes instrument.filter_position and instrument.pupil_position.