### PR TITLE
fix units in computation of roll_ref

### DIFF
--- a/jwst/tests/test_set_telescope_pointing.py
+++ b/jwst/tests/test_set_telescope_pointing.py
@@ -213,7 +213,7 @@ def test_add_wcs_default(fits_file):
     assert header['PC2_2'] == 1.0
     assert header['RA_REF'] == TARG_RA
     assert header['DEC_REF'] == TARG_DEC
-    assert np.isclose(header['ROLL_REF'], 0.07993869)
+    assert np.isclose(header['ROLL_REF'], 358.9045979379)
     assert header['WCSAXES'] == 0.
 
 
@@ -233,5 +233,5 @@ def test_add_wcs_with_db(eng_db, fits_file):
         assert np.isclose(header['PC2_2'], -0.0385309)
         assert np.isclose(header['RA_REF'], 348.8776709)
         assert np.isclose(header['DEC_REF'], -38.854159)
-        assert np.isclose(header['ROLL_REF'], 354.76818)
+        assert np.isclose(header['ROLL_REF'], 50.20832726650)
         assert header['WCSAXES'] == 0.

--- a/scripts/set_telescope_pointing.py
+++ b/scripts/set_telescope_pointing.py
@@ -476,9 +476,9 @@ def compute_local_roll(pa_v3, ra_ref, dec_ref, v2_ref, v3_ref):
     """
     v2 = np.deg2rad(v2_ref / 3600)
     v3 = np.deg2rad(v3_ref / 3600)
-
-    angles = [-pa_v3, -dec_ref, ra_ref]
-    axes = "xyz"
+    ra_ref = np.deg2rad(ra_ref)
+    dec_ref = np.deg2rad(dec_ref)
+    pa_v3 = np.deg2rad(pa_v3)
 
     M = np.array([[cos(ra_ref) * cos(dec_ref),
                    -sin(ra_ref) * cos(pa_v3) + cos(ra_ref) * sin(dec_ref) * sin(pa_v3),


### PR DESCRIPTION
Similar code is in assign_wcs. The model there uses the correct units. This was missed when the codde was copied here.