### PR TITLE
MIRI MRS inverse transform

### DIFF
--- a/jwst/assign_wcs/miri.py
+++ b/jwst/assign_wcs/miri.py
@@ -320,16 +320,25 @@ def detector_to_alpha_beta(input_model, reference_files):
         wr[ch] = r
     f.close()
     ch_dict = {}
+    bzero = {'1SHORT': -1.77210143797,
+             '2SHORT': -2.23774549066
+             }
+    bdel = {'1SHORT': 0.177210143797,
+            '2SHORT': 0.279718186333
+            }
     for c in channels:
-        ch_dict.update({tuple(wr[c]): selector.LabelMapperDict(('alpha', 'beta', 'lam'), slice_model[c],
-                                                   models.Mapping([1, ], n_inputs=3), atol=10**-2)})
+        mapper = jwmodels.MIRI_AB2Slice(bzero[c], bdel[c])
+        lm = selector.LabelMapper(inputs=('alpha', 'beta', 'lam'),
+                                  mapper=mapper, inputs_mapping=models.Mapping((1,), n_inputs=3))
+        ch_dict[tuple(wr[c])] = lm
+
     alpha_beta_mapper = selector.LabelMapperRange(('alpha', 'beta', 'lam'), ch_dict,
                                                   models.Mapping((2,)))
+
     label_mapper.inverse = alpha_beta_mapper
-
-
     det2alpha_beta = selector.RegionsSelector(('x', 'y'), ('alpha', 'beta', 'lam'),
-                                              label_mapper=label_mapper, selector=transforms)
+                                              label_mapper=label_mapper,
+                                              selector=transforms)
     return det2alpha_beta
 
 

--- a/jwst/assign_wcs/miri.py
+++ b/jwst/assign_wcs/miri.py
@@ -253,7 +253,7 @@ def ifu(input_model, reference_files):
     tel2sky = pointing.v23tosky(input_model) & models.Identity(1)
 
     shape = input_model.data.shape
-    det2alpha_beta.bounding_box = ((-0.5, shape[0]), (-0.5, shape[1]))
+    det2alpha_beta.bounding_box = ((-0.5, shape[0] - 0.5), (-0.5, shape[1] - 0.5))
     pipeline = [(detector, det2alpha_beta),
                 (miri_focal, ab2xyan),
                 (xyan, xyan2v23),

--- a/jwst/assign_wcs/tests/test_miri.py
+++ b/jwst/assign_wcs/tests/test_miri.py
@@ -20,7 +20,7 @@ Both notes have been communicated to the INS team.
 
 """
 from __future__ import absolute_import, division, unicode_literals, print_function
-
+import pytest
 import numpy as np
 from astropy.io import fits
 from gwcs import wcs
@@ -105,37 +105,37 @@ def run_test(model):
         #utils.assert_allclose(xin, x, atol=10**-5)
         #utils.assert_allclose(yin, y, atol=10**-5)
 
-
+@pytest.mark.xfail(reason="reference file not in CRDS yet, #834")
 def test_miri_mrs_12A():
     hdul = create_hdul(detector="MIRIFUSHORT", channel="12", band="SHORT")
     im = create_datamodel(hdul)
     run_test(im)
 
-
+@pytest.mark.xfail(reason="reference file not in CRDS yet, #834")
 def test_miri_mrs_12B():
     hdul = create_hdul(detector="MIRIFUSHORT", channel="12", band="MEDIUM")
     im = create_datamodel(hdul)
     run_test(im)
 
-
+@pytest.mark.xfail(reason="reference file not in CRDS yet, #834")
 def test_miri_mrs_12C():
     hdul = create_hdul(detector="MIRIFUSHORT", channel="12", band="LONG")
     im = create_datamodel(hdul)
     run_test(im)
 
-
+@pytest.mark.xfail(reason="reference file not in CRDS yet, #834")
 def test_miri_mrs_34A():
     hdul = create_hdul(detector="MIRIFULONG", channel="34", band="SHORT")
     im = create_datamodel(hdul)
     run_test(im)
 
-
+@pytest.mark.xfail(reason="reference file not in CRDS yet, #834")
 def test_miri_mrs_34B():
     hdul = create_hdul(detector="MIRIFULONG", channel="34", band="MEDIUM")
     im = create_datamodel(hdul)
     run_test(im)
 
-
+@pytest.mark.xfail(reason="reference file not in CRDS yet, #834")
 def test_miri_mrs_34C():
     hdul = create_hdul(detector="MIRIFULONG", channel="34", band="LONG")
     im = create_datamodel(hdul)

--- a/jwst/transforms/jwextension.py
+++ b/jwst/transforms/jwextension.py
@@ -12,7 +12,7 @@ class JWSTExtension(AsdfExtension):
     @property
     def types(self):
         return [GratingEquationType, CoordsType, RotationSequenceType, LRSWavelengthType,
-                Gwa2SlitType, Slit2MsaType]
+                Gwa2SlitType, Slit2MsaType, MIRI_AB2SliceType]
 
     @property
     def tag_mapping(self):

--- a/jwst/transforms/models.py
+++ b/jwst/transforms/models.py
@@ -18,7 +18,8 @@ from astropy import units as u
 __all__ = ['AngleFromGratingEquation', 'WavelengthFromGratingEquation',
            'NRSZCoord', 'Unitless2DirCos', 'DirCos2Unitless',
            'Rotation3DToGWA', 'Gwa2Slit', 'Slit2Msa',
-           'Snell', 'Logical', 'NirissSOSSModel', 'V23ToSky', 'Slit']
+           'Snell', 'Logical', 'NirissSOSSModel', 'V23ToSky', 'Slit', 
+           'MIRI_AB2DET']
 
 
 # Number of shutters per quadrant
@@ -33,6 +34,31 @@ Slit.__new__.__defaults__= ("", 0, 0.0, 0.0, 0.0, 0.0, 0, 0, 0, "", "", "", 0.0,
 
 
 
+class MIRI_AB2Slice(Model):
+    """
+    MIRI MRS alpha, beta to slice transform
+
+    Parameters
+    ----------
+    b_zero : float
+    b_del : float
+    """
+    standard_broadcastnig = False
+
+    inputs = ("beta",)
+    outputs = ("slice",)
+
+    def __init__(self, b_zero, b_del, **kwargs):
+        super(MIRI_AB2Slice, self).__init__(**kwargs)
+        self.b_zero = b_zero
+        self.b_del = b_del
+
+    @staticmethod
+    def evaluate(beta, b_zero, b_del):
+        return (beta - b_zero) / b_del
+    
+
+    
 class Snell(Model):
     """
     Apply transforms, including Snell law, through the NIRSpec prism.

--- a/jwst/transforms/models.py
+++ b/jwst/transforms/models.py
@@ -74,10 +74,12 @@ class MIRI_AB2Slice(Model):
 
     beta_zero = Parameter('beta_zero', default=0)
     beta_del = Parameter('beta_del', default=1)
+    channel = Parameter("channel", default=1)
 
     @staticmethod
-    def evaluate(beta, beta_zero, beta_del):
-        return (beta - beta_zero) / beta_del
+    def evaluate(beta, beta_zero, beta_del, channel):
+        s = channel * 100 + (beta - beta_zero) / beta_del + 1
+        return _toindex(s)
 
 
 class Snell(Model):
@@ -809,3 +811,25 @@ class V23ToSky(Rotation3D):
             outputs = (outputs,)
 
         return self.prepare_outputs(format_info, *outputs)
+
+
+def _toindex(value):
+    """
+    Convert value to an int or an int array.
+
+    Input coordinates converted to integers
+    corresponding to the center of the pixel.
+    The convention is that the center of the pixel is
+    (0, 0), while the lower left corner is (-0.5, -0.5).
+
+    Examples
+    --------
+    >>> _toindex(np.array([-0.5, 0.49999]))
+    array([0, 0])
+    >>> _toindex(np.array([0.5, 1.49999]))
+    array([1, 1])
+    >>> _toindex(np.array([1.5, 2.49999]))
+    array([2, 2])
+    """
+    indx = np.asarray(np.floor(np.asarray(value) + 0.5), dtype=np.int)
+    return indx

--- a/jwst/transforms/schemas/miri_ab2slice-0.7.0.yaml
+++ b/jwst/transforms/schemas/miri_ab2slice-0.7.0.yaml
@@ -1,0 +1,26 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/jwst_pipeline/miri_ab2slice-0.7.0"
+tag: "tag:stsci.edu:jwst_pipeline/miri_ab2slice-0.7.0"
+title: >
+  MIRI MRS (alpha, beta) to slice number transform.
+
+description: |
+  This model is used by the MIRI MRS WCS pipeline.
+  Given a (beta, ) cooridnate it computes the slice number
+  that the coordinate belongs to in detector coordinates.
+
+allOf:
+  - $ref: ../asdf/transform/transform-1.1.0
+  - type: object
+    properties:
+      beta_zero:
+        description: |
+          Beta coordinate of the center of slice 1 in the MIRI MRS.
+        type: number
+      beta_del:
+        description: |
+          Slice width.
+        type: number
+    required: [beta_zero, beta_del]

--- a/jwst/transforms/schemas/miri_ab2slice-0.7.0.yaml
+++ b/jwst/transforms/schemas/miri_ab2slice-0.7.0.yaml
@@ -23,4 +23,9 @@ allOf:
         description: |
           Slice width.
         type: number
-    required: [beta_zero, beta_del]
+      channel:
+        description: |
+          MIRI channel number.
+        type:
+          number
+    required: [beta_zero, beta_del, channel]

--- a/jwst/transforms/tags/jwst_models.py
+++ b/jwst/transforms/tags/jwst_models.py
@@ -7,12 +7,12 @@ from asdf.tags.transform.basic import TransformType
 from ..models import (WavelengthFromGratingEquation, AngleFromGratingEquation,
                       NRSZCoord, Unitless2DirCos, DirCos2Unitless, Rotation3DToGWA,
                       LRSWavelength, Gwa2Slit, Slit2Msa, Logical, NirissSOSSModel, V23ToSky,
-                      RefractionIndexFromPrism, Snell)
+                      RefractionIndexFromPrism, Snell, MIRI_AB2Slice)
 
 
 __all__ = ['GratingEquationType', 'CoordsType', 'RotationSequenceType', 'LRSWavelengthType',
            'Gwa2SlitType', 'Slit2MsaType', 'LogicalType', 'NirissSOSSType', 'V23ToSky',
-           'RefractionIndexType', 'SnellType']
+           'RefractionIndexType', 'SnellType', 'MIRI_AB2SliceType']
 
 
 class RotationSequenceType(TransformType):
@@ -277,3 +277,27 @@ class SnellType(TransformType):
         assert_array_equal(a.pref, b.pref)
         assert_array_equal(a.temp, b.temp)
         assert_array_equal(a.pressure, b.pressure)
+
+
+class MIRI_AB2SliceType(TransformType):
+    name = "miri_ab2slice"
+    types = [MIRI_AB2Slice]
+    standard = "jwst_pipeline"
+    version = "0.7.0"
+
+    @classmethod
+    def from_tree_transform(cls, node, ctx):
+        return MIRI_AB2Slice(node['beta_zero'], node['beta_del'])
+
+    @classmethod
+    def to_tree_transform(cls, model, ctx):
+        node = {'beta_zero': model.beta_zero.value, 'beta_del': model.beta_del.value}
+        return yamlutil.custom_tree_to_tagged_tree(node, ctx)
+
+    @classmethod
+    def assert_equal(cls, a, b):
+        TransformType.assert_equal(a, b)
+        assert (isinstance(a, MIRI_AB2Slice) and
+                isinstance(b, MIRI_AB2Slice))
+        assert_array_equal(a.beta_zero, b.beta_zero)
+        assert_array_equal(a.beta_del, b.beta_del)

--- a/jwst/transforms/tags/jwst_models.py
+++ b/jwst/transforms/tags/jwst_models.py
@@ -287,11 +287,14 @@ class MIRI_AB2SliceType(TransformType):
 
     @classmethod
     def from_tree_transform(cls, node, ctx):
-        return MIRI_AB2Slice(node['beta_zero'], node['beta_del'])
+        return MIRI_AB2Slice(node['beta_zero'], node['beta_del'], node['channel'])
 
     @classmethod
     def to_tree_transform(cls, model, ctx):
-        node = {'beta_zero': model.beta_zero.value, 'beta_del': model.beta_del.value}
+        node = {'beta_zero': model.beta_zero.value,
+                'beta_del': model.beta_del.value,
+                'channel': model.channel.value
+                }
         return yamlutil.custom_tree_to_tagged_tree(node, ctx)
 
     @classmethod
@@ -301,3 +304,4 @@ class MIRI_AB2SliceType(TransformType):
                 isinstance(b, MIRI_AB2Slice))
         assert_array_equal(a.beta_zero, b.beta_zero)
         assert_array_equal(a.beta_del, b.beta_del)
+        assert_array_equal(a.channel, b.channel)


### PR DESCRIPTION

This corrects problems with the MIRI MRS transform from `alpha, beta` to `detector`.
These changes go with spacetelescope/asdf-standard#140 and spacetelescope/gwcs#78 which should be merged before this one.