### PR TITLE
Fix PC matrix computation

### DIFF
--- a/jwst/tests/test_set_telescope_pointing.py
+++ b/jwst/tests/test_set_telescope_pointing.py
@@ -207,10 +207,10 @@ def test_add_wcs_default(fits_file):
     assert header['PA_V3'] == 0.
     assert header['CRVAL1'] == TARG_RA
     assert header['CRVAL2'] == TARG_DEC
-    assert header['PC1_1'] == 1.0
-    assert header['PC1_2'] == 0.0
-    assert header['PC2_1'] == 0.0
-    assert header['PC2_2'] == 1.0
+    assert np.isclose(header['PC1_1'], -0.7558009)
+    assert np.isclose(header['PC1_2'], 0.6548015)
+    assert np.isclose(header['PC2_1'], 0.6548015)
+    assert np.isclose(header['PC2_2'], 0.7558009)
     assert header['RA_REF'] == TARG_RA
     assert header['DEC_REF'] == TARG_DEC
     assert np.isclose(header['ROLL_REF'], 358.9045979379)
@@ -227,8 +227,8 @@ def test_add_wcs_with_db(eng_db, fits_file):
         assert np.isclose(header['PA_V3'], 50.1767077)
         assert np.isclose(header['CRVAL1'], 348.8776709)
         assert np.isclose(header['CRVAL2'], -38.854159)
-        assert np.isclose(header['PC1_1'], -0.0385309)
-        assert np.isclose(header['PC1_2'], -0.9992574)
+        assert np.isclose(header['PC1_1'], 0.0385309)
+        assert np.isclose(header['PC1_2'], 0.9992574)
         assert np.isclose(header['PC2_1'], 0.9992574)
         assert np.isclose(header['PC2_2'], -0.0385309)
         assert np.isclose(header['RA_REF'], 348.8776709)

--- a/scripts/set_telescope_pointing.py
+++ b/scripts/set_telescope_pointing.py
@@ -257,40 +257,43 @@ def add_wcs(filename):
     except ValueError as exception:
         logger.warning(
             'Cannot retrieve telescope pointing.'
-            '\nUsing proposal values.'
-            '\nFailure {}'.format(exception)
+            '\n{}'
+            '\nUsing TARG_RA, TARG_DEC and PA_V3=0 '
+            'to set pointing.'.format(exception)
         )
         ra = pheader['TARG_RA']
         dec = pheader['TARG_DEC']
         roll = 0
-        wcsinfo = (ra, dec, roll)
+        local_roll = compute_local_roll(roll, ra, dec, v2ref, v3ref)
+        wcsinfo = (ra, dec, local_roll)
         vinfo = (ra, dec, roll)
+        crval1, crval2, pa_aper_deg = wcsinfo
+        v1_ra_deg, v1_dec_deg, v3_pa_deg = vinfo
+        pa_aper_deg = local_roll - vparity * v3idlyang
     else:
         # compute relevant WCS information
-        logger.info('Successful read of Engineering Quaternions.')
+        logger.info('Successful read of engineering quaternions.')
         logger.debug('q={}'.format(q))
         logger.debug('j2fgs_matrix={}'.format(j2fgs_matrix))
         logger.debug('fsmcorr={}'.format(fsmcorr))
         wcsinfo, vinfo = calc_wcs(v2ref, v3ref, v3idlyang, vparity,
                                   q, j2fgs_matrix, fsmcorr)
+        crval1, crval2, pa_aper_deg = wcsinfo
+        v1_ra_deg, v1_dec_deg, v3_pa_deg = vinfo
+        local_roll = compute_local_roll(v3_pa_deg, crval1, crval2, v2ref, v3ref)
 
-    crval1, crval2, pa_aper_deg = wcsinfo
-    v1_ra_deg, v1_dec_deg, v3_pa_deg = vinfo
-    # update header
     pheader['RA_V1'] = v1_ra_deg
     pheader['DEC_V1'] = v1_dec_deg
     pheader['PA_V3'] = v3_pa_deg
     pheader['CRVAL1'] = crval1
     pheader['CRVAL2'] = crval2
-    pheader['PC1_1'] = np.cos(pa_aper_deg * D2R)
-    pheader['PC1_2'] = -np.sin(pa_aper_deg * D2R)
+    pheader['PC1_1'] = -np.cos(pa_aper_deg * D2R)
+    pheader['PC1_2'] = np.sin(pa_aper_deg * D2R)
     pheader['PC2_1'] = np.sin(pa_aper_deg * D2R)
     pheader['PC2_2'] = np.cos(pa_aper_deg * D2R)
     pheader['RA_REF'] = crval1
     pheader['DEC_REF'] = crval2
-    pheader['ROLL_REF'] = compute_local_roll(
-        v3_pa_deg, crval1, crval2, v2ref, v3ref
-    )
+    pheader['ROLL_REF'] = local_roll
     pheader['WCSAXES'] = len(pheader['CTYPE*'])
     hdulist.flush()
     hdulist.close()
@@ -421,8 +424,8 @@ def get_pointing(obstart, obsend, result_type='first'):
 
     if not len(results):
         raise ValueError(
-                'No non-zero quanternion found'
-                'in the DB for observation range given.'
+                'No non-zero quanternion found '
+                'in the DB between MJD {} and {}'.format(obstart, obsend)
             )
 
     if result_type == 'first':


### PR DESCRIPTION
For cases where quaternions are not found in DB:

- PA_V3 is zero, but compute ROLL_REF correctly for the detector at hand
- Use the correct ROLL_REF and V3I_YANG to compute the angle for
  use in PC matrix

Correct the parity of the PC matrix

Make log messages a bit more informative.