### PR TITLE
fix order of transforms in extract2d

### DIFF
--- a/jwst/extract_2d/extract_2d.py
+++ b/jwst/extract_2d/extract_2d.py
@@ -47,7 +47,7 @@ def extract2d(input_model, which_subarray=None):
 
             # Add the slit offset to each slit WCS object
             tr = slit_wcs.get_transform('detector', 'sca')
-            tr = tr | Shift(xlo) & Shift(ylo)
+            tr = Shift(xlo) & Shift(ylo) | tr
             slit_wcs.set_transform('detector', 'sca', tr.rename('dms2sca'))
 
             log.info('Name of subarray extracted: %s', slit.name)


### PR DESCRIPTION
The subarray offset should be applied before the rest of the transforms. The best test for this is NRS2 observation. On NRS1 this will result in wavelengths being slightly off while on NRS2 the result will be all NaNs.