### PR TITLE
Prevents build failure if sphinx is not installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,34 +1,50 @@
+from __future__ import print_function
+
 import os
 import subprocess
 import sys
-from setuptools import setup, find_packages, Extension
+from setuptools import setup, find_packages, Extension, Command
 from setuptools.command.test import test as TestCommand
 from numpy import get_include as np_include
 from glob import glob
 
 # hack building the sphinx docs with C source
 from setuptools.command.build_ext import build_ext
-import sphinx
-from sphinx.setup_command import BuildDoc
 
+try:
+    import sphinx
+    from sphinx.setup_command import BuildDoc
 
-class BuildSphinx(BuildDoc):
-    """Build Sphinx documentation after compiling C source files"""
+    class BuildSphinx(BuildDoc):
+        """Build Sphinx documentation after compiling C source files"""
 
-    description = 'Build Sphinx documentation'
+        description = 'Build Sphinx documentation'
 
-    def initialize_options(self):
-        BuildDoc.initialize_options(self)
+        def initialize_options(self):
+            BuildDoc.initialize_options(self)
 
-    def finalize_options(self):
-        BuildDoc.finalize_options(self)
+        def finalize_options(self):
+            BuildDoc.finalize_options(self)
 
-    def run(self):
-        build_cmd = self.reinitialize_command('build_ext')
-        build_cmd.inplace = 1
-        self.run_command('build_ext')
-        sphinx.build_main(['setup.py', '-b', 'html', './docs', './docs/_build/html'])
+        def run(self):
+            build_cmd = self.reinitialize_command('build_ext')
+            build_cmd.inplace = 1
+            self.run_command('build_ext')
+            sphinx.build_main(['setup.py', '-b', 'html', './docs', './docs/_build/html'])
 
+except ImportError:
+    class BuildSphinx(Command):
+        user_options = []
+
+        def initialize_options(self):
+            pass
+
+        def finalize_options(self):
+            pass
+
+        def run(self):
+            print('!\n! Sphinx is not installed!\n!', file=sys.stderr)
+            exit(1)
 
 
 NAME = 'jwst'


### PR DESCRIPTION
A person trying to build the jwst source code without `sphinx` installed will see this:

```bash
$ python setup.py install
Traceback (most recent call last):
  File "setup.py", line 11, in <module>
    import sphinx
ImportError: No module named sphinx
```

This change prevents `sphinx` from becoming a hard dependency at compile-time. If the user runs `build_sphinx` and `sphinx` is not installed, the script dies "gracefully".

```bash
$ python setup.py build_sphinx
running build_sphinx
!
! Sphinx is not installed!
!
```