### PR TITLE
Modifying miri.py for new MRS structure

### DIFF
--- a/jwst/assign_wcs/miri.py
+++ b/jwst/assign_wcs/miri.py
@@ -69,9 +69,9 @@ def imaging(input_model, reference_files):
     try:
         bb = distortion.bounding_box
     except NotImplementedError:
-        shape = input_model.data.shape
+        shape = 1032,1024
         # Note: Since bounding_box is attached to the model here it's in reverse order.
-        distortion.bounding_box = ((-0.5, shape[0] - 0.5), (3.5, shape[1] - 0.5))
+        distortion.bounding_box = ((-0.5, shape[1] - 0.5), (3.5, shape[0] - 4.5))
 
     # Create the pipeline
     pipeline = [(detector, distortion),
@@ -98,7 +98,7 @@ def imaging_distortion(input_model, reference_files):
     3. Apply Ai and BI matrices
     4. Apply the TI matrix (this gives Xan/Yan coordinates)
     5. Aply the XanYan --> V2V3 transform
-    5. Apply V2V3 --> sky transform
+    6. Apply V2V3 --> sky transform
 
     ref_file: filter_offset.asdf - (1)
     ref_file: distortion.asdf -(2,3,4)
@@ -114,7 +114,7 @@ def imaging_distortion(input_model, reference_files):
             distortion = models.Shift(filter_corr['column_offset']) & models.Shift(
                 filter_corr['row_offset']) | distortion
 
-    # scale to degrees
+    # scale to degrees (remove this once pipeline can handle v2,v3 in arcsec)
     distortion = distortion | models.Scale(1 / 3600) & models.Scale(1 / 3600)
     return distortion
 
@@ -218,6 +218,8 @@ def lrs(input_model, reference_files):
 def ifu(input_model, reference_files):
     """
     Create the WCS pipeline for a MIRI IFU observation.
+    Goes from 0-indexed detector pixels (0,0) middle of lower left reference pixel
+    to V2,V3 in arcsec.
 
     Parameters
     ----------
@@ -232,34 +234,34 @@ def ifu(input_model, reference_files):
                         #'regions': 'jwst_miri_regions_00001.asdf',
                         #'v2v3': 'jwst_miri_v2v3_00001.asdf'
                         #'wavelengthrange': 'jwst_miri_wavelengthrange_0001.asdf'}
+
+    # Define reference frames
     detector = cf.Frame2D(name='detector', axes_order=(0, 1), unit=(u.pix, u.pix))
     alpha_beta = cf.Frame2D(name='alpha_beta_spatial', axes_order=(0, 1), unit=(u.arcsec, u.arcsec), axes_names=('alpha', 'beta'))
     spec_local = cf.SpectralFrame(name='alpha_beta_spectral', axes_order=(2,), unit=(u.micron,), axes_names=('lambda',))
     miri_focal = cf.CompositeFrame([alpha_beta, spec_local], name='alpha_beta')
-    xyan_spatial = cf.Frame2D(name='Xan_Yan_spatial', axes_order=(0, 1), unit=(u.arcmin, u.arcmin), axes_names=('v2', 'v3'))
-    spec = cf.SpectralFrame(name='Xan_Yan_spectral', axes_order=(2,), unit=(u.micron,), axes_names=('lambda',))
-    xyan = cf.CompositeFrame([xyan_spatial, spec], name='Xan_Yan')
     v23_spatial = cf.Frame2D(name='V2_V3_spatial', axes_order=(0, 1), unit=(u.deg, u.deg), axes_names=('v2', 'v3'))
     spec = cf.SpectralFrame(name='spectral', axes_order=(2,), unit=(u.micron,), axes_names=('lambda',))
     v2v3 = cf.CompositeFrame([v23_spatial, spec], name='v2v3')
     icrs = cf.CelestialFrame(name='icrs', reference_frame=coord.ICRS(),
                              axes_order=(0, 1), unit=(u.deg, u.deg), axes_names=('RA', 'DEC'))
     world = cf.CompositeFrame([icrs, spec], name='world')
-    det2alpha_beta = (detector_to_alpha_beta(input_model, reference_files)).rename(
-        "detector_to_alpha_beta")
-    ab2xyan = (alpha_beta2XanYan(input_model, reference_files)).rename("alpha_beta_to_Xan_Yan")
-    xyan2v23 = models.Identity(1) & (models.Shift(7.8) | models.Scale(-1)) & models.Identity(1) | \
-        models.Scale(1/60) & models.Scale(1/60) & models.Identity(1)
+
+    # Define the actual transforms
+    det2abl = (detector_to_abl(input_model, reference_files)).rename(
+        "detector_to_abl")
+    abl2v2v3l = (abl_to_v2v3l(input_model, reference_files)).rename("abl_to_v2v3l")
     tel2sky = pointing.v23tosky(input_model) & models.Identity(1)
-    pipeline = [(detector, det2alpha_beta),
-                (miri_focal, ab2xyan),
-                (xyan, xyan2v23),
+
+    # Put the transforms together into a single transform
+    pipeline = [(detector, det2abl),
+                (miri_focal, abl2v2v3l),
                 (v2v3, tel2sky),
                 (world, None)]
     return pipeline
 
 
-def detector_to_alpha_beta(input_model, reference_files):
+def detector_to_abl(input_model, reference_files):
     """
     Create the transform from detector to alpha, beta frame.
 
@@ -333,9 +335,9 @@ def detector_to_alpha_beta(input_model, reference_files):
     return det2alpha_beta
 
 
-def alpha_beta2XanYan(input_model, reference_files):
+def abl_to_v2v3l(input_model, reference_files):
     """
-    Create the transform from detector to Xan, Yan frame.
+    Create the transform from (alpha,beta,lambda) to (V2,V3,lambda) frame.
 
     Parameters
     ----------
@@ -348,12 +350,12 @@ def alpha_beta2XanYan(input_model, reference_files):
       RegionsSelector
         label_mapper is LabelMapperDict()
         {channel_wave_range (): channel_number}
-        selector is {channel_number: ab2Xan & ab2Yan}
+        selector is {channel_number: ab2v2 & ab2v3}
     bacward_transform
       RegionsSelector
         label_mapper is LabelMapperDict()
         {channel_wave_range (): channel_number}
-        selector is {channel_number: Xan2ab & Yan2ab}
+        selector is {channel_number: v22ab & v32ab}
     """
     band = input_model.meta.instrument.band
     channel = input_model.meta.instrument.channel
@@ -372,32 +374,32 @@ def alpha_beta2XanYan(input_model, reference_files):
 
     dict_mapper = {}
     sel = {}
+    # Since there are two channels in each reference file we need to loop over them
     for c in channels:
         ch = int(c[0])
         dict_mapper[tuple(wr[c])] = models.Mapping((2,), name="mapping_lam") | \
                    models.Const1D(ch, name="channel #")
-        map1 = models.Mapping((1, 0, 1, 0), name='map2poly')
-        map1._outputs = ('alpha', 'beta', 'alpha', 'beta')
-        map1._inputs = ('alpha', 'beta')
-        map1.inverse = models.Mapping((0, 1))
         ident1 = models.Identity(1, name='identity_lam')
         ident1._inputs = ('lam',)
         chan_v23 = v23[c]
         v23chan_backward = chan_v23.inverse
         del chan_v23.inverse
-        v23_spatial = map1 | chan_v23
-        v23_spatial.inverse = map1 | v23chan_backward
+        # This is the spatial part of the transform; tack on additional conversion to degrees
+        # Remove this degrees conversion once pipeline can handle v2,v3 in arcsec
+        v23_spatial=chan_v23 | models.Scale(1 / 3600) & models.Scale(1 / 3600)
+        v23_spatial.inverse = models.Scale(3600) & models.Scale(3600) | v23chan_backward
+        # Tack on passing the third wavelength component
         v23c = v23_spatial & ident1
         sel[ch] = v23c
 
     wave_range_mapper = selector.LabelMapperRange(('alpha', 'beta', 'lam'), dict_mapper,
                                                   inputs_mapping=models.Mapping([2, ]))
     wave_range_mapper.inverse = wave_range_mapper.copy()
-    ab2xyan = selector.RegionsSelector(('alpha', 'beta', 'lam'), ('v2', 'v3', 'lam'),
+    abl2v2v3l = selector.RegionsSelector(('alpha', 'beta', 'lam'), ('v2', 'v3', 'lam'),
                                       label_mapper=wave_range_mapper,
                                       selector=sel)
 
-    return ab2xyan
+    return abl2v2v3l
 
 exp_type2transform = {'mir_image': imaging,
                       'mir_tacq': imaging,


### PR DESCRIPTION
Revises miri.py to work with the newly-created MRS reference files; abstracts XAN/YAN into the reference file instead of requiring handling in miri.py.  Changes some function names for better clarity.  Updates imager bounding boxes.