### PR TITLE
Pass thru jsonschema error message after validation error

### DIFF
--- a/jwst/datamodels/fits_support.py
+++ b/jwst/datamodels/fits_support.py
@@ -473,15 +473,15 @@ def _load_from_schema(hdulist, schema, tree, pass_invalid_values):
     known_datas = set()
     invalid_values = set()
 
-    def prefix_filename(msg):
-        # Prefix filename to message where it can be found
+    def prefix_filename(errmsg):
+        # Prefix filename to error message where it can be found
         try:
             filename = hdulist._file.name
         except AttributeError:
             filename = None
         if filename is not None:
-            msg = "In {0} {1}".format(filename, msg)
-        return msg
+            errmsg = "In {0} {1}".format(filename, errmsg)
+        return errmsg
                         
     def callback(schema, path, combiner, ctx, recurse):
         result = None
@@ -497,17 +497,8 @@ def _load_from_schema(hdulist, schema, tree, pass_invalid_values):
                 temp_schema.update(schema)
                 try:
                     asdf_schema.validate(result, schema=temp_schema)
-                except jsonschema.ValidationError:
-                    if isinstance(result, six.string_types):
-                        result = "'{0}'".format(result)
-                    else:
-                        result = str(result)
-
-                    msgfmt = "{0} is not valid in {1}"
-                    msg = msgfmt.format(result, fits_keyword)
-                    msg = prefix_filename(msg)
-
-                    warnings.warn(msg, properties.ValidationWarning)
+                except jsonschema.ValidationError as errmsg:
+                    warnings.warn(str(errmsg), properties.ValidationWarning)
                     if not pass_invalid_values:
                         invalid_values.add(fits_keyword)
                         
@@ -525,16 +516,11 @@ def _load_from_schema(hdulist, schema, tree, pass_invalid_values):
                 temp_schema.update(schema)
                 try:
                     asdf_schema.validate(result, schema=temp_schema)
-                except jsonschema.ValidationError:
+                except jsonschema.ValidationError as errmsg:
                     fits_hdu = schema['fits_hdu']
-                    
-                    msgfmt = "{0} is not valid"
-                    msg = msgfmt.format(fits_hdu)
-                    msg = prefix_filename(msg)
-
-                    warnings.warn(msg, properties.ValidationWarning)
+                    warnings.warn(str(errmsg), properties.ValidationWarning)
                     if not pass_invalid_values:
-                        invalid_values.add(fits_keyword)
+                        invalid_values.add(fits_hdu)
                 else:
                     properties.put_value(path, result, tree)
 
@@ -551,9 +537,9 @@ def _load_from_schema(hdulist, schema, tree, pass_invalid_values):
     mschema.walk_schema(schema, callback)
     if len(invalid_values) > 0:
         msgfmt = "fits data is not valid: {0}"
-        msg = msgfmt.format(','.join(list(invalid_values)))
-        msg = prefix_filename(msg)
-        raise jsonschema.ValidationError(msg)
+        errmsg = msgfmt.format(','.join(list(invalid_values)))
+        errmsg = prefix_filename(errmsg)
+        raise jsonschema.ValidationError(errmsg)
     return known_keywords, known_datas
 
 

--- a/jwst/datamodels/properties.py
+++ b/jwst/datamodels/properties.py
@@ -156,40 +156,17 @@ class Node(object):
         self._schema['$schema'] = 'http://stsci.edu/schemas/asdf-schema/0.1.0/asdf-schema'
         self._ctx = ctx
 
-    def _report(self, value, attr=None):
-        if value is None:
-            if attr is None:
-                msg = "is not valid list operation"
-            else:
-                msgfmt = "{0} is not valid to delete"
-                msg = msgfmt.format(attr)
-        else:
-            if isinstance(value, six.string_types):
-                value = "'{0}'".format(value)
-            else:
-                value = str(value)
-                if len(value) > 55:
-                    value = value[:56] + " ..."
-
-            if attr is None:
-                msgfmt = "{0} is not valid"
-                msg = msgfmt.format(value)
-            else:
-                msgfmt = "{0} is not valid in {1}"
-                msg = msgfmt.format(value, attr)
-                
+    def _report(self, errmsg):
         try:
             filename = self._ctx.meta.filename
+            errmsg = "In {0} {1}".format(filename, errmsg)
         except AttributeError:
-            filename = None
-        
-        if filename is not None:
-            msg = "In {0} {1}".format(filename, msg)
+            pass
 
         if self._ctx._pass_invalid_values:
-            warnings.warn(msg, ValidationWarning)
+            warnings.warn(errmsg, ValidationWarning)
         else:
-            raise jsonschema.ValidationError(msg)
+            raise jsonschema.ValidationError(errmsg)
 
 
     def _validate(self):
@@ -197,10 +174,11 @@ class Node(object):
             self._instance, self._ctx._asdf)
         try:
             schema.validate(instance, schema=self._schema)
-            valid = True
-        except jsonschema.ValidationError:
-            valid = False     
-        return valid
+            errmsg = None
+        except jsonschema.ValidationError as errmsg:
+            errmsg = str(errmsg)
+            self._report(errmsg)  
+        return errmsg
 
     @property
     def instance(self):
@@ -257,15 +235,20 @@ class ObjectNode(Node):
             old_val = self._instance.get(attr, None)
 
             self._instance[attr] = val
-            if not self._validate():
+            try:
+                errmsg = self._validate()
+                reraise = False
+            except jsonschema.ValidationError as errmsg:
+                reraise = True
+            if errmsg is not None:
                 # Revert the change
                 if old_val is None:
                     del self._instance[attr]
                 else:
                     self._instance[attr] = old_val
+                if reraise:
+                    raise jsonschema.ValidationError(errmsg)
 
-                self._report(val, attr)
-                
     def __delattr__(self, attr):
         if attr.startswith('_'):
             del self.__dict__[attr]
@@ -277,12 +260,17 @@ class ObjectNode(Node):
             except KeyError:
                 raise AttributeError(
                     "Attribute '{0}' missing".format(attr))
-            if not self._validate():
+            try:
+                errmsg = self._validate()
+                reraise = False
+            except jsonschema.ValidationError as errmsg:
+                reraise = True
+            if errmsg is not None:
                 # Revert the change
                 if old_val is not None:
                     self._instance[attr] = old_val
-                        
-                self._report(None, attr)
+                if reraise:
+                    raise jsonschema.ValidationError(errmsg)
 
     def __hasattr__(self, attr):
         return (attr in self._instance or
@@ -316,13 +304,11 @@ class ListNode(Node):
     def __setitem__(self, i, val):
         schema = _get_schema_for_index(self._schema, i)
         self._instance[i] = _cast(val, schema)
-        if not self._validate():
-            self._report(val)
+        self._validate()
 
     def __delitem__(self, i):
         del self._instance[i]
-        if not self._validate():
-            self._report(None)
+        self._validate()
 
     def __getslice__(self, i, j):
         if isinstance(self._schema['items'], list):
@@ -340,37 +326,31 @@ class ListNode(Node):
         parts = [_cast(x, _get_schema_for_index(self._schema, k))
                  for (k, x) in enumerate(parts)]
         self._instance[i:j] = _unmake_node(other)
-        if not self._validate():
-            self._report(None)
+        self._validate()
 
     def __delslice__(self, i, j):
         del self._instance[i:j]
-        if not self._validate():
-            self._report(None)
+        self._validate()
             
     def append(self, item):
         schema = _get_schema_for_index(self._schema, len(self._instance))
         self._instance.append(_cast(item, schema))
-        if not self._validate():
-            self._report(item)
+        self._validate()
 
     def insert(self, i, item):
         schema = _get_schema_for_index(self._schema, i)
         self._instance.insert(i, _cast(item, schema))
-        if not self._validate():
-            self._report(item)
+        self._validate()
 
     def pop(self, i=-1):
         schema = _get_schema_for_index(self._schema, 0)
         x = self._instance.pop(i)
-        if not self._validate():
-            self._report(None)
+        self._validate()
         return _make_node(x, schema, self._ctx)
 
     def remove(self, item):
         self._instance.remove(item)
-        if not self._validate():
-            self._report(None)
+        self._validate()
 
     def count(self, item):
         return self._instance.count(item)
@@ -380,13 +360,11 @@ class ListNode(Node):
 
     def reverse(self):
         self._instance.reverse()
-        if not self._validate():
-            self._report(None)
+        self._validate()
 
     def sort(self, *args, **kwargs):
         self._instance.sort(*args, **kwargs)
-        if not self._validate():
-            self._report(None)
+        self._validate()
             
     def extend(self, other):
         for part in _unmake_node(other):
@@ -395,8 +373,7 @@ class ListNode(Node):
     def item(self, **kwargs):
         assert isinstance(self._schema['items'], dict)
         obj = ObjectNode(kwargs, self._schema['items'], self._ctx)
-        if not obj._validate():
-            self._report(None)
+        obj._validate()
         return obj
 
 def put_value(path, value, tree):

--- a/jwst/datamodels/properties.py
+++ b/jwst/datamodels/properties.py
@@ -239,6 +239,7 @@ class ObjectNode(Node):
                 errmsg = self._validate()
                 reraise = False
             except jsonschema.ValidationError as errmsg:
+                errmsg = str(errmsg)
                 reraise = True
             if errmsg is not None:
                 # Revert the change
@@ -264,6 +265,7 @@ class ObjectNode(Node):
                 errmsg = self._validate()
                 reraise = False
             except jsonschema.ValidationError as errmsg:
+                errmsg = str(errmsg)
                 reraise = True
             if errmsg is not None:
                 # Revert the change


### PR DESCRIPTION
Datamodels validates changes against the schema. However, the change itself may not be the actual error if the model is already invalid. Passing thru the message generated by jsonschema ensures the
error message is not misleading.