### PR TITLE
Fix bugs in Image3Pipeline

### DIFF
--- a/jwst/outlier_detection/flag_cr.py
+++ b/jwst/outlier_detection/flag_cr.py
@@ -204,11 +204,11 @@ def flag_cr(sci_image, blot_image, gain_image, readnoise_image, **pars):
     np.logical_and(where_cr_ctegrow_kernel_conv, where_cr_grow_kernel_conv, cr_mask)
     cr_mask = cr_mask.astype(bool)
 
-    # Update the DQ array in the input image
+    # Update the DQ array in the input image in place
     np.bitwise_or(sci_image.dq, np.invert(cr_mask) * CRBIT, sci_image.dq)
 
     # write out the updated file to disk to preserve the changes
-    sci_image.save(sci_image.meta.filename)
+    # sci_image.save(sci_image.meta.filename)
 
     # write out the dq array as a separate file
     # outfilename = sci_image.meta.filename.split('.')[0] + '_dq.fits'

--- a/jwst/outlier_detection/outlier_detection.py
+++ b/jwst/outlier_detection/outlier_detection.py
@@ -130,12 +130,13 @@ class OutlierDetection(object):
         pars = self.outlierpars
 
         # Start by creating resampled/mosaic images for each group of exposures
-        sdriz = resample.resample.ResampleData(self.input_models, single=True, **pars)
+        sdriz = resample.resample.ResampleData(self.input_models, single=True,
+            blendheaders=False, **pars)
         sdriz.do_drizzle(**pars)
         drizzled_models = sdriz.output_models
         if self.to_file:
             log.info("Saving resampled grouped exposures to disk...")
-            drizzled_models.save(None)
+            drizzled_models.save()
 
         # Initialize intermediate products used in the outlier detection
         median_model = datamodels.ImageModel(init=drizzled_models[0].data.shape)
@@ -162,7 +163,7 @@ class OutlierDetection(object):
             blot_models.save()
 
         # Perform outlier detection using statistical comparisons between
-        # original input images and their blotted-median images
+        # each original input image and its blotted version of the median image
         flag_cr.do_detection(self.input_models, blot_models,
             self.reffiles, **pars)
 

--- a/jwst/pipeline/calwebb_image3.py
+++ b/jwst/pipeline/calwebb_image3.py
@@ -52,28 +52,30 @@ class Image3Pipeline(Pipeline):
         is_container = (type(input_models) == type(datamodels.ModelContainer()))
         if is_container and len(input_models.group_names) > 1:
 
-            generate_2c_names(input_models)
+            # generate_2c_names(input_models)
 
-            # perform full outlier_detection of ASN data
             log.info("Generating source catalogs for alignment...")
             input_models = self.tweakreg_catalog(input_models)
+
             log.info("Aligning input images...")
             input_models = self.tweakreg(input_models)
+
             log.info("Matching sky values across all input images...")
             input_models = self.skymatch(input_models)
+
             log.info("Performing outlier detection on input images...")
             input_models = self.outlier_detection(input_models)
             
-            # Now clean up intermediate products which no are no longer needed
-            for i in input_models:
+            # Now clean up intermediate tweakreg_catalog catalogs
+            # which no are no longer needed
+            for model in input_models:
                 try:
-                    catalog_name = i.meta.tweakreg_catalog.filename
+                    catalog_name = model.meta.tweakreg_catalog.filename
                     os.remove(catalog_name)
                 except:
                     pass
 
-            log.info("Resampling {} to create combined "
-                "product: {}".format(input, input_models.meta.resample.output))
+            log.info("Resampling images in {} ...".format(input))
 
         # Setup output file name for subsequent use
         # TODO: fix single resample to do what outlier detection does
@@ -92,9 +94,9 @@ class Image3Pipeline(Pipeline):
         # Save the final image product
         log.info('Saving final image product to %s', output_file)
         output.save(output_file)
-        log.info('... ending calwebb_image3')
 
         return
+
 
 def generate_2c_names(input_models):
     """ Update the names of the input files with Level 2C names

--- a/jwst/pipeline/calwebb_image3.py
+++ b/jwst/pipeline/calwebb_image3.py
@@ -1,10 +1,10 @@
-#!/usr/bin/env python
+from __future__ import unicode_literals, absolute_import
+
 import os
 
 from ..stpipe import Pipeline
 from .. import datamodels
 
-# calwebb Image3 step imports
 from ..resample import resample_step
 from ..skymatch import skymatch_step
 from ..outlier_detection import outlier_detection_step
@@ -13,7 +13,7 @@ from ..tweakreg_catalog import tweakreg_catalog_step
 from ..tweakreg import tweakreg_step
 
 __version__ = "0.7.0"
-# Define logging
+
 import logging
 log = logging.getLogger()
 log.setLevel(logging.DEBUG)
@@ -49,10 +49,10 @@ class Image3Pipeline(Pipeline):
 
         input_models = datamodels.open(input)
 
-        is_container = (type(input_models) == type(datamodels.ModelContainer()))
-        if is_container and len(input_models.group_names) > 1:
+        is_container = isinstance(input_models, datamodels.ModelContainer)
 
-            # generate_2c_names(input_models)
+        # Multiple input files that represent more than 1 exposure
+        if is_container and len(input_models.group_names) > 1:
 
             log.info("Generating source catalogs for alignment...")
             input_models = self.tweakreg_catalog(input_models)
@@ -60,14 +60,7 @@ class Image3Pipeline(Pipeline):
             log.info("Aligning input images...")
             input_models = self.tweakreg(input_models)
 
-            log.info("Matching sky values across all input images...")
-            input_models = self.skymatch(input_models)
-
-            log.info("Performing outlier detection on input images...")
-            input_models = self.outlier_detection(input_models)
-            
-            # Now clean up intermediate tweakreg_catalog catalogs
-            # which no are no longer needed
+            # Clean up tweakreg catalogs which no are no longer needed
             for model in input_models:
                 try:
                     catalog_name = model.meta.tweakreg_catalog.filename
@@ -75,24 +68,27 @@ class Image3Pipeline(Pipeline):
                 except:
                     pass
 
-            log.info("Resampling images in {} ...".format(input))
+            log.info("Matching sky values across all input images...")
+            input_models = self.skymatch(input_models)
+
+            log.info("Performing outlier detection on input images...")
+            input_models = self.outlier_detection(input_models)
+
+            log.info("Writing out Level 2c images with updated DQ arrays...")
+            generate_2c_names(input_models)
+            input_models.save()
 
         # Setup output file name for subsequent use
-        # TODO: fix single resample to do what outlier detection does
-        # in updating meta.resample.*
-        output_file = mk_prodname(self.output_dir,
-            input_models.meta.resample.output, 'i2d')
+        output_file = mk_prodname(self.output_dir, input_models.meta.resample.output, 'i2d')
         input_models.meta.resample.output = output_file
 
-        # Resample step always returns ModelContainer,
-        # yet we only need the DataModel result
+        log.info("Resampling images to final output...")
         output = self.resample(input_models)
 
-        # create final source catalog from resampled output
+        log.info("Creating source catalog...")
         out_catalog = self.source_catalog(output)
 
-        # Save the final image product
-        log.info('Saving final image product to %s', output_file)
+        log.info('Saving final resampled image to %s', output_file)
         output.save(output_file)
 
         return

--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -96,8 +96,8 @@ class ResampleData(object):
         drizpars = ref_model.drizpars_table
 
         filter_match = False # flag to support wild-card rows in drizpars table
-        for n, filt, num in zip(range(1, drizpars.numimages.shape[0] + 1),
-            drizpars.filter, drizpars.numimages):
+        for n, filt, num in zip(range(0, len(drizpars)), drizpars.filter,
+            drizpars.numimages):
             # only remember this row if no exact match has already been made for
             # the filter. This allows the wild-card row to be anywhere in the
             # table; since it may be placed at beginning or end of table.
@@ -117,7 +117,7 @@ class ResampleData(object):
         # read in values from that row for each parameter
         for kw in self.drizpars:
             if kw in drizpars.names:
-                self.drizpars[kw] = ref_model['drizpars_table.{0}'.format(kw)][row]
+                self.drizpars[kw] = getattr(drizpars, kw)[row]
 
     def update_driz_outputs(self):
         """ Define output arrays for use with drizzle operations.


### PR DESCRIPTION
- Prevent flag_cr from writing out the updated dq array to the
  input FITS files
- Turn off blendheaders for outlier_detection step
- Turn off 2c names in Image3Pipeline