### PR TITLE
Update photom reference file schema [skip ci]

### DIFF
--- a/jwst/datamodels/schemas/fgs_photom.schema.yaml
+++ b/jwst/datamodels/schemas/fgs_photom.schema.yaml
@@ -1,6 +1,7 @@
 title: FGS photometric flux conversion data model
 allOf:
 - $ref: photom.schema.yaml
+- $ref: keyword_pixelarea.schema.yaml
 - type: object
   properties:
     phot_table:

--- a/jwst/datamodels/schemas/keyword_photmjsr.schema.yaml
+++ b/jwst/datamodels/schemas/keyword_photmjsr.schema.yaml
@@ -1,0 +1,13 @@
+type: object
+properties:
+  meta:
+    type: object
+    properties:
+      photometry:
+        title: Photometry information
+        type: object
+        properties:
+          conversion_megajanskys:
+            title: Flux density (MJy/steradian) producing 1 cps
+            type: number
+            fits_keyword: PHOTMJSR

--- a/jwst/datamodels/schemas/keyword_pixelarea.schema.yaml
+++ b/jwst/datamodels/schemas/keyword_pixelarea.schema.yaml
@@ -1,0 +1,17 @@
+type: object
+properties:
+  meta:
+    type: object
+    properties:
+      photometry:
+        title: Photometry information
+        type: object
+        properties:
+          pixelarea_steradians:
+            title: Nominal pixel area in steradians
+            type: number
+            fits_keyword: PIXAR_SR
+          pixelarea_arcsecsq:
+            title: Nominal pixel area in arcsec^2
+            type: number
+            fits_keyword: PIXAR_A2

--- a/jwst/datamodels/schemas/mirimg_photom.schema.yaml
+++ b/jwst/datamodels/schemas/mirimg_photom.schema.yaml
@@ -1,6 +1,7 @@
 title: MIRI imager photometric flux conversion data model
 allOf:
 - $ref: photom.schema.yaml
+- $ref: keyword_pixelarea.schema.yaml
 - type: object
   properties:
     phot_table:

--- a/jwst/datamodels/schemas/mirmrs_photom.schema.yaml
+++ b/jwst/datamodels/schemas/mirmrs_photom.schema.yaml
@@ -1,6 +1,8 @@
 title: MIRI MRS photometric flux conversion data model
 allOf:
 - $ref: photom.schema.yaml
+- $ref: keyword_band.schema.yaml
+- $ref: keyword_photmjsr.schema.yaml
 - type: object
   properties:
     data:

--- a/jwst/datamodels/schemas/nircam_photom.schema.yaml
+++ b/jwst/datamodels/schemas/nircam_photom.schema.yaml
@@ -1,6 +1,7 @@
 title: NIRCam photometric flux conversion data model
 allOf:
 - $ref: photom.schema.yaml
+- $ref: keyword_pixelarea.schema.yaml
 - type: object
   properties:
     phot_table:

--- a/jwst/datamodels/schemas/niriss_photom.schema.yaml
+++ b/jwst/datamodels/schemas/niriss_photom.schema.yaml
@@ -1,6 +1,7 @@
 title: NIRISS photometric flux conversion data model
 allOf:
 - $ref: photom.schema.yaml
+- $ref: keyword_pixelarea.schema.yaml
 - type: object
   properties:
     phot_table:

--- a/jwst/datamodels/schemas/nirspec_photom.schema.yaml
+++ b/jwst/datamodels/schemas/nirspec_photom.schema.yaml
@@ -1,6 +1,7 @@
 title: NIRSpec Image, IFU, and MOS photometric flux conversion data model
 allOf:
 - $ref: photom.schema.yaml
+- $ref: keyword_pexptype.schema.yaml
 - type: object
   properties:
     phot_table:

--- a/jwst/datamodels/schemas/nirspecfs_photom.schema.yaml
+++ b/jwst/datamodels/schemas/nirspecfs_photom.schema.yaml
@@ -1,6 +1,7 @@
 title: NIRSpec Fixed-Slit photometric flux conversion data model
 allOf:
 - $ref: photom.schema.yaml
+- $ref: keyword_pexptype.schema.yaml
 - type: object
   properties:
     phot_table:


### PR DESCRIPTION
Updated the various photom reference file schemas to use the new (non-core) approach. Also added a couple of new keyword_xxxxx schemas that I needed: one for the PHOTMJSR keyword and another for the 2 PIXAR_SR and PIXAR_A2 keywords. 

For the latter, I included the definitions for both keywords in a single schema and hence if we stick to the agreed upon convention for naming these files, it should be "pixelarea.schema.yaml". But because we already have a schema by that name, for the pixel area reference file, I named it "keyword_pixelarea.schema.yaml", even though it contains 2 keyword definitions. We could potentially get around this by renaming the existing pixelarea.schema.yaml (and associated pixearea.py module) to just "area.schema.yaml" (and "area.py").