### PR TITLE
Update flat field reference file schemas [skip ci]

### DIFF
--- a/jwst/datamodels/schemas/flat.schema.yaml
+++ b/jwst/datamodels/schemas/flat.schema.yaml
@@ -1,5 +1,6 @@
 allOf:
 - $ref: referencefile.schema.yaml
+- $ref: subarray.schema.yaml
 - type: object
   properties:
     data:

--- a/jwst/datamodels/schemas/nirspec_flat.schema.yaml
+++ b/jwst/datamodels/schemas/nirspec_flat.schema.yaml
@@ -1,5 +1,6 @@
 allOf:
-- $ref: core.schema.yaml
+- $ref: referencefile.schema.yaml
+- $ref: subarray.schema.yaml
 - type: object
   properties:
     data:

--- a/jwst/datamodels/schemas/nirspec_quad_flat.schema.yaml
+++ b/jwst/datamodels/schemas/nirspec_quad_flat.schema.yaml
@@ -1,5 +1,6 @@
 allOf:
-- $ref: core.schema.yaml
+- $ref: referencefile.schema.yaml
+- $ref: subarray.schema.yaml
 - type: object
   properties:
     quadrants:


### PR DESCRIPTION
The subarray schema was added to all three.  In the nirspec_flat and
nirspec_quad_flat schemas, core.schema.yaml was replaced with
referencefile.schema.yaml.  See issue #861.