### PR TITLE
Update reffile schema for drizpars and outlierpars

### DIFF
--- a/jwst/datamodels/schemas/drizpars.schema.yaml
+++ b/jwst/datamodels/schemas/drizpars.schema.yaml
@@ -1,10 +1,10 @@
 title: Default Drizzle parameters data model
 allOf:
-- $ref: core.schema.yaml
+- $ref: referencefile.schema.yaml
 - type: object
   properties:
     drizpars_table:
-      title: Distortion correction parameters table
+      title: Drizzle parameters table
       fits_hdu: DRIZPARS
       datatype:
       - name: numimages

--- a/jwst/datamodels/schemas/outlierpars.schema.yaml
+++ b/jwst/datamodels/schemas/outlierpars.schema.yaml
@@ -1,6 +1,6 @@
 title: Default Oulier Detection parameters data model
 allOf:
-- $ref: core.schema.yaml
+- $ref: referencefile.schema.yaml
 - type: object
   properties:
     outlierpars_table:


### PR DESCRIPTION
The other instrument-specific drizpars and outlierpars reffiles do not need to be updated.  This is in support of #861.  