### PR TITLE
Add Level-1b data model

### DIFF
--- a/jwst/datamodels/__init__.py
+++ b/jwst/datamodels/__init__.py
@@ -60,6 +60,7 @@ from .image import ImageModel
 from .ipc import IPCModel
 from .irs2 import IRS2Model
 from .lastframe import LastFrameModel
+from .level1b import Level1bModel
 from .linearity import LinearityModel
 from .mask import MaskModel
 from .miri_ramp import MIRIRampModel
@@ -102,8 +103,8 @@ __all__ = [
     'PathlossModel', 'PixelAreaModel',
     'DrizProductModel', 'FgsPhotomModel', 'ThroughputModel',
     'FlatModel', 'FringeModel', 'GainModel', 'GLS_RampFitModel',
-    'ImageModel', 'IPCModel', 'IRS2Model', 'LastFrameModel', 'LinearityModel',
-    'MaskModel', 'MIRIRampModel', 'ModelContainer',
+    'ImageModel', 'IPCModel', 'IRS2Model', 'LastFrameModel', 'Level1bModel',
+    'LinearityModel', 'MaskModel', 'MIRIRampModel', 'ModelContainer',
     'MultiExposureModel', 'MultiProductModel', 'MultiSlitModel',
     'MultiSpecModel', 'IFUCubeModel', 'PhotomModel', 'NircamPhotomModel',
     'NirissPhotomModel', 'NirspecPhotomModel', 'NirspecFSPhotomModel',

--- a/jwst/datamodels/level1b.py
+++ b/jwst/datamodels/level1b.py
@@ -21,18 +21,24 @@ class Level1bModel(model_base.DataModel):
     zeroframe : numpy array
         The zero-frame data
 
+    refout : numpy array
+        The MIRI reference output data
+
     group : table
         The group parameters table
 
     """
     schema_url = "level1b.schema.yaml"
 
-    def __init__(self, init=None, data=None, zeroframe=None, group=None,
-        **kwargs):
+    def __init__(self, init=None, data=None, refout=None, zeroframe=None,
+                 group=None, **kwargs):
         super(Level1bModel, self).__init__(init=init, **kwargs)
 
         if data is not None:
             self.data = data
+
+        if refout is not None:
+            self.refout = refout
 
         if zeroframe is not None:
             self.zeroframe = zeroframe

--- a/jwst/datamodels/level1b.py
+++ b/jwst/datamodels/level1b.py
@@ -1,0 +1,42 @@
+from __future__ import absolute_import, unicode_literals, division, print_function
+
+from . import model_base
+
+
+__all__ = ['Level1bModel']
+
+
+class Level1bModel(model_base.DataModel):
+    """
+    A data model for raw 4D ramps level-1b products.
+
+    Parameters
+    ----------
+    init : any
+        Any of the initializers supported by `~jwst.datamodels.DataModel`.
+
+    data : numpy array
+        The science data
+
+    zeroframe : numpy array
+        The zero-frame data
+
+    group : table
+        The group parameters table
+
+    """
+    schema_url = "level1b.schema.yaml"
+
+    def __init__(self, init=None, data=None, zeroframe=None, group=None,
+        **kwargs):
+        super(Level1bModel, self).__init__(init=init, **kwargs)
+
+        if data is not None:
+            self.data = data
+
+        if zeroframe is not None:
+            self.zeroframe = zeroframe
+
+        if group is not None:
+            self.group = group
+

--- a/jwst/datamodels/schemas/level1b.schema.yaml
+++ b/jwst/datamodels/schemas/level1b.schema.yaml
@@ -1,0 +1,20 @@
+allOf:
+- $ref: core.schema.yaml
+- $ref: bunit.schema.yaml
+- type: object
+  properties:
+    data:
+      title: The science data
+      fits_hdu: SCI
+      default: 0.0
+      ndim: 4
+      datatype: int16
+    zeroframe:
+      title: Zeroframe array
+      fits_hdu: ZEROFRAME
+      default: 0.0
+      ndim: 3
+      datatype: int16
+    group:
+      $ref: group.schema.yaml
+$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/level1b.schema.yaml
+++ b/jwst/datamodels/schemas/level1b.schema.yaml
@@ -15,6 +15,12 @@ allOf:
       default: 0.0
       ndim: 3
       datatype: int16
+    refout:
+      title: Reference Output
+      fits_hdu: REFOUT
+      default: 0.0
+      ndim: 4
+      datatype: int16
     group:
       $ref: group.schema.yaml
 $schema: http://stsci.edu/schemas/fits-schema/fits-schema


### PR DESCRIPTION
Adding a new data model that is an exact match to the actual level-1b data products from SDP, which means it contains only the SCI and (optionally) ZEROFRAME data arrays, both with integer data type, and the GROUP parameters table. This is to allow for easier creation of simulated level-1b data sets. Using the RampModel means the SCI array gets stored as float data type and also adds all of the other ERR, PIXELDQ, and GROUPDQ arrays, which results in a FITS file that is unnecessarily large, due to the presence of all those extra zero-filled arrays.