### PR TITLE
Fix outlier_detection so params get passed to subroutines

### DIFF
--- a/jwst/outlier_detection/create_median.py
+++ b/jwst/outlier_detection/create_median.py
@@ -12,10 +12,17 @@ NOTE: This version is simplified from astrodrizzle's version in the
 :License:
 
 """
+from __future__ import (division, print_function, unicode_literals,
+    absolute_import)
+
 import numpy as np
 
 from stsci.image import numcombine
 from stsci.imagestats import ImageStats
+
+import logging
+log = logging.getLogger(__name__)
+log.setLevel(logging.DEBUG)
 
 
 def do_median(drizzle_groups_sci, drizzle_groups_wht, **pars):
@@ -28,47 +35,34 @@ def do_median(drizzle_groups_sci, drizzle_groups_wht, **pars):
     maskpt = pars.get('maskpt', 0.7)
 
     # Perform additional interpretation of some parameters
-    sigmaSplit = nsigma.split()
-    nsigma1 = float(sigmaSplit[0])
-    nsigma2 = float(sigmaSplit[1])
+    nsigma1 = float(nsigma.split()[0])
+    nsigma2 = float(nsigma.split()[1])
 
-    if high_threshold is not None and (high_threshold.strip() == "" or high_threshold < 0):
+    if high_threshold and high_threshold < 0:
         high_threshold = None
-    if low_threshold is not None and (low_threshold.strip() == "" or low_threshold < 0):
+    if low_threshold and low_threshold < 0:
         low_threshold = None
 
-    if high_threshold is not None: high_threshold = float(high_threshold)
-    if low_threshold is not None: low_threshold = float(low_threshold)
-
-
-    _weight_mask_list = []
+    weight_mask_list = []
 
     for weight_arr in drizzle_groups_wht:
         # Initialize an output mask array to ones
         # This array will be reused for every output weight image
-        _weight_mask = np.zeros(weight_arr.shape, dtype=np.uint8)
+        weight_mask = np.zeros(weight_arr.shape, dtype=np.uint8)
         try:
             tmp_mean_value = ImageStats(weight_arr, lower=1e-8,
                 fields="mean", nclip=0).mean
         except ValueError:
             tmp_mean_value = 0.0
-        _wht_mean = tmp_mean_value * maskpt
+        wht_mean = tmp_mean_value * maskpt
         # 0 means good, 1 means bad here...
-        np.putmask(_weight_mask, np.less(weight_arr, _wht_mean), 1)
-        #_weight_mask.info()
-        _weight_mask_list.append(_weight_mask)
+        np.putmask(weight_mask, np.less(weight_arr, wht_mean), 1)
+        weight_mask_list.append(weight_mask)
 
     # Create the combined array object using the numcombine task
     result = numcombine.numCombine(drizzle_groups_sci,
-                            numarrayMaskList=_weight_mask_list,
-                            combinationType="median",
-                            nlow=nlow,
-                            nhigh=nhigh,
-                            upper=high_threshold,
-                            lower=low_threshold
-                        )
+        numarrayMaskList=weight_mask_list, combinationType="median", nlow=nlow,
+        nhigh=nhigh, upper=high_threshold, lower=low_threshold)
     median_array = result.combArrObj
-
-    del _weight_mask_list
 
     return median_array

--- a/jwst/outlier_detection/outlier_detection.py
+++ b/jwst/outlier_detection/outlier_detection.py
@@ -39,23 +39,6 @@ class OutlierDetection(object):
       6. Updates input data model DQ arrays with mask of detected outliers.
 
     """
-    outlierpars = {'kernel': 'square',
-                   'pixfrac': 1.0,
-                   'resample_bits': None,
-                   'fillval': 'INDEF',
-                   'wht_type': 'exptime',
-                   'nlow': 0,
-                   'nhigh': 1,
-                   'hthresh': None,
-                   'lthresh': None,
-                   'nsigma': '4 3',
-                   'maskpt': 0.7,
-                   'grow': 1,
-                   'ctegrow': 0,
-                   'snr': "4.0 3.0",
-                   'scale': "0.5 0.4",
-                   'backg': 0
-                   }
 
     def __init__(self, input_models, reffiles=None, to_file=False, **pars):
         """
@@ -124,8 +107,7 @@ class OutlierDetection(object):
             self.outlierpars[kw] = ref_model['outlierpars_table.{0}'.format(kw)]
 
     def do_detection(self):
-        """ Perform drizzling operation on input images's to create a new output
-
+        """Compare blotted median to input images to flag outlier pixels in DQ
         """
         pars = self.outlierpars
 
@@ -165,7 +147,7 @@ class OutlierDetection(object):
         # Perform outlier detection using statistical comparisons between
         # each original input image and its blotted version of the median image
         flag_cr.do_detection(self.input_models, blot_models,
-            self.reffiles, **pars)
+            self.reffiles, **self.outlierpars)
 
         # clean-up (just to be explicit about being finished with these results)
         del median_model, blot_models

--- a/jwst/outlier_detection/outlier_detection_step.py
+++ b/jwst/outlier_detection/outlier_detection_step.py
@@ -5,10 +5,6 @@ from ..stpipe import Step, cmdline
 from .. import datamodels
 from . import outlier_detection
 
-import logging
-log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
-
 
 class OutlierDetectionStep(Step):
     """
@@ -32,7 +28,7 @@ class OutlierDetectionStep(Step):
         nhigh = integer(default=0)
         hthresh = float(default=-1.0)
         lthresh = float(default=-1.0)
-        nsigma = string(default='4 3')
+        nsigma = string(default='4.0 3.0')
         maskpt = float(default=0.7)
         grow = integer(default=1)
         ctegrow = integer(default=0)
@@ -44,19 +40,44 @@ class OutlierDetectionStep(Step):
 
     def process(self, input, to_file=False):
 
-        self.input_models = datamodels.open(input)
+        with datamodels.open(input) as input_models:
 
-        self.reffiles= {}
-        self.reffiles['gain'] = self._build_reffile_container('gain')
-        self.reffiles['readnoise'] = self._build_reffile_container('readnoise')
+            if not isinstance(input_models, datamodels.ModelContainer):
+                self.log.warning("Input is not a ModelContainer.")
+                self.log.warning("Outlier detection step will be skipped.")
+                result = input_models.copy()
+                result.meta.cal_step.outlier_detection = "SKIPPED"
+                return result
 
-        # Call the resampling routine
-        self.step = outlier_detection.OutlierDetection(self.input_models,
-                                to_file=to_file,
-                                reffiles=self.reffiles)
-        self.step.do_detection()
+            self.input_models = input_models
 
-        return self.input_models
+            reffiles= {}
+            reffiles['gain'] = self._build_reffile_container('gain')
+            reffiles['readnoise'] = self._build_reffile_container('readnoise')
+
+            pars = {
+                'wht_type': self.wht_type,
+                'pixfrac': self.pixfrac,
+                'kernel': self.kernel,
+                'fillval': self.fillval,
+                'nlow': self.nlow,
+                'nhigh': self.nhigh,
+                'hthresh': self.hthresh,
+                'lthresh': self.lthresh,
+                'nsigma': self.nsigma,
+                'maskpt': self.maskpt,
+                'grow': self.grow,
+                'ctegrow': self.ctegrow,
+                'snr': self.snr,
+                'scale': self.scale,
+                'backg': self.backg}
+
+            # Set up outlier detection, then do detection
+            step = outlier_detection.OutlierDetection(self.input_models,
+                reffiles=reffiles, to_file=to_file, **pars)
+            step.do_detection()
+
+            return self.input_models
 
     def _build_reffile_container(self, reftype):
         """
@@ -76,16 +97,22 @@ class OutlierDetectionStep(Step):
 
         a ModelContainer with corresponding reference files for each input model
         """
+
+        reffile_to_model = {'gain': datamodels.GainModel,
+            'readnoise': datamodels.ReadnoiseModel}
+
         reffiles = [self.get_reference_file(im, reftype) for im in self.input_models]
-        log.debug("Using {} reffile(s) {}".format(reftype.upper(), set(reffiles)))
+        self.log.debug("Using {} reffile(s):".format(reftype.upper()))
+        for r in set(reffiles):
+            self.log.debug("    {}".format(r))
 
         # Check if all the ref files are the same.  If so build it by reading
         # the reference file just once.
         if len(set(reffiles)) <= 1:
             length = len(self.input_models)
-            ref_list = [datamodels.open(reffiles[0])] * length
+            ref_list = [reffile_to_model.get(reftype)(reffiles[0])] * length
         else:
-            ref_list = [datamodels.open(ref) for ref in reffiles]
+            ref_list = [reffile_to_model.get(reftype)(ref) for ref in reffiles]
         return datamodels.ModelContainer(ref_list)
 
 


### PR DESCRIPTION
The outlier_detection step spec parameters were not getting passed
to the routines that actually do all the work: outlier_detection,
create_median, resample, blot and flag_cr.  Now they do.

Also some general code cleanup in the step.