### PR TITLE
Fix slice indexing errors and cubepars error

### DIFF
--- a/jwst/ami/leastsqnrm.py
+++ b/jwst/ami/leastsqnrm.py
@@ -335,10 +335,10 @@ def model_array(ctrs, lam, oversample, pitch, fov, d,
     ffmodel.append(ffc.N * np.ones(ffc.size))
     for q, r in enumerate(alist):
         # r[0] and r[1] are holes i and j, x-coord: 0, y-coord: 1
-        ffc.ri = ctrs[r[0]]
-        ffc.rj = ctrs[r[1]]
-        ffs.ri = ctrs[r[0]]
-        ffs.rj = ctrs[r[1]]
+        ffc.ri = ctrs[int(r[0])]
+        ffc.rj = ctrs[int(r[1])]
+        ffs.ri = ctrs[int(r[0])]
+        ffs.rj = ctrs[int(r[1])]
         ffmodel.append(np.fromfunction(ffc, ffc.size))
         ffmodel.append(np.fromfunction(ffs, ffs.size))
 

--- a/jwst/cube_build/cube_build_step.py
+++ b/jwst/cube_build/cube_build_step.py
@@ -49,7 +49,7 @@ class CubeBuildStep (Step):
          ydebug = integer(default=None) 
          zdebug = integer(default=None)
        """
-    reference_file_types = ['cubepars','resol']
+    # reference_file_types = ['cubepars','resol']
 
     def process(self, input):
         self.log.info('Starting IFU Cube Building Step')

--- a/jwst/wfs_combine/wfs_combine.py
+++ b/jwst/wfs_combine/wfs_combine.py
@@ -162,10 +162,10 @@ class DataSet(object):
             # 3. Set limits of the subarrays (in frames of input data)
             #    for interpolation by taking this centroid +/- PSF_SIZE
             #    and adding BLUR_SIZE, taking edges into account
-            xmin = round(max(0, ctrd_x - PSF_SIZE))
-            ymin = round(max(0, ctrd_y - PSF_SIZE))
-            xmax = round(min(self.input_1.data.shape[1], ctrd_x + PSF_SIZE))
-            ymax = round(min(self.input_1.data.shape[0], ctrd_y + PSF_SIZE))
+            xmin = int(round(max(0, ctrd_x - PSF_SIZE)))
+            ymin = int(round(max(0, ctrd_y - PSF_SIZE)))
+            xmax = int(round(min(self.input_1.data.shape[1], ctrd_x + PSF_SIZE)))
+            ymax = int(round(min(self.input_1.data.shape[0], ctrd_y + PSF_SIZE)))
 
             # 3a. Set subarrays and interpolate over bad pixels
             data_sub_1 = self.input_1.data[ymin: ymax, xmin: xmax]
@@ -727,10 +727,10 @@ def calc_cor_coef(sci_nai_1, sci_nai_2, off_x, off_y):
     xcen = xlen / 2 + 1
     ycen = ylen / 2 + 1
 
-    xmin = max(0, xcen - PSF_SIZE)
-    xmax = min(xlen - 1, xcen + PSF_SIZE)
-    ymin = max(0, ycen - PSF_SIZE)
-    ymax = min(ylen - 1, ycen + PSF_SIZE)
+    xmin = int(max(0, xcen - PSF_SIZE))
+    xmax = int(min(xlen - 1, xcen + PSF_SIZE))
+    ymin = int(max(0, ycen - PSF_SIZE))
+    ymax = int(min(ylen - 1, ycen + PSF_SIZE))
 
     # Create subarrays using these limits, and make them
     #   1D for numpy's correlation coefficient


### PR DESCRIPTION
Fix routines in the wfs_combine and ami_analyze steps that were causing errors due to the use of floating-point values as slice indexes.

Also temporarily comment out declaration of the new reference file types in cube_build_step, so that pre-fetch is disabled and allows calwebb_spec2 to run.