### PR TITLE
Add exptype keyword to pathloss ref file schema

### DIFF
--- a/jwst/datamodels/schemas/pathloss.schema.yaml
+++ b/jwst/datamodels/schemas/pathloss.schema.yaml
@@ -2,6 +2,7 @@ title: Pathloss correction data model
 allOf:
 - $ref: referencefile.schema.yaml
 - $ref: keyword_pexptype.schema.yaml
+- $ref: keyword_exptype.schema.yaml
 - type: object
   properties:
     apertures:


### PR DESCRIPTION
The pathloss step code accesses the value of the EXP_TYPE keyword in the pathloss reference file returned from CRDS, so that keyword needs to be defined in the pathloss ref file schema.