### PR TITLE
Save arrays

### DIFF
--- a/jwst/datamodels/properties.py
+++ b/jwst/datamodels/properties.py
@@ -25,7 +25,6 @@ log.addHandler(logging.NullHandler())
 
 __all__ = ['ObjectNode', 'ListNode']
 
-
 def _cast(val, schema):
     val = _unmake_node(val)
     if val is not None:
@@ -43,11 +42,6 @@ def _cast(val, schema):
             raise ValueError(
                 "Array has wrong number of dimensions.  Expected <= {0}, got {1}".format(
                     schema['max_ndim'], len(val.shape)))
-        #tag = schema.get('tag')
-        #if tag is not None:
-            #val = tagged.tag_object(tag, val)
-        #if isinstance(val, np.generic) and np.isscalar(val):
-            #val = np.asscalar(val)
 
     return val
 
@@ -59,6 +53,7 @@ def _make_default_array(attr, schema, ctx):
     ndim = schema.get('ndim', schema.get('max_ndim'))
     default = schema.get('default', None)
     primary_array_name = ctx.get_primary_array_name()
+
     if attr == primary_array_name:
         if ctx.shape is not None:
             shape = ctx.shape
@@ -232,6 +227,7 @@ class ObjectNode(Node):
                 val = _make_default(attr, schema, self._ctx)
             val = _cast(val, schema)
             old_val = self._instance.get(attr, None)
+
             self._instance[attr] = val
             try:
                 if not self._validate():

--- a/jwst/datamodels/properties.py
+++ b/jwst/datamodels/properties.py
@@ -25,6 +25,7 @@ log.addHandler(logging.NullHandler())
 
 __all__ = ['ObjectNode', 'ListNode']
 
+
 def _cast(val, schema):
     val = _unmake_node(val)
     if val is not None:
@@ -42,11 +43,11 @@ def _cast(val, schema):
             raise ValueError(
                 "Array has wrong number of dimensions.  Expected <= {0}, got {1}".format(
                     schema['max_ndim'], len(val.shape)))
-        tag = schema.get('tag')
-        if tag is not None:
-            val = tagged.tag_object(tag, val)
-        if isinstance(val, np.generic) and np.isscalar(val):
-            val = np.asscalar(val)
+        #tag = schema.get('tag')
+        #if tag is not None:
+            #val = tagged.tag_object(tag, val)
+        #if isinstance(val, np.generic) and np.isscalar(val):
+            #val = np.asscalar(val)
 
     return val
 
@@ -58,7 +59,6 @@ def _make_default_array(attr, schema, ctx):
     ndim = schema.get('ndim', schema.get('max_ndim'))
     default = schema.get('default', None)
     primary_array_name = ctx.get_primary_array_name()
-
     if attr == primary_array_name:
         if ctx.shape is not None:
             shape = ctx.shape
@@ -232,7 +232,6 @@ class ObjectNode(Node):
                 val = _make_default(attr, schema, self._ctx)
             val = _cast(val, schema)
             old_val = self._instance.get(attr, None)
-
             self._instance[attr] = val
             try:
                 if not self._validate():
@@ -240,7 +239,7 @@ class ObjectNode(Node):
             except jsonschema.ValidationError:
                 self._revert(attr, old_val)
                 raise
-    
+
     def __delattr__(self, attr):
         if attr.startswith('_'):
             del self.__dict__[attr]
@@ -325,7 +324,7 @@ class ListNode(Node):
     def __delslice__(self, i, j):
         del self._instance[i:j]
         self._validate()
-            
+
     def append(self, item):
         schema = _get_schema_for_index(self._schema, len(self._instance))
         self._instance.append(_cast(item, schema))
@@ -359,7 +358,7 @@ class ListNode(Node):
     def sort(self, *args, **kwargs):
         self._instance.sort(*args, **kwargs)
         self._validate()
-            
+
     def extend(self, other):
         for part in _unmake_node(other):
             self.append(part)

--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -4,12 +4,10 @@ properties:
     type: object
     properties:
       date:
-        #allOf:
-        #- $ref: http://stsci.edu/schemas/asdf/time/time-1.0.0
-        #- title: Date this file was created (UTC)
-        #  fits_keyword: DATE
+        anyOf:
+          - $ref: http://stsci.edu/schemas/asdf/time/time-1.0.0
+          - type: string
         title: Date this file was created (UTC)
-        type: string
         fits_keyword: DATE
       origin:
         title: Organization responsible for creating file
@@ -106,12 +104,10 @@ properties:
         type: object
         properties:
           date:
-            #allOf:
-            #- $ref: http://stsci.edu/schemas/asdf/time/time-1.0.0
-            #- title: UTC date at the start of the exposure
-            #  fits_keyword: DATE-OBS
+            anyOf:
+              - $ref: http://stsci.edu/schemas/asdf/time/time-1.0.0
+              - type: string
             title: (yyyy-mm-dd) UTC date at start of exposure
-            type: string
             fits_keyword: DATE-OBS
           time:
             title: (hh:mm:ss.ssssss) UTC time at start of exposure


### PR DESCRIPTION
I am proposing removing some of previous changes to `properties._cast`.
The problem I am trying to solve is to serialize numpy arrays directly to asdf files. Note that currently all numpy array serialization in datamodels is to FITS files which calls specialized code.
Serializing ndarrays works with asdf but not with datamodels.

Looking at the code in `properties._cast` removed in this PR, I think it was added to solve an issue with saving Time objects to FITS files using the core schema. I believe there was a bug/typo in the core schema which caused the Time object problems. So here I've also commented out and changed the `date` field in the core schema to use `anyOf` instead of `allOf`.

This is all motivate by work on #888 which is currently stalled until the problem with numpy arrays is solved.