### PR TITLE
Set wcs to None when naxis is zero in header

### DIFF
--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -776,7 +776,12 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         hdu = fits_support.get_hdu(ff._hdulist, hdu_name)
         header = hdu.header
 
-        return WCS(header, key=key, relax=True, fix=True)
+        naxis = header.get('NAXIS', 0)
+        if naxis == 0:
+            wcs = None
+        else:
+            wcs = WCS(header, key=key, relax=True, fix=True)
+        return wcs
 
     def set_fits_wcs(self, wcs, hdu_name='PRIMARY'):
         """


### PR DESCRIPTION
ipython shows a warning message when tab is used to auto-complete the list
of attributes of a datamodel. The warning message comes from the wcs code and
says:

The WCS transformation has more axes (2) than the image it is
associated with (0)

The problem is that the code is trying to create a wcs when naxis in
the primary heade is zero. I have modified get_fits_wcs so that it
sets the wcs to None when naxis is zero. This eliminates the warning
message.