### PR TITLE
Spec2Pipeline minor bug fixes

### DIFF
--- a/jwst/pipeline/calwebb_spec2.py
+++ b/jwst/pipeline/calwebb_spec2.py
@@ -158,7 +158,7 @@ class Spec2Pipeline(Pipeline):
             log.error('Assign_wcs processing was skipped')
             log.error('Aborting remaining processing for this exposure')
             log.error('No output product will be created')
-            return
+            return input
 
         # Do background processing, if necessary
         if len(members_by_type['BACKGROUND']) > 0:
@@ -170,7 +170,7 @@ class Spec2Pipeline(Pipeline):
 
             # Backwards compatibility
             if self.save_bsub:
-                self.bkg_subtract.save_results = true
+                self.bkg_subtract.save_results = True
 
             # Call the background subtraction step
             input = self.bkg_subtract(input, members_by_type['BACKGROUND'])

--- a/jwst/pipeline/tests/test_calwebb_spec2.py
+++ b/jwst/pipeline/tests/test_calwebb_spec2.py
@@ -73,6 +73,35 @@ def test_asn_with_bkg(mk_tmp_dirs):
     assert path.isfile(BSUBFILE)
 
 
+def test_asn_with_bkg_bsub(mk_tmp_dirs):
+    """Test background saving using the bsub flag"""
+    tmp_current_path, tmp_data_path, tmp_config_path = mk_tmp_dirs
+    exppath = path.join(DATAPATH, EXPFILE)
+    lv2_meta = {
+        'program': 'test',
+        'target': 'test',
+        'asn_pool': 'test',
+    }
+    asn = asn_from_list([exppath], rule=DMSLevel2bBase, meta=lv2_meta)
+    asn['products'][0]['members'].append({
+        'expname': exppath, 'exptype': 'BACKGROUND'
+    })
+    asn_file, serialized = asn.dump()
+    with open(asn_file, 'w') as fp:
+        fp.write(serialized)
+
+    args = [
+        path.join(path.dirname(__file__), 'calwebb_spec2.cfg'),
+        asn_file,
+        '--save_bsub=true'
+    ]
+
+    Step.from_cmdline(args)
+
+    assert path.isfile(CALFILE)
+    assert path.isfile(BSUBFILE)
+
+
 def test_asn(mk_tmp_dirs):
     tmp_current_path, tmp_data_path, tmp_config_path = mk_tmp_dirs
     exppath = path.join(DATAPATH, EXPFILE)


### PR DESCRIPTION
Includes
- When assign_wcs is not done, a bare return was used. Should return the datamodel.
- Setting of save_results flag was bad