### PR TITLE
Fix dark_current nframes problem #907

### DIFF
--- a/jwst/dark_current/dark_sub.py
+++ b/jwst/dark_current/dark_sub.py
@@ -59,9 +59,11 @@ def do_correction(input_model, dark_model, dark_output=None):
 
     # Check that the number of groups in the science data does not exceed
     # the number of groups in the dark current array.
-    if (sci_nframes + sci_groupgap) * sci_ngroups - sci_groupgap > drk_ngroups:
-        log.warning("There are more groups in the science data than in the " +
-        "dark data.")
+    sci_total_frames = sci_ngroups * (sci_nframes + sci_groupgap)
+    drk_total_frames = drk_ngroups * (drk_nframes + drk_groupgap)
+    if sci_total_frames > drk_total_frames:
+        log.warning("Not enough data in dark reference file to match to " +
+        "science data.")
         log.warning("Input will be returned without subtracting dark current.")
         input_model.meta.cal_step.dark_sub = 'SKIPPED'
         return input_model.copy()


### PR DESCRIPTION
This update to the dark_current step fixes the problem identified in #907, by computing the full amount of data available in the dark reference file via its values of ngroups, nframes, and groupgap, with no assumption that nframes=1 and groupgap=0 for dark reference files.