### PR TITLE
Remove _tag_values from datamodels/fits_support.py

### DIFF
--- a/jwst/datamodels/fits_support.py
+++ b/jwst/datamodels/fits_support.py
@@ -352,8 +352,6 @@ def _save_from_schema(hdulist, tree, schema):
     validator.hdulist = hdulist
     # TODO: Handle comment stack on per-hdu-basis
     validator.comment_stack = []
-    # Tag the tree values first, the validator requires it
-    _tag_values(tree, schema)
     # This actually kicks off the saving
     validator.validate(tree, _schema=schema)
 
@@ -382,31 +380,6 @@ def _save_history(hdulist, tree):
             else:
                 history[i] = HistoryEntry({'description': str(history[i])})
         hdulist[0].header['HISTORY'] = history[i]['description']
-
-
-def _tag_values(tree, schema):
-    # Replace tag value in tree with tagged versions
-
-    def included(cursor, part):
-        if isinstance(part, int):
-            return part > 0 and part < len(cursor)
-        else:
-            return part in cursor
-
-    def callback(subschema, path, combiner, ctx, recurse):
-        tag = subschema.get('tag')
-        if tag is not None:
-            cursor = tree
-            for part in path[:-1]:
-                if included(cursor, part):
-                    cursor = cursor[part]
-                else:
-                    return
-            part = path[-1]
-            if included(cursor, part):
-                cursor[part] = tagged.tag_object(tag, cursor[part])
-
-    mschema.walk_schema(schema, callback)
 
 
 def to_fits(tree, schema, extensions=None):


### PR DESCRIPTION
When setting an attribute of a datamodel or writing the datamodel out as a fits file, the code validates the datamodel against its schema. This schema can contain tag fields. When validating a tag field, the code checks for equality between the value of the tag field and the value of the _tag attribute of the corresponding item in the datamodel. You may ask, what is this _tag attribute and how is it set? Previously it was set by calling tag_object in asdf/tagged.py from _cast in datamodels/properties.py and _tag_values in datamodels/fits_support.py.

But, conscientiously tagging our data values was a mistake, as the validation code, in validate_tag in asdf/schema.py, skips the check if the _tag attribute is undefined. Since this check has no value for our use cases, we are creating needless problems by trying to set it. @nden has already removed the code in datamodels/properties.py. This removes the code in datamodels/fits_support.py.