### PR TITLE
model.close() should close all components

### DIFF
--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -215,6 +215,8 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         for fd in self._files_to_close:
             if fd is not None:
                 fd.close()
+        if self._asdf is not None:
+            self._asdf.close()
 
     def copy(self, memo=None):
         """


### PR DESCRIPTION
A user reported on MacOSX he's getting 
```
OSError: [Errno 24] Too many open files
```

when running assign_wcs with the new WCS models. It turns out that when model.close() is called it only closes the file that was passed to the model. However,  `DataModel._asdf` is a separate instance of `AsdfFile` and it's not closed. Combined with the fact that data is mmapped (which seems to create a file handle for each mmapped block) it's clear why the file handles disappear.
This PR calls Model._asdf.close() which solves the problem. 
This problem was not seen before because assign_wcs used asdf directly to open the reference files.

I have confirmed also that using

```
with DataModel(filename) as f:
    do_something
```
now releases the file handles after exiting the `with` statement.