### PR TITLE
Add history to models

### DIFF
--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -741,8 +741,19 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         return self._instance.setdefault('history', [])
 
     @history.setter
-    def history(self, v):
-        self._instance['history'] = v
+    def history(self, value):
+        """
+        Set a history entry.
+
+        Parameters
+        ----------
+        value : list
+            For FITS files this should be a list of strings.
+            For ASDF files use a list of ``HistoryEntry`` object. It can be created
+            with `~jwst.datamodels.util.create_history_entry`.
+
+        """
+        self._instance['history'] = value
 
     def get_fits_wcs(self, hdu_name='PRIMARY', key=' '):
         """

--- a/jwst/datamodels/util.py
+++ b/jwst/datamodels/util.py
@@ -365,3 +365,47 @@ def ensure_ascii(s):
             s = s.decode('ascii')
     return s
 
+
+def create_historty_entry(description, software=None):
+    """
+    Create a HistoryEntry object.
+
+    Parameters
+    ----------
+    description : str
+        Description of the change.
+    software : dict or list of dict
+        A description of the software used.  It should not include
+        asdf itself, as that is automatically notated in the
+        `asdf_library` entry.
+
+        Each dict must have the following keys:
+
+        ``name``: The name of the software
+        ``author``: The author or institution that produced the software
+        ``homepage``: A URI to the homepage of the software
+        ``version``: The version of the software
+
+    Examples
+    --------
+    >>> soft = {'name': 'jwreftools', 'author': 'STSCI',
+                'homepage': 'https://github.com/spacetelescope/jwreftools', 'version': "0.7"}
+    >>> entry = create_history_entry(description="HISTORY of this file", software=soft)
+
+    """
+    from asdf.tags.core import Software, HistoryEntry
+    import datetime
+
+    if isinstance(software, list):
+            software = [Software(x) for x in software]
+    elif software is not None:
+        software = Software(software)
+
+    entry = HistoryEntry({
+        'description': description,
+        'time': datetime.datetime.utcnow()
+    })
+
+    if software is not None:
+        entry['software'] = software
+    return entry


### PR DESCRIPTION
Currently `DataModel.history=value`  works with FITS files if `value` is a list of strings. It doesn't work with ASDF files as they expect a `HistoryEntry` to be passed.

This PR adds documentation on how to use `DataModel.history` and a new function `util.create_history_entry` which can be used to create a valid `DataModel.history` object which can then be saved to an ASDF file.