### PR TITLE
restore casting of numpy scalars to python ints

### DIFF
--- a/jwst/datamodels/properties.py
+++ b/jwst/datamodels/properties.py
@@ -42,7 +42,8 @@ def _cast(val, schema):
             raise ValueError(
                 "Array has wrong number of dimensions.  Expected <= {0}, got {1}".format(
                     schema['max_ndim'], len(val.shape)))
-
+        if isinstance(val, np.generic) and np.isscalar(val):
+            val = np.asscalar(val)
     return val
 
 


### PR DESCRIPTION
#903 removed code from `properties._cast` that shouldn't have been removed. It casts numpy integer types to python int. This PR restores the removed lines.