### PR TITLE
Fix fits test that fails, but shouldn't

### DIFF
--- a/jwst/datamodels/tests/test_fits.py
+++ b/jwst/datamodels/tests/test_fits.py
@@ -40,6 +40,13 @@ def setup():
 def teardown():
     shutil.rmtree(TMP_DIR)
 
+def lists_equal(a, b):
+    if len(a) != len(b):
+        return False
+    for i in range(len(a)):
+        if a[i] != b[i]:
+            return False
+    return True
 
 def test_from_new_hdulist():
     with pytest.raises(AttributeError):
@@ -382,7 +389,7 @@ def test_replace_table():
     m.to_fits(TMP_FITS, overwrite=True)
 
     with fits.open(TMP_FITS) as hdulist:
-        assert repr(list(x)) == repr(list(np.asarray(hdulist[1].data)))
+        assert list_equals(x, np.asarray(hdulist[1].data))
         assert hdulist[1].data.dtype[1].str == '>f4'
         assert hdulist[1].header['TFORM2'] == 'E'
 

--- a/jwst/datamodels/tests/test_fits.py
+++ b/jwst/datamodels/tests/test_fits.py
@@ -40,13 +40,16 @@ def setup():
 def teardown():
     shutil.rmtree(TMP_DIR)
 
-def lists_equal(a, b):
-    if len(a) != len(b):
-        return False
-    for i in range(len(a)):
-        if a[i] != b[i]:
-            return False
-    return True
+def records_equal(a, b):
+    a = a.item()
+    b = b.item()
+    a_size = len(a)
+    b_size = len(b)
+    equal = a_size == b_size
+    for i in range(a_size):
+        if not equal: break
+        equal = a[i] == b[i]
+    return equal
 
 def test_from_new_hdulist():
     with pytest.raises(AttributeError):
@@ -389,7 +392,7 @@ def test_replace_table():
     m.to_fits(TMP_FITS, overwrite=True)
 
     with fits.open(TMP_FITS) as hdulist:
-        assert list_equals(x, np.asarray(hdulist[1].data))
+        assert records_equal(x, np.asarray(hdulist[1].data))
         assert hdulist[1].data.dtype[1].str == '>f4'
         assert hdulist[1].header['TFORM2'] == 'E'
 
@@ -399,7 +402,7 @@ def test_replace_table():
         m.to_fits(TMP_FITS2, overwrite=True)
 
     with fits.open(TMP_FITS2) as hdulist:
-        assert repr(list(x)) == repr(list(np.asarray(hdulist[1].data)))
+        assert records_equal(x, np.asarray(hdulist[1].data))
         assert hdulist[1].data.dtype[1].str == '>f8'
         assert hdulist[1].header['TFORM2'] == 'D'
 


### PR DESCRIPTION
A test in jwst.datamodels was reporting a failure. The values reported were ('string', 1., 2. 3., 4.) and ('string', 1.0, 2.0, 3.0, 4.0). The test should be a success, but was a failure because of how the two records were compared. I wrote a  small function that compares the two records element by element and now the test passes.