### PR TITLE
change coord system for source position

### DIFF
--- a/jwst/assign_wcs/nirspec.py
+++ b/jwst/assign_wcs/nirspec.py
@@ -1284,45 +1284,6 @@ def nrs_ifu_wcs(input_model):
     return wcs_list
 
 
-def compute_dispersion(wcsobj):
-    x, y = grid_from_bounding_box(wcsobj.bounding_box)
-    _, _, lam = wcsobj(x, y)
-    disp = np.empty(lam.shape)
-    disp[:-1, :-1] = lam[1:] - lam[:-1]
-    disp[:,-1] = disp[:,-2] + disp[:,-2]-disp[:,-3]
-    return disp
-
-
-def compute_lam_zero_point(lam, x_source, reference_files):
-    f = fits.open('wzprf.fits')
-    data = f[1].data
-    w = wcs.WCS(f[1].header)
-    width = f[1].header['width']
-    x_source *= width
-    lam, xpos = w.wcs_pixel2world(lam, xpos, 1)
-    t = Tabular2D(lookup_table=data)
-    corr_interp = t(lam, xpos, fill_value=np.nan)
-    lam_corr = dispersion *corr_interp
-    return lam_corr
-
-class WZPModel(Model):
-    def __init__(self, xpos, dispersion, table, wcs, width):
-        self.table = table
-        self.xpos = xpos
-        self.dispersion = dispersion
-        self.wcs = wcs
-        self.width = width
-
-    def __call__(self, lam):
-        lam, xpos = self.wcs.wcs_pix2world(lam, self.xpos*self.width)
-        t = Tabular2D(lookup_table=self.data)
-        return self.dispersion * t(lam, xpos)
-
-
-
-
-
-
 exp_type2transform = {'nrs_tacq': imaging,
                       'nrs_taslit': imaging,
                       'nrs_taconfirm': imaging,

--- a/jwst/assign_wcs/tests/test_nirspec.py
+++ b/jwst/assign_wcs/tests/test_nirspec.py
@@ -287,7 +287,7 @@ def test_msa_configuration_normal():
     msaconfl = get_file_path('msa_configuration.fits')
     slitlet_info = nirspec.get_open_msa_slits(msaconfl, msa_meta_id)
     ref_slit = Slit(55, 9376, 251, 26, -5.15, 0.55, 4, 1, 5, '95065_1', '2122',
-                      '2122', 0.13, 0.18283921, 0.31907734)
+                      '2122', 0.13, -0.31716078999999997, -0.18092266)
     _compare_slits(slitlet_info[0], ref_slit)
 
 
@@ -312,7 +312,7 @@ def test_msa_configuration_all_background():
     msaconfl = get_file_path('msa_configuration.fits')
     slitlet_info = nirspec.get_open_msa_slits(msaconfl, msa_meta_id)
     ref_slit = Slit(57, 616, 251, 2, 22.45, 25.85, 4, 1, 3, '95065_1', '2122',
-                    '2122', 0.13, 0, 0)
+                    '2122', 0.13, -0.5, -0.5)
     _compare_slits(slitlet_info[0], ref_slit)
 
 
@@ -327,7 +327,7 @@ def test_msa_configuration_row_skipped():
     msaconfl = get_file_path('msa_configuration.fits')
     slitlet_info = nirspec.get_open_msa_slits(msaconfl, msa_meta_id)
     ref_slit = Slit(58, 8646, 251, 24, -2.85, 5.15, 4, 1, 6, '95065_1', '2122',
-                      '2122', 0.130, 0.18283921, 0.31907734)
+                      '2122', 0.130, -0.31716078999999997, -0.18092266)
     _compare_slits(slitlet_info[0], ref_slit)
 
 
@@ -340,8 +340,8 @@ def test_msa_configuration_multiple_returns():
     msaconfl = get_file_path('msa_configuration.fits')
     slitlet_info = nirspec.get_open_msa_slits(msaconfl, msa_meta_id)
     ref_slit1 = Slit(59, 8651, 256, 24, -2.85, 5.15, 4, 1, 6, '95065_1', '2122',
-                     '2122', 0.13000000000000003, 0.18283921, 0.31907734 )
+                     '2122', 0.13000000000000003, -0.31716078999999997, -0.18092266)
     ref_slit2 = Slit(60, 11573, 258, 32, -2.85, 4, 4, 2, 6, '95065_2', '172',
-                     '172', 0.70000000000000007, 0.18283921, 0.31907734)
+                     '172', 0.70000000000000007, -0.31716078999999997, -0.18092266)
     _compare_slits(slitlet_info[0], ref_slit1)
     _compare_slits(slitlet_info[1], ref_slit2)


### PR DESCRIPTION
#601 describes the coordinate frame used for the source position in the slit for Nirspec MSA and FS observations. The origin of the frame is the upper left corner of the pixel with positive x to the right and positive y downwards. The position needs to be converted to the frame the Nirspec instrument model uses where the origin is in the center of the slit , +y is up and +x is right. This PR makes the conversion of the cooridnates when the Slit values are read in from the msa configuration file. This means that the wavelength zero-point correction and the path loss correction may use the values directly.

@hbushouse @stscirij 

Another related question (which was briefly discussed) is if this needs to be further transformed because of the DMS vs native coordinates. I am pretty sure the source position values are in native coordinates. The wavelength zero-point table is in native coordinates as well. So I think that at least for the WZPC this does not matter.