### PR TITLE
Add filter and pupil keywords to FlatModel schema

### DIFF
--- a/jwst/datamodels/schemas/flat.schema.yaml
+++ b/jwst/datamodels/schemas/flat.schema.yaml
@@ -1,5 +1,7 @@
 allOf:
 - $ref: referencefile.schema.yaml
+- $ref: keyword_filter.schema.yaml
+- $ref: keyword_pupil.schema.yaml
 - $ref: subarray.schema.yaml
 - type: object
   properties:


### PR DESCRIPTION
Bryan Hilbert noticed that the FILTER and PUPIL keywords were not be written to flat-field reference files he was creating via the updated FlatModel data model. Added definitions for those keywords to the FlatModel schema, because they are used as flat selectors for MIRI, NIRCam, and NIRISS.