### PR TITLE
Output model

### DIFF
--- a/jwst/cube_build/cube_build.py
+++ b/jwst/cube_build/cube_build.py
@@ -22,6 +22,7 @@ from . import instrument_defaults
 from . import spaxel
 from . import cube_overlap
 from . import cube_cloud
+from . import data_types
 
 from gwcs import wcstools
 
@@ -216,9 +217,7 @@ class CubeData(object):
 # Set up values to return and acess for other parts of cube_build
 
         self.master_table = master_table
-
-        print('****in set up these two are ==',self.output_name,self.output_file)
-
+        
         return self.output_file
 
 #********************************************************************************
@@ -465,6 +464,7 @@ class CubeData(object):
 
         # loop over input models
 
+
         single_IFUCube = datamodels.ModelContainer()
         n = len(self.input_models)
         this_par1 = self.band_channel[0] # only one channel is used in this approach
@@ -526,7 +526,7 @@ class CubeData(object):
 
             t1 = time.time()
             log.info("Time Create Single IFUcube  = %.1f.s" % (t1 - t0,))
-            print('build_ifucube_single:',IFUCube.meta.filename)
+#            print('build_ifucube_single:',IFUCube.meta.filename)
 #_______________________________________________________________________
             single_IFUCube.append(IFUCube)
             del spaxel[:]
@@ -829,17 +829,23 @@ class CubeData(object):
         IFUCube = datamodels.IFUCubeModel(data=data, dq=dq_cube, err=err_cube, weightmap=idata)
 
 
-#        if self.cube_type =='Model' :
+
         IFUCube.update(self.input_models[j])
         IFUCube.meta.filename = self.output_name
         if self.single:
-#            print('THis is a single file')
             with datamodels.open(self.input_models[j]) as input:
                 # makingf fileanme = org gives a error later when past
                 # back to model container - do we want to define
                 # a new KEYWORD - filename_org ?
                 #IFUCube.meta.filename = input.meta.filename
-                #print('input filename',input.meta.filename,IFUCube.meta.filename)
+
+
+                filename = self.input_filenames[j]
+                indx = filename.rfind('.fits')
+                self.output_name_base = filename[:indx]
+                self.output_file = None
+                newname  = cube_build_io_util.update_output_name(self)
+                IFUCube.meta.filename = newname
                 IFUCube.meta.instrument.channel = self.band_channel[0] 
 
         IFUCube.meta.wcsinfo.crval1 = self.Crval1

--- a/jwst/cube_build/cube_build_io_util.py
+++ b/jwst/cube_build/cube_build_io_util.py
@@ -268,7 +268,7 @@ def update_output_name(self):
 #________________________________________________________________________________
 # check and see if one is provided by the user
 # self.output_file is automatically filled in by step class
-        print('output file',self.output_file)
+        #print('output file',self.output_file)
         if(self.output_file == None):
             self.output_file = newname
         else: 

--- a/jwst/cube_build/cube_build_io_util.py
+++ b/jwst/cube_build/cube_build_io_util.py
@@ -265,10 +265,11 @@ def update_output_name(self):
             fg_name = fg_name.lower()
 
             newname = self.output_name_base + fg_name+ '_s3d.fits'
+
 #________________________________________________________________________________
 # check and see if one is provided by the user
 # self.output_file is automatically filled in by step class
-        #print('output file',self.output_file)
+
         if(self.output_file == None):
             self.output_file = newname
         else: 
@@ -278,7 +279,6 @@ def update_output_name(self):
                 self.output_file = newname
             else:
                 newname = self.output_file
-
 
     return newname
 

--- a/jwst/cube_build/cube_build_step.py
+++ b/jwst/cube_build/cube_build_step.py
@@ -201,7 +201,7 @@ class CubeBuildStep (Step):
 
         self.output_file = cubeinfo.setup()
 
-        print('in cube_build_step',self.output_file)
+        #print('in cube_build_step',self.output_file)
 
 #________________________________________________________________________________
 # find the min & max final coordinates of cube: map each slice to cube
@@ -218,9 +218,9 @@ class CubeBuildStep (Step):
 # this option is used for background matching and outlier rejection
 
         if self.single:
+            self.output_file = None
             result = cubeinfo.build_ifucube_single()
             self.log.info("Number of IFUCube models returned from building single IFUCubes %i ",len(result))
-            print('output file',self.output_file)
 
 # Else standard IFU cube building
         else:

--- a/jwst/cube_build/cube_build_step.py
+++ b/jwst/cube_build/cube_build_step.py
@@ -200,6 +200,9 @@ class CubeBuildStep (Step):
 # or grating/filter
 
         self.output_file = cubeinfo.setup()
+
+        print('in cube_build_step',self.output_file)
+
 #________________________________________________________________________________
 # find the min & max final coordinates of cube: map each slice to cube
 # add any dither offsets, then find the min & max value in each dimension
@@ -217,6 +220,7 @@ class CubeBuildStep (Step):
         if self.single:
             result = cubeinfo.build_ifucube_single()
             self.log.info("Number of IFUCube models returned from building single IFUCubes %i ",len(result))
+            print('output file',self.output_file)
 
 # Else standard IFU cube building
         else:

--- a/jwst/cube_build/data_types.py
+++ b/jwst/cube_build/data_types.py
@@ -107,6 +107,10 @@ class DataTypes(object):
         single_product = filename[:indx]
         return single_product
 
+
+        
+    
+
 # TODO:  Routines not used below - saved just in case we need them later - if not
 # remove. 
 


### PR DESCRIPTION
When running single=True the default method of determining the output_file and meta.filename was causing problems when the set of individual IFUCubes where saved as a ModelContainer. 
Reworked out filename in this case is determined. Need a better method long term - but for now this works. 