### PR TITLE
Make ModelContainer.save consistent with DataModel.save

### DIFF
--- a/jwst/datamodels/container.py
+++ b/jwst/datamodels/container.py
@@ -186,12 +186,18 @@ class ModelContainer(model_base.DataModel):
         self.meta.asn_rule = str(asn_data['asn_rule'])
 
 
-    def save(self, path=None, *args, **kwargs):
+    def save(self, path_not_used, path=None, *args, **kwargs):
         """
         Write out models in container to FITS or ASDF.
 
         Parameters
         ----------
+        path_not_used : string
+            This first argument is ignored in this implementation of the
+            save method.  It is used by pipeline steps to save individual
+            files, but that is not applicable here.  Instead, we use the path
+            arg below and read the filename output from `meta.filename` in each
+            file in the container.
 
         path : string
             Directory to write out files.  Defaults to current working dir.

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -9,6 +9,7 @@ import datetime
 import inspect
 import os
 import sys
+import warnings
 
 import numpy as np
 import jsonschema
@@ -362,7 +363,9 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
 
         with fits_support.to_fits(self._instance, self._schema,
                                   extensions=self._extensions) as ff:
-            ff.write_to(init, *args, **kwargs)
+            with warnings.catch_warnings():
+                warnings.filterwarnings('ignore', message='Card is too long')
+                ff.write_to(init, *args, **kwargs)
 
     @property
     def shape(self):


### PR DESCRIPTION
The `save` method gets passed a filename.  This gets ignored for ModelContainer, and `meta.filename` is used to write out the file. This change is needed as `stpipe.Step.save_model` method needs the same call signature for all DataModels that are returned from a step.

Also, add a filter to suppress "Card is too long" warnings from `astropoy.io.fits` when writing out a DataModel.  These warning messages are caused by our schemas containing descriptions that are too long for the FITS standard in some cases, and in others by keyword value strings that are very long.  All `DataModel.save` operations produce this warning, so let's suppress it.