### PR TITLE
Make Image3Pipeline consistent with stpipe refactor

### DIFF
--- a/jwst/pipeline/calwebb_image3.py
+++ b/jwst/pipeline/calwebb_image3.py
@@ -29,24 +29,35 @@ class Image3Pipeline(Pipeline):
         source_catalog
     """
 
+    spec = """
+        suffix = string(default='i2d')
+    """
+
     # Define alias to steps
-    step_defs = {'resample': resample_step.ResampleStep,
+    step_defs = {'tweakreg_catalog': tweakreg_catalog_step.TweakregCatalogStep,
+                 'tweakreg': tweakreg_step.TweakRegStep,
                  'skymatch': skymatch_step.SkyMatchStep,
                  'outlier_detection': outlier_detection_step.OutlierDetectionStep,
-                 'tweakreg': tweakreg_step.TweakRegStep,
-                 'source_catalog': source_catalog_step.SourceCatalogStep,
-                 'tweakreg_catalog': tweakreg_catalog_step.TweakregCatalogStep
+                 'resample': resample_step.ResampleStep,
+                 'source_catalog': source_catalog_step.SourceCatalogStep
                  }
 
     def process(self, input):
+        """
+        Run the Image3Pipeline
+
+        Parameters
+        ----------
+        input: Level3 Association, or ModelContainer
+            The exposures to process
+        """
 
         self.log.info('Starting calwebb_image3 ...')
 
         input_models = datamodels.open(input)
 
+        # Check if input is multiple exposures, as required by some steps
         is_container = isinstance(input_models, datamodels.ModelContainer)
-
-        # Multiple input files that represent more than 1 exposure
         if is_container and len(input_models.group_names) > 1:
 
             self.log.info("Generating source catalogs for alignment...")
@@ -69,72 +80,23 @@ class Image3Pipeline(Pipeline):
             self.log.info("Performing outlier detection on input images...")
             input_models = self.outlier_detection(input_models)
 
-            self.log.info("Writing out Level 2c images with updated DQ arrays...")
-            generate_2c_names(input_models)
-            input_models.save()
-
-        # Setup output file name for subsequent use
-        output_file = mk_prodname(self.output_dir, input_models.meta.resample.output, 'i2d')
-        input_models.meta.resample.output = output_file
+            self.log.info("Writing Level 2c images with updated DQ arrays...")
+            suffix_2c = 'cal-{}'.format(input_models.meta.asn_table.asn_id)
+            for model in input_models:
+                self.save_model(model, suffix=suffix_2c)
 
         self.log.info("Resampling images to final output...")
         output = self.resample(input_models)
 
+        product = input_models.meta.asn_table.products[0].name + '.fits'
+        output.meta.filename = product
+        self.save_model(output, suffix=self.suffix)
+        self.log.info('Saved resampled image to %s', output.meta.filename)
+
         self.log.info("Creating source catalog...")
         out_catalog = self.source_catalog(output)
-
-        self.log.info('Saving final resampled image to %s', output_file)
-        output.save(output_file)
+        # NOTE: source_catalog step writes out the catalog in .ecsv format
+        # In the future it would be nice if it was returned to the pipeline,
+        # and then written here.  A datamodel for .ecsv might be required.
 
         return
-
-
-def generate_2c_names(input_models):
-    """ Update the names of the input files with Level 2C names
-    """
-
-    if hasattr(input_models.meta,'asn_id'):
-        asn_id = input_models.meta.asn_table.asn_id
-    else:
-        asn_id = "a3001"
-        
-    for i in input_models:
-        i.meta.filename = i.meta.filename.replace('.fits','-{}.fits'.format(asn_id))
-
-def mk_prodname(output_dir, filename, suffix):
-
-    """
-    Build a file name based on an ASN product name template.
-
-    The input ASN product name is used as a template. A user-specified
-    output directory path is prepended to the root of the product name.
-    The input product type suffix is appended to the root of the input
-    product name, preserving any existing file name extension 
-    (e.g. ".fits").
-
-    Args:
-        output_dir (str): The output_dir requested by the user
-        filename (str): The input file name, to be reworked
-        suffix (str): The desired file type suffix for the new file name
-
-    Returns:
-        string: The new file name
-
-    Examples:
-        For output_dir='/my/path', filename='jw12345_nrca_cal.fits', and
-        suffix='i2d', the returned file name will be
-        '/my/path/jw12345_nrca_cal_i2d.fits'
-    """
-
-    # If the user specified an output_dir, replace any existing
-    # path with output_dir
-    if output_dir is not None:
-        dirname, filename = os.path.split(filename)
-        filename = os.path.join(output_dir, filename)
-
-    # Now append the new suffix to the root name, preserving
-    # any existing extension
-    base, ext = os.path.splitext(filename)
-    if len(ext) == 0:
-        ext = ".fits"
-    return base + '_' + suffix + ext

--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -152,21 +152,21 @@ class ResampleData(object):
         # in single-drizzle mode (mosaic all detectors in a single observation)
         if self.drizpars['single']:
             driz_outputs = self.input_models.group_names
-            model_groups = self.input_models.models_grouped
+            exposures = self.input_models.models_grouped
             group_exptime = []
-            for group in model_groups:
-                group_exptime.append(group[0].meta.exposure.exposure_time)
+            for exposure in exposures:
+                group_exptime.append(exposure[0].meta.exposure.exposure_time)
         else:
-            driz_outputs = [self.input_models.meta.resample.output]
-            model_groups = [self.input_models]
+            driz_outputs = [self.output_filename]
+            exposures = [self.input_models]
 
             total_exposure_time = 0.0
-            for group in model_groups:
-                total_exposure_time += group[0].meta.exposure.exposure_time
+            for exposure in exposures:
+                total_exposure_time += exposure[0].meta.exposure.exposure_time
             group_exptime = [total_exposure_time]
         pointings = len(self.input_models.group_names)
 
-        for obs_product, group, texptime in zip(driz_outputs, model_groups,
+        for obs_product, exposure, texptime in zip(driz_outputs, exposures,
             group_exptime):
             output_model = self.blank_output.copy()
             output_model.meta.filename = obs_product
@@ -188,7 +188,7 @@ class ResampleData(object):
                                 kernel=self.drizpars['kernel'],
                                 fillval=self.drizpars['fillval'])
 
-            for n, img in enumerate(group):
+            for n, img in enumerate(exposure):
                 exposure_times['start'].append(img.meta.exposure.start_time)
                 exposure_times['end'].append(img.meta.exposure.end_time)
 
@@ -223,7 +223,7 @@ class ResampleData(object):
             output_model.meta.resample.pointings = pointings
 
             self.output_models.append(output_model)
-        #self.output_models.save(None)  # DEBUG: Remove for production
+
 
 def _buildMask(dqarr, bitvalue):
     """ Builds a bit-mask from an input DQ array and a bitvalue flag"""


### PR DESCRIPTION
This simplifies the `Image3Pipeline` to take advantage of built-in `stpipe.Step` methods for writing output and makes it more consistent with the `stpipe` refactor in PR #897.