### PR TITLE
Add valid suffixes for suffix replacement in stpipe.Step class

### DIFF
--- a/jwst/stpipe/step.py
+++ b/jwst/stpipe/step.py
@@ -22,7 +22,9 @@ from . import log
 from . import utilities
 from .. import __version_commit__, __version__
 
-REMOVE_SUFFIX = '(.+?)(_(rate|cal)(ints)?)?$'
+SUFFIX_LIST = ['rate', 'cal', 'uncal', 'i2d', 's2d', 's3d',
+    'jump', 'ramp', 'x1d', 'x2d', 'x1dints', 'calints', 'rateints']
+REMOVE_SUFFIX = '^(.+?)(_(' + '|'.join(SUFFIX_LIST) + '))?$'
 
 
 class Step(object):


### PR DESCRIPTION
- Allows know valid suffixes used in the JWST pipeline to be replaced with a new suffix in `Step.make_output_path`
- Resolves #949 
- restores the suffix-replacement behavior of `Step.save_model` from before the `stpipe` refactor
- We may want to automatically generate this suffix list as a suffix registry in the future