### PR TITLE
Turn on saving _cal results in Spec2Pipeline

### DIFF
--- a/jwst/pipeline/calwebb_spec2.cfg
+++ b/jwst/pipeline/calwebb_spec2.cfg
@@ -2,6 +2,7 @@ name = "Spec2Pipeline"
 class = "jwst.pipeline.Spec2Pipeline"
 save_bsub = False
 output_use_model = True
+save_results = True
 
     [steps]
       [[assign_wcs]]


### PR DESCRIPTION
This is a quickfix to get the pipeline to write out all necessary results when run with the default calwebb_spec2.cfg as in DMS.