### PR TITLE
Fix for #650, interpolation in building output frame in Spec2Pipeline [skip CI]

### DIFF
--- a/jwst/resample/resample_spec.py
+++ b/jwst/resample/resample_spec.py
@@ -182,7 +182,8 @@ class ResampleSpecData(object):
                 xpos.append(np.nan)
             else:
                 f = interpolate.interp1d(row[x_center - sz + 1:x_center + sz],
-                    x[y_center, x_center - sz + 1:x_center + sz])
+                    x[y_center, x_center - sz + 1:x_center + sz],
+                    bounds_error=False, fill_value='extrapolate')
                 xpos.append(f(lam[y_center, x_center]))
         x_arg = np.array(xpos)[~np.isnan(lam[:, x_center])]
         y_arg = y[~np.isnan(lam[:,x_center]), x_center]


### PR DESCRIPTION
This fixes the failure at `interpolate`, but it doesn't solve the larger issue of pixels being thrown to the wind and not landing in the output frame when we resample.