### PR TITLE
Modify behavior of running post hooks

### DIFF
--- a/docs/jwst/stpipe/user_pipeline.rst
+++ b/docs/jwst/stpipe/user_pipeline.rst
@@ -219,7 +219,10 @@ provided to make them easier to specify in a configuration file.
 Pre-hooks are run right before the Step.  The inputs to the pre-hook
 are the same as the inputs to their parent Step.
 Post-hooks are run right after the Step.  The inputs to the post-hook
-are the return value(s) from the parent Step.
+are the return value(s) from the parent Step. The return values are
+always passed as a list. If the return value from the parent Step is a
+single item, a list of this single item is passed to the post hooks.
+This allows the post hooks to modify the return results, if necessary.
 
 Hooks are specified using the ``pre_hooks`` and ``post_hooks``
 configuration parameter associated with each step.  More than one pre-

--- a/jwst/pipeline/tests/test_calwebb_image2.py
+++ b/jwst/pipeline/tests/test_calwebb_image2.py
@@ -84,7 +84,7 @@ def test_datamodel(mk_tmp_dirs):
     model = dm_open(path.join(DATAPATH, EXPFILE))
     cfg = path.join(path.dirname(__file__), 'calwebb_image2_save.cfg')
     Image2Pipeline.call(model, config_file=cfg)
-    assert path.isfile('jw00001001001_01101_00001_MIRIMAGE_uncal_cal.fits')
+    assert path.isfile('jw00001001001_01101_00001_MIRIMAGE_cal.fits')
 
 
 def test_file(mk_tmp_dirs):

--- a/jwst/stpipe/step.py
+++ b/jwst/stpipe/step.py
@@ -378,7 +378,7 @@ class Step(object):
                 self._reference_files_used = []
 
             for post_hook in self._post_hooks:
-                post_hook.run(result)
+                post_hook.run(results)
 
             # Mark versions
             for result in results:

--- a/jwst/stpipe/step.py
+++ b/jwst/stpipe/step.py
@@ -338,8 +338,12 @@ class Step(object):
                 'Step {0} running with args {1}.'.format(
                     self.name, args))
 
+            hook_args = args
             for pre_hook in self._pre_hooks:
-                pre_hook.run(*args)
+                hook_results = pre_hook.run(*hook_args)
+                if hook_results is not None:
+                    hook_args = hook_results
+            args = hook_args
 
             self._reference_files_used = []
 
@@ -362,6 +366,16 @@ class Step(object):
             # Warn if returning a discouraged object
             self._check_args(result, DISCOURAGED_TYPES, "Returned")
 
+            # Run the post hooks
+            for post_hook in self._post_hooks:
+                hook_results = post_hook.run(result)
+                if hook_results is not None:
+                    result = hook_results
+
+            # Result to return
+            result_return = result
+
+            # Update meta information
             if not isinstance(result, (list, tuple)):
                 results = [result]
             else:
@@ -376,9 +390,6 @@ class Step(object):
                         result.meta.ref_file.crds.sw_version = crds_client.get_svn_version()
                         result.meta.ref_file.crds.context_used = crds_client.get_context_used()
                 self._reference_files_used = []
-
-            for post_hook in self._post_hooks:
-                post_hook.run(results)
 
             # Mark versions
             for result in results:
@@ -411,7 +422,7 @@ class Step(object):
         finally:
             log.delegator.log = orig_log
 
-        return result
+        return result_return
 
     __call__ = run
 

--- a/jwst/stpipe/tests/steps/__init__.py
+++ b/jwst/stpipe/tests/steps/__init__.py
@@ -119,3 +119,37 @@ class ProperPipeline(Pipeline):
         r = self.another_stepwithmodel(r)
 
         return r
+
+
+class PreHookStep(Step):
+    """A step to try out hooks"""
+
+    spec = """
+    """
+
+    def process(self, *args):
+        self.log.info('Received args: "{}"'.format(args))
+        self.log.info('Self.parent = "{}"'.format(self.parent))
+
+        assert isinstance(args[0], ImageModel)
+        assert isinstance(self.parent, Step)
+
+        args[0].pre_hook_run = True
+        self.parent.pre_hook_run = True
+
+
+class PostHookStep(Step):
+    """A step to try out hooks"""
+
+    spec = """
+    """
+
+    def process(self, *args):
+        self.log.info('Received args: "{}"'.format(args))
+        self.log.info('Self.parent = "{}"'.format(self.parent))
+
+        assert isinstance(args[0], ImageModel)
+        assert isinstance(self.parent, Step)
+
+        args[0].post_hook_run = True
+        self.parent.post_hook_run = True

--- a/jwst/stpipe/tests/steps/__init__.py
+++ b/jwst/stpipe/tests/steps/__init__.py
@@ -145,5 +145,19 @@ class PostHookStep(Step):
         self.log.info('Received args: "{}"'.format(args))
         self.log.info('Self.parent = "{}"'.format(self.parent))
 
-        args[0][0].post_hook_run = True
+        args[0].post_hook_run = True
         self.parent.post_hook_run = True
+
+
+class PostHookWithReturnStep(Step):
+    """A step to try out hooks"""
+
+    spec = """
+    """
+
+    def process(self, *args):
+        self.log.info('Received args: "{}"'.format(args))
+        self.log.info('Self.parent = "{}"'.format(self.parent))
+
+        self.parent.post_hook_run = True
+        return 'PostHookWithReturnStep executed'

--- a/jwst/stpipe/tests/steps/__init__.py
+++ b/jwst/stpipe/tests/steps/__init__.py
@@ -131,9 +131,6 @@ class PreHookStep(Step):
         self.log.info('Received args: "{}"'.format(args))
         self.log.info('Self.parent = "{}"'.format(self.parent))
 
-        assert isinstance(args[0], ImageModel)
-        assert isinstance(self.parent, Step)
-
         args[0].pre_hook_run = True
         self.parent.pre_hook_run = True
 
@@ -148,8 +145,5 @@ class PostHookStep(Step):
         self.log.info('Received args: "{}"'.format(args))
         self.log.info('Self.parent = "{}"'.format(self.parent))
 
-        assert isinstance(args[0], ImageModel)
-        assert isinstance(self.parent, Step)
-
-        args[0].post_hook_run = True
+        args[0][0].post_hook_run = True
         self.parent.post_hook_run = True

--- a/jwst/stpipe/tests/steps/stepwithmodel_hook.cfg
+++ b/jwst/stpipe/tests/steps/stepwithmodel_hook.cfg
@@ -1,0 +1,4 @@
+name = 'StepWithModleHook'
+class = 'jwst.stpipe.tests.steps.StepWithModel'
+pre_hooks = 'jwst.stpipe.tests.steps.PreHookStep',
+post_hooks = 'jwst.stpipe.tests.steps.PostHookStep',

--- a/jwst/stpipe/tests/steps/stepwithmodel_hookreturn.cfg
+++ b/jwst/stpipe/tests/steps/stepwithmodel_hookreturn.cfg
@@ -1,0 +1,4 @@
+name = 'StepWithModleHook'
+class = 'jwst.stpipe.tests.steps.StepWithModel'
+pre_hooks = 'jwst.stpipe.tests.steps.PreHookStep',
+post_hooks = 'jwst.stpipe.tests.steps.PostHookWithReturnStep',

--- a/jwst/stpipe/tests/test_step.py
+++ b/jwst/stpipe/tests/test_step.py
@@ -12,6 +12,23 @@ import numpy as np
 from ..config_parser import ValidationError
 
 
+def test_hook():
+    """Test the running of hooks"""
+    from .. import Step
+    from ... import datamodels
+
+    step_fn = join(dirname(__file__), 'steps', 'stepwithmodel_hook.cfg')
+    step = Step.from_config_file(step_fn)
+
+    model = datamodels.ImageModel()
+    result = step.run(model)
+
+    assert result.pre_hook_run
+    assert step.pre_hook_run
+    assert result.post_hook_run
+    assert step.post_hook_run
+
+
 def test_step():
     from .. import Step
 

--- a/jwst/stpipe/tests/test_step.py
+++ b/jwst/stpipe/tests/test_step.py
@@ -29,6 +29,22 @@ def test_hook():
     assert step.post_hook_run
 
 
+def test_hook_with_return():
+    """Test the running of hooks"""
+    from .. import Step
+    from ... import datamodels
+
+    step_fn = join(dirname(__file__), 'steps', 'stepwithmodel_hookreturn.cfg')
+    step = Step.from_config_file(step_fn)
+
+    model = datamodels.ImageModel()
+    result = step.run(model)
+
+    assert result == 'PostHookWithReturnStep executed'
+    assert step.pre_hook_run
+    assert step.post_hook_run
+
+
 def test_step():
     from .. import Step
 


### PR DESCRIPTION
Previously, the result of the parent Step was passed directly to the
post hooks. This commit modifies to the calls to the post hooks to
always pass a list. If the parent Step already passes a list, no
modification is made. However, if the parent Step returns a single
item, that item is placed into a list, and this is passed to the post
hooks.

This allows post-hooks to modify the results.

Also a minor fix to the calimage2 tests is included.