### PR TITLE
Remove unnecessary keywords from core schema

### DIFF
--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -476,10 +476,6 @@ properties:
             title: Effective exposure time (sec)
             type: number
             fits_keyword: EFFEXPTM
-          charge_time:
-            title: Charge accumulation time per integration (sec)
-            type: number
-            fits_keyword: CHRGTIME
           duration:
             title: Total duration of exposure (sec)
             type: number
@@ -1088,18 +1084,6 @@ properties:
             type: string
             enum: [COARSE, FINEGUIDE, MOVING, NONE, TRACK]
             fits_keyword: PCS_MODE
-          gs_ctd_x:
-            title: guide star centroid x position in the FGS ideal coordinate frame (arcsec)
-            type: number
-            fits_keyword: GSCENTX
-          gs_ctd_y:
-            title: guide star centroid y position in the FGS ideal coordinate frame (arcsec)
-            type: number
-            fits_keyword: GSCENTY
-          gs_jitter_rms:
-            title: RMS jitter over the exposure (arcsec)
-            type: number
-            fits_keyword: JITTERMS
           visit_end_time:
             title: Observatory UTC time when the visit completed
             type: string


### PR DESCRIPTION
Remove CHRGTIME, GSCENTX, GSCENTY, and JITTERMS keywords from core schema. These are being removed from level-1b product headers by SDP.

Addresses #969 and #971.