### PR TITLE
Add new pytest option runslow and a central helpers module

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,11 @@
+"""Project default for pytest"""
+import pytest
+
+
+# Add option to run slow tests
+def pytest_addoption(parser):
+    parser.addoption(
+        "--runslow",
+        action="store_true",
+        help="run slow tests"
+    )

--- a/jwst/associations/tests/test_generate.py
+++ b/jwst/associations/tests/test_generate.py
@@ -8,13 +8,6 @@ from .helpers import full_pool_rules
 
 from .. import (generate, load_asn)
 
-# Temporarily skip if running under Travis
-# pytestmark = pytest.mark.skipif(
-#     "TRAVIS" in os.environ and os.environ["TRAVIS"] == "true",
-#     reason='Temporarily disable due to performance issues'
-# )
-
-
 def test_generate(full_pool_rules):
     pool, rules, pool_fname = full_pool_rules
     (asns, orphaned) = generate(pool, rules)

--- a/jwst/tests/helpers.py
+++ b/jwst/tests/helpers.py
@@ -1,0 +1,25 @@
+"""Handy helpful pytest helpers helping pytest test"""
+
+import os
+import pytest
+
+
+# Decorator to indicate slow tests
+runslow = pytest.mark.skipif(
+    not pytest.config.getoption("--runslow"),
+    reason="need --runslow option to run"
+)
+
+
+# Decorator to indicate TEST_BIGDATA required
+require_bigdata = pytest.mark.skipif(
+    'TEST_BIGDATA' not in os.environ,
+    reason='"TEST_BIGDATA" environmental not defined. Cannot access test data.'
+)
+
+
+# Decorator to skip test if running under a TravisCI
+not_under_travis = pytest.mark.skipif(
+    "TRAVIS" in os.environ and os.environ["TRAVIS"] == "true",
+    reason='Temporarily disable due to performance issues'
+)


### PR DESCRIPTION
If running under pytest, a new option has been added, `--runslow`. If
specified, tests marked with the `runslow` pytest marker will execute.
Otherwise those tests are bypassed

In `jwst/tests/helpers.py`, a number of decorators for pytest markers have been added:

- @runslow
  As described, tests marked as such will only execute if the `--runslow` command line option
  has been specified
- @require_bigdata
  Checks for the existence of the environment variable "TEST_BIGDATA". If not found,
  the marked test will not execute
- @not_under_travis
  Checks for the existence of the environment variable "TRAVIS" and that its
  value is "true". Is so, the test will not execute. Use to prevent tests from running
  under TravisCI

To use, import the jwst/tests/helpers.py module. On the required test, simply add
the desired decorator to the test definition::

    @runslow
    def test_me():
        ...

Note that, as with any decorator, they can be chained::

     @require_bigdata
     @runslow
     def test_slow_with_data():
         ...

Finally, if one needs to add yet another specific pytest.mark, xfail, or skip, simply
add it to the chain::

    @pytest.xfail(reason='Because its bad code')
    @require_bigdata
    @runslow
    def test_that_really_needs_work():
        ...