### PR TITLE
Update remaining reference file schemas to use new approach

### DIFF
--- a/jwst/datamodels/schemas/referencecube.schema.yaml
+++ b/jwst/datamodels/schemas/referencecube.schema.yaml
@@ -1,5 +1,6 @@
+title: Reference cube data model
 allOf:
-- $ref: core.schema.yaml
+- $ref: referencefile.schema.yaml
 - type: object
   properties:
     data:
@@ -18,31 +19,4 @@ allOf:
       fits_hdu: ERR
       default: 0.0
       datatype: float32
-    meta:
-      type: object
-      properties:
-        reffile:
-          title: Information about the reference file
-          type: object
-          properties:
-            type:
-              title: Reference file type
-              type: string
-              fits_keyword: REFTYPE
-            pedigree:
-              title: The pedigree of the reference file
-              type: string
-              fits_keyword: PEDIGREE
-            description:
-              title: Description of the reference file
-              type: string
-              fits_keyword: DESCRIP
-            author:
-              title: Author of the reference file
-              type: string
-              fits_keyword: AUTHOR
-            useafter:
-              title: Use after date of the reference file
-              type: string
-              fits_keyword: USEAFTER
 $schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/referenceimage.schema.yaml
+++ b/jwst/datamodels/schemas/referenceimage.schema.yaml
@@ -1,5 +1,6 @@
+title: Reference image data model
 allOf:
-- $ref: core.schema.yaml
+- $ref: referencefile.schema.yaml
 - type: object
   properties:
     data:
@@ -18,31 +19,4 @@ allOf:
       fits_hdu: ERR
       default: 0.0
       datatype: float32
-    meta:
-      type: object
-      properties:
-        reffile:
-          title: Information about the reference file
-          type: object
-          properties:
-            type:
-              title: Reference file type
-              type: string
-              fits_keyword: REFTYPE
-            pedigree:
-              title: The pedigree of the reference file
-              type: string
-              fits_keyword: PEDIGREE
-            description:
-              title: Description of the reference file
-              type: string
-              fits_keyword: DESCRIP
-            author:
-              title: Author of the reference file
-              type: string
-              fits_keyword: AUTHOR
-            useafter:
-              title: Use after date of the reference file
-              type: string
-              fits_keyword: USEAFTER
 $schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/referencequad.schema.yaml
+++ b/jwst/datamodels/schemas/referencequad.schema.yaml
@@ -1,5 +1,6 @@
+title: Reference quad data model
 allOf:
-- $ref: core.schema.yaml
+- $ref: referencefile.schema.yaml
 - type: object
   properties:
     data:
@@ -18,31 +19,4 @@ allOf:
       fits_hdu: ERR
       default: 0.0
       datatype: float32
-    meta:
-      type: object
-      properties:
-        reffile:
-          title: Information about the reference file
-          type: object
-          properties:
-            type:
-              title: Reference file type
-              type: string
-              fits_keyword: REFTYPE
-            pedigree:
-              title: The pedigree of the reference file
-              type: string
-              fits_keyword: PEDIGREE
-            description:
-              title: Description of the reference file
-              type: string
-              fits_keyword: DESCRIP
-            author:
-              title: Author of the reference file
-              type: string
-              fits_keyword: AUTHOR
-            useafter:
-              title: Use after date of the reference file
-              type: string
-              fits_keyword: USEAFTER
 $schema: http://stsci.edu/schemas/fits-schema/fits-schema


### PR DESCRIPTION
Update more reference file schemas in support of #861. These are the reference image, cube, and quad models. I don't think they're in use by any code modules anywhere, but they are used in the datamodels.open utilities to try to open reference files in a generic way.