### PR TITLE
Explicitly set backwards compatible behavior of AsdfFile.open ...

### DIFF
--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -153,7 +153,13 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
             if isinstance(init, bytes):
                 init = init.decode(sys.getfilesystemencoding())
             try:
-                asdf = AsdfFile.open(init, extensions=extensions)
+                # The open function now automatically processes FITS files with
+                # ASDF extensions. However, since our implementation expects
+                # the function to raise a ValueError for anything other than a
+                # true ASDF file, we need to explicitly tell open to ignore
+                # FITS files.
+                asdf = AsdfFile.open(init, extensions=extensions,
+                                     accept_asdf_in_fits=False)
             except (ValueError):
                 try:
                     hdulist = fits.open(init)


### PR DESCRIPTION
AsdfFile.open recently changed its implementation to automatically
process FITS files that contain ASDF extensions. However, the way that
this function was being used here expected a ValueError for all input
other than pure ASDF files. This change updates the call to
AsdfFile.open to explicitly request the old behavior. However, in the
long term this should be refactored to no longer require such behavior.