### PR TITLE
fixed error when running single = true

### DIFF
--- a/jwst/cube_build/cube_build.py
+++ b/jwst/cube_build/cube_build.py
@@ -181,8 +181,9 @@ class CubeData(object):
         cube_build_io_util.check_cube_type(self)
 
         self.output_name = cube_build_io_util.update_output_name(self)
-        log.info('Output Name %s',self.output_name)
-        log.info('Output Base %s ', self.output_name_base)
+        if not self.single:
+            log.info('Output Name %s',self.output_name)
+#            log.info('Output Base %s ', self.output_name_base)
 #________________________________________________________________________________
 # InstrumentDefaults is an  dictionary that holds default parameters for
 # difference instruments and for each band
@@ -827,10 +828,8 @@ class CubeData(object):
         err_cube = np.zeros((naxis3, naxis2, naxis1))
 
         IFUCube = datamodels.IFUCubeModel(data=data, dq=dq_cube, err=err_cube, weightmap=idata)
-
-
-
         IFUCube.update(self.input_models[j])
+
         IFUCube.meta.filename = self.output_name
         if self.single:
             with datamodels.open(self.input_models[j]) as input:
@@ -838,7 +837,6 @@ class CubeData(object):
                 # back to model container - do we want to define
                 # a new KEYWORD - filename_org ?
                 #IFUCube.meta.filename = input.meta.filename
-
 
                 filename = self.input_filenames[j]
                 indx = filename.rfind('.fits')
@@ -874,10 +872,10 @@ class CubeData(object):
 
         IFUCube.meta.wcsinfo.wcsaxes = 3
 
-        IFUCube.flux_extension = 'SCI'
-        IFUCube.error_extension = 'ERR'
+        IFUCube.meta.flux_extension = 'SCI'
+        IFUCube.meta.error_extension = 'ERR'
         IFUCube.meta.dq_extension = 'DQ'
-        IFUCube.meta.weightmap = 'WMAP'
+        IFUCube.meta.weightmap_extension = 'WMAP'
         IFUCube.meta.data_model_type = 'IFUCubeModel'
         IFUCube.error_type = 'ERR'
 

--- a/jwst/cube_build/cube_build_step.py
+++ b/jwst/cube_build/cube_build_step.py
@@ -129,7 +129,7 @@ class CubeBuildStep (Step):
 # We need to do this in cube_build_step because we need to pass the data_model to
 # CRDS to figure out what type of reference files to grab (MIRI or NIRSPEC)
 #________________________________________________________________________________
-        input_table = data_types.DataTypes(input)
+        input_table = data_types.DataTypes(input,self.single)
         self.cube_type = input_table.input_type
         self.input_models = input_table.input_models
         self.input_filenames = input_table.filenames
@@ -201,7 +201,7 @@ class CubeBuildStep (Step):
 
         self.output_file = cubeinfo.setup()
 
-        #print('in cube_build_step',self.output_file)
+#        print('in cube_build_step',self.output_file)
 
 #________________________________________________________________________________
 # find the min & max final coordinates of cube: map each slice to cube

--- a/jwst/cube_build/data_types.py
+++ b/jwst/cube_build/data_types.py
@@ -41,7 +41,7 @@ class DataTypes(object):
                 ]
               }
 
-    def __init__(self, input):
+    def __init__(self, input,single):
 
         self.input_models = []
         self.filenames = []
@@ -65,14 +65,16 @@ class DataTypes(object):
 #            print('this is a model container type')
             self.input_type='Container'
             self.data_type = 'multi'
-            with datamodels.ModelContainer(input) as input_model:
-                self.output_name =input_model.meta.asn_table.products[0].name
+            self.output_name  = 'Temp'
+            if not single:  # find the name of the output file from the association 
+                with datamodels.ModelContainer(input) as input_model:
+                    self.output_name =input_model.meta.asn_table.products[0].name
 
             for model in input:
                 self.input_models.append(model)
                 self.filenames.append(model.meta.filename)
 #            print('number of models',len(self.filenames))
-
+#            print('the name of the output file', self.output_name) 
         elif isinstance(input, str):
             try:
                 # The name of an association table
@@ -91,7 +93,7 @@ class DataTypes(object):
                         self.input_models.append(datamodels.ImageModel(m['expname']))
             except:
                 # The name of a single image file
- #               print(' this is a single file  read in filename')
+#                print(' this is a single file  read in filename')
                 self.input_type = 'File'
                 self.data_type = 'singleton'
                 self.filenames.append(input)

--- a/jwst/datamodels/schemas/ifucube.schema.yaml
+++ b/jwst/datamodels/schemas/ifucube.schema.yaml
@@ -18,6 +18,10 @@ allOf:
           title: EXTNAME of the extension containing data quality mask
           type: string
           fits_keyword: MASKEXT
+        weightmap_extension:
+          title: EXTNAME of the extension containing weight map
+          type: string
+          fits_keyword: WMAPEXT
         data_model_type:
           title: type of data model used to construct object
           type: string


### PR DESCRIPTION
Fixed an error when running cube_build single=true. No longer is it assumed that the ModelContainer has association info. Also fixed a error in writing the FLUX_EXT, ERR_EXT and WMAP_EXT names to the header. 
@mcara 
@hbushouse 