### PR TITLE
Initial version of white_light step for caltso3 pipeline

### DIFF
--- a/docs/jwst/white_light/arguments.rst
+++ b/docs/jwst/white_light/arguments.rst
@@ -1,0 +1,5 @@
+Step Arguments
+==============
+
+The white light curve generation step has no step-specific arguments.
+

--- a/docs/jwst/white_light/description.rst
+++ b/docs/jwst/white_light/description.rst
@@ -1,0 +1,27 @@
+Description
+===========
+
+Overview
+--------
+
+The ``white_light`` step sums the spectroscopic flux over all
+wavelengths in each integration of a multi-integration extracted
+spectrum product to produce an integrated ("white") flux as a
+function of time for a target. This is usually applied to the _x1dints
+product in a spectroscopic Time-Series Observation (TSO), as part of
+the ``caltso3`` pipeline.
+
+Input details
+-------------
+The input should be in the form of an _x1dints product, which contains
+extracted spectra from multiple integrations for a given target.
+
+Algorithm
+---------
+The algorithm performs a simple sum of the flux values over all
+wavelengths for each extracted spectrum contained in the input product.
+
+Output product
+--------------
+The output product will be a table of time vs. integrated flux, stored
+in the form of a ECSV (Extended Comma-Separated Value) file.

--- a/docs/jwst/white_light/index.rst
+++ b/docs/jwst/white_light/index.rst
@@ -1,0 +1,12 @@
+============================
+White Light Curve Generation
+============================
+
+.. toctree::
+   :maxdepth: 2
+
+   description.rst
+   reference_files.rst
+   arguments.rst
+
+.. automodapi:: jwst.white_light

--- a/docs/jwst/white_light/reference_files.rst
+++ b/docs/jwst/white_light/reference_files.rst
@@ -1,0 +1,3 @@
+Reference File
+==============
+The white_light step does use any reference files.

--- a/jwst/pipeline/white_light.cfg
+++ b/jwst/pipeline/white_light.cfg
@@ -1,0 +1,3 @@
+name = "white_light"
+class = "jwst.white_light.WhiteLightStep"
+

--- a/jwst/white_light/__init__.py
+++ b/jwst/white_light/__init__.py
@@ -1,0 +1,4 @@
+from __future__ import absolute_import
+from .white_light_step import WhiteLightStep
+
+__version__ = '0.7.1'

--- a/jwst/white_light/white_light.py
+++ b/jwst/white_light/white_light.py
@@ -1,0 +1,51 @@
+from __future__ import absolute_import
+
+import time
+import logging
+
+import numpy as np
+from collections import OrderedDict
+from astropy.table import QTable
+from astropy.time import Time, TimeDelta
+from ..datamodels import dqflags
+
+log = logging.getLogger(__name__)
+log.setLevel(logging.DEBUG)
+
+def white_light(input):
+
+    nints = input.meta.exposure.nints
+    fluxsums = []
+    times = []
+
+    # Compute the flux sum for each integration in the input
+    for i in np.arange(nints):
+        fluxsums.append(input.spec[i].spec_table['flux'].sum())
+
+    # Populate meta data for the output table
+    tbl_meta = OrderedDict()
+    tbl_meta['instrument'] = input.meta.instrument.name
+    tbl_meta['detector'] = input.meta.instrument.detector
+    tbl_meta['exp_type'] = input.meta.exposure.type
+    tbl_meta['subarray'] = input.meta.subarray.name
+    tbl_meta['filter'] = input.meta.instrument.filter
+    tbl_meta['pupil'] = input.meta.instrument.pupil
+    tbl_meta['target_name'] = input.meta.target.catalog_name
+    tbl_meta['number_of_integrations'] = nints
+
+    # Create the output table
+    tbl = QTable(meta=tbl_meta)
+
+    # Compute the delta time of each integration
+    dt = (input.meta.exposure.group_time * (input.meta.exposure.ngroups + 1))
+    dt_arr = (np.arange(1, 1 + input.meta.exposure.nints) * dt - (dt / 2.))
+    int_dt = TimeDelta(dt_arr, format='sec')
+
+    # Compute the absolute time at the mid-point of each integration
+    int_times = (Time(input.meta.exposure.start_time, format='mjd') + int_dt)
+
+    # Store the times and flux sums in the table
+    tbl['MJD'] = int_times.mjd
+    tbl['whitelight_flux'] = fluxsums
+
+    return tbl

--- a/jwst/white_light/white_light_step.py
+++ b/jwst/white_light/white_light_step.py
@@ -1,0 +1,30 @@
+#! /usr/bin/env python
+
+from ..stpipe import Step, cmdline
+from .. import datamodels
+from .white_light import white_light
+
+
+class WhiteLightStep(Step):
+    """
+    WhiteLightStep: Computes integrated flux as a function of time for a
+    multi-integration spectroscopic observation.
+    """
+
+    spec = """
+    """
+
+    def process(self, input):
+
+        # Load the input
+        with datamodels.open(input) as input_model:
+
+            # Call the white light curve generation routine
+            result = white_light(input_model)
+
+            # Write the output catalog
+            index = input_model.meta.filename.rfind('_')
+            cat_name = input_model.meta.filename[:index + 1] + 'cat.ecsv'
+            result.write(cat_name, format='ascii.ecsv')
+
+        return


### PR DESCRIPTION
Adding draft 0 version of code and docs for the new step "white_light", which will be the final step of the caltso3 pipeline when processing spectroscopic data. It's very barebones for now, but at least creates the integrated flux from the spectrum corresponding to each integration, computes the time of each integration (stolen from the tso_photometry step), and dumps a table of time vs. integrated flux to an .ecsv file.

Addresses #621.