### PR TITLE
Remove duplicate crds console logging

### DIFF
--- a/jwst/stpipe/crds_client.py
+++ b/jwst/stpipe/crds_client.py
@@ -39,6 +39,8 @@ import gc
 import crds
 from crds import log, config
 
+log.remove_console_handler()  # Remove CRDS native output in favor of stpipe Step logging
+
 def _flatten_dict(nested):
     def flatten(root, path, output):
         for key, val in root.items():


### PR DESCRIPTION
This patch removes the default CRDS console logging handler and instead relies on the handler installed by stpipe.   This prevents duplicates of the same log message,  one starting with "CRDS" and one in the normal stpipe log format.

