### PR TITLE
Close hdulist if it was opened by datamodels.util.open

### DIFF
--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -163,7 +163,7 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
                 else:
                     asdf = fits_support.from_fits(hdulist, self._schema,
                                                   extensions, pass_invalid_values)
-                self._files_to_close.append(hdulist)
+                    self._files_to_close.append(hdulist)
         else:
             raise ValueError(
                 "Can't initialize datamodel using {0}".format(str(type(init))))

--- a/jwst/datamodels/schema_editor.py
+++ b/jwst/datamodels/schema_editor.py
@@ -424,34 +424,59 @@ class Model_db(object):
             for value in values:
                 save_dictionary(fd, value, leading=leading+'- ')
             
-        def save_simple_list(leading, name, values, max_length=80):
+        def is_long_line(leading, name, value, max_length=80):
+            long_line = leading + name + ': ' + value
+            return len(long_line) > max_length
+    
+        def save_long_line(leading, name, value, sep1, sep2, max_length=80):
+            long_line = leading + name + ': '
+            values = value.split(sep1)
+                
             start = True
             line_start = 0
             prefix = leading + '  '
-            long_line = leading + name + ": ["
 
-            for value in sorted(values):
-                if not isinstance(value, six.string_types):
-                    value = str(value)
-                value = value.strip()
-                
+            for value in values:
                 if start:
                     long_line += value
                     start = False
                 else:
-                    line_length = len(long_line) + len(value) + 2 - line_start
+                    line_length = (len(long_line) + len(value) + len(sep1)
+                                    - line_start)
+
                     if line_length < max_length:
-                        long_line += ", " + value
+                        long_line += sep1 + value
                     else:
-                        line_start = len(long_line) + 2
-                        long_line += ",\n" + prefix + value
+                        line_start = len(long_line) + len(sep2)
+                        long_line +=  sep2 + prefix + value
                     
-            long_line += "]\n"
+            long_line += '\n'
+
             return long_line
 
+        def save_short_line(leading, name, value):
+            short_line = leading + name + ': ' + value + '\n'
+            return short_line
+            
+        def save_simple_list(leading, name, values, max_length=80):
+            sep1 = ', '
+            sep2 = sep1 + '\n'
+            vstr = [str(v) for v in values]
+            value = '[' + sep1.join(vstr) + ']'
+            if is_long_line(leading, name, value):
+                line = save_long_line(leading, name, value, sep1, sep2)
+            else:
+                line = save_short_line(leading, name, value)
+            return line
     
         def save_scalar(leading, name, value):
-            return leading + name + ": " + str(value) + "\n"
+            sep = '|'
+            if is_long_line(leading, name, value):
+                value = '"' + value + '"'
+                line = save_long_line(leading, name, value, '|', '|\\\n')
+            else:
+                line = save_short_line(leading, name, value)
+            return line
     
         with open(schema_file, mode='w') as fd:
             save_dictionary(fd, schema)
@@ -588,11 +613,12 @@ class Options(object):
         else:
             if self.first_time:
                 if not self.query_run(self.preamble, self.run_script):
-                    return
+                    return False
             
             parameters = self.query_options(parameters)
 
         self.set_parameters(editor, parameters)
+        return True
         
     def get_parameters(self, editor):
         """
@@ -868,7 +894,8 @@ class Schema_editor(object):
         if self.options is None:
             self.query = False
         else:
-            self.options.get(self)
+            if not self.options.get(self):
+                return
         
         # Parse the keyword database files            
         keyword_db = Keyword_db(self.input)

--- a/jwst/datamodels/schema_editor.py
+++ b/jwst/datamodels/schema_editor.py
@@ -425,7 +425,7 @@ class Model_db(object):
                 save_dictionary(fd, value, leading=leading+'- ')
             
         def is_long_line(leading, name, value, max_length=80):
-            long_line = leading + name + ': ' + value
+            long_line = leading + name + ': ' + str(value)
             return len(long_line) > max_length
     
         def save_long_line(leading, name, value, sep1, sep2, max_length=80):
@@ -437,6 +437,12 @@ class Model_db(object):
             prefix = leading + '  '
 
             for value in values:
+                nl = value.find('\n')
+                if nl >= 0:
+                    long_line += value[0:nl+1]
+                    value = value[nl+1:]
+                    line_start = len(long_line)
+
                 if start:
                     long_line += value
                     start = False
@@ -455,7 +461,7 @@ class Model_db(object):
             return long_line
 
         def save_short_line(leading, name, value):
-            short_line = leading + name + ': ' + value + '\n'
+            short_line = leading + name + ': ' + str(value) + '\n'
             return short_line
             
         def save_simple_list(leading, name, values, max_length=80):
@@ -472,7 +478,7 @@ class Model_db(object):
         def save_scalar(leading, name, value):
             sep = '|'
             if is_long_line(leading, name, value):
-                value = '"' + value + '"'
+                value = '"\n' + value + '"\\'
                 line = save_long_line(leading, name, value, '|', '|\\\n')
             else:
                 line = save_short_line(leading, name, value)

--- a/jwst/datamodels/tests/test_models.py
+++ b/jwst/datamodels/tests/test_models.py
@@ -21,7 +21,7 @@ from numpy.testing import assert_array_equal
 
 from .. import (DataModel, ImageModel, QuadModel, MultiSlitModel,
                 ModelContainer)
-from ..util import open
+from ..util import open as open_model
 from .. import schema
 
 
@@ -69,13 +69,13 @@ def test_broadcast2():
 def test_from_hdulist():
     from astropy.io import fits
     with fits.open(FITS_FILE) as hdulist:
-        with open(hdulist) as dm:
+        with open_model(hdulist) as dm:
             pass
         assert hdulist.fileinfo(0)['file'].closed == False
 
 
 def delete_array():
-    with open() as dm:
+    with open_model() as dm:
         del dm.data
 
 
@@ -136,13 +136,13 @@ def test_delete():
 
 
 def test_open():
-    with open() as dm:
+    with open_model() as dm:
         pass
 
-    with open((50, 50)) as dm:
+    with open_model((50, 50)) as dm:
         pass
 
-    with open(FITS_FILE) as dm:
+    with open_model(FITS_FILE) as dm:
         assert isinstance(dm, QuadModel)
 
 
@@ -171,7 +171,7 @@ def test_section():
 
 def test_init_with_array():
     array = np.empty((50, 50))
-    with open(array) as dm:
+    with open_model(array) as dm:
         assert dm.data.shape == (50, 50)
         assert isinstance(dm, ImageModel)
 

--- a/jwst/datamodels/util.py
+++ b/jwst/datamodels/util.py
@@ -58,6 +58,7 @@ def open(init=None, extensions=None, **kwargs):
 
     hdulist = {}
     shape = ()
+    file_to_close = None
 
     # Get special cases for opening a model out of the way
     # all special cases return a model if they match
@@ -80,6 +81,7 @@ def open(init=None, extensions=None, **kwargs):
 
         if file_type == "fits":
             hdulist = fits.open(init)
+            file_to_close = hdulist
 
         elif file_type == "asn":
             # Read the file as an association / model container
@@ -146,6 +148,11 @@ def open(init=None, extensions=None, **kwargs):
 
     # Actually open the model
     model = new_class(init, extensions=extensions, **kwargs)
+    
+    # Close the hdulist if we opened it
+    if file_to_close is not None:
+        file_to_close.close()
+        
     return model
 
 


### PR DESCRIPTION
Several users have reported problems with warning messages from astropy.io.fits about trying to access an hdu after it was closed. I looked at the code and found two places where the handling of hdus can be improved.
    
In util.open a fits file is opened as a hdulist so the code can determine which class to use when opening a file. If the fits file is opened as a hdulist, as opposed to the hdulist being passed as an
argument, it is now closed before exiting util.open.
    
In model_base.__init__ fits files are opened as a hdulist. The data in the hdulist is then converted to an asdf file. The hdulist is placed in a list of objects to close when the datamodel is closed. The code
that adds the hdulist to that list was supposed to be inside a try block, in case the open failed. Because of incorrect indentation, it was not. So I changed the indentation to move it into the try block.