### PR TITLE
Change code to close hdulist in datamodels.open

### DIFF
--- a/jwst/datamodels/util.py
+++ b/jwst/datamodels/util.py
@@ -149,7 +149,7 @@ def open(init=None, extensions=None, **kwargs):
     
     # Close the hdulist if we opened it
     if file_to_close is not None:
-        file_to_close.close()
+        model._files_to_close.append(file_to_close)
         
     return model
 


### PR DESCRIPTION
Datamodels.open opens a fits file as a hdulist in order to examine the
header andshape and determine which class to use to open the
file. Since it opens the hdulist, it should also close it. Previously
I had the open function close the hdulist, which was wrong. (What was
I thinking?) The code now appends the hdulist to the list of files to
close when closing the datamodel.