### PR TITLE
Add iterators to object nodes in datamodels

### DIFF
--- a/jwst/datamodels/ndmodel.py
+++ b/jwst/datamodels/ndmodel.py
@@ -240,9 +240,6 @@ class MetaNode(properties.ObjectNode, collections.MutableMapping):
         path = key.split('.')
         return self._find(path)
     
-    def __iter__(self):
-        return MetaNodeIterator(self)
-
     def __len__(self):
         def recurse(val):
             n = 0
@@ -262,35 +259,6 @@ class MetaNode(properties.ObjectNode, collections.MutableMapping):
             parent.__setattr__(path[-1], value)
         except KeyError:
             raise KeyError("'%s'" % key)
-
-class MetaNodeIterator(six.Iterator):
-    """
-    An iterator for the meta node which flattens the hierachical structure
-    """
-    def __init__(self, node):
-        self.key_stack = []
-        self.iter_stack = [six.iteritems(node._instance)]
-    
-    def __iter__(self):
-        return self
-    
-    def __next__(self):
-        while self.iter_stack:
-            try:
-                key, val = six.next(self.iter_stack[-1])
-            except StopIteration:
-                self.iter_stack.pop()
-                if self.iter_stack:
-                    self.key_stack.pop()
-                continue
-                
-            if isinstance(val, dict):
-                self.key_stack.append(key)
-                self.iter_stack.append(six.iteritems(val))
-            else:
-                return '.'.join(self.key_stack + [key])
-                
-        raise StopIteration
 
 class Uncertainty(np.ndarray):
     """


### PR DESCRIPTION
An iterator was defined on the datamodels meta node as part of the effort to provide compatibility with the astropy NDData interface. Because having a way to iterate over nodes in a datamodel is generally useful, the code for the iterator was moved into the parent of MetaNode, ObjectNode. The iterator walks the tree and returns keys from subtrees as dotted names, e.g. "meta.instrument.name".

In addition a new method was added to ObjectNode, items(). It is a generator which returns a (key, value) tuple with each invocation. It invokes the new iterator and so the key in the tuple has the same format.

This request addresses issue #1003