### PR TITLE
Add FGS guiding modes to EXP_TYPE

### DIFF
--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -397,7 +397,8 @@ properties:
           type:
             title: Type of data in the exposure
             type: string
-            enum: [FGS_DARK, FGS_FOCUS, FGS_IMAGE, FGS_INTFLAT, FGS_SKYFLAT,
+            enum: [FGS_ACQ1, FGS_ACQ2, FGS_DARK, FGS_FINEGUIDE, FGS_FOCUS,
+              FGS_ID-IMAGE, FGS_ID-STACK, FGS_IMAGE, FGS_INTFLAT, FGS_SKYFLAT, FGS_TRACK,
               MIR_IMAGE, MIR_TACQ, MIR_LYOT, MIR_4QPM, MIR_LRS-FIXEDSLIT,
               MIR_LRS-SLITLESS, MIR_MRS, MIR_DARK, MIR_FLAT-IMAGE, MIR_FLATIMAGE,
               MIR_FLAT-MRS, MIR_FLATMRS, MIR_CORONCAL, NIS_AMI, NIS_DARK,


### PR DESCRIPTION
Update core schema to add the new FGS guiding mode EXP_TYPE's to the enum list for EXP_TYPE. They include FGS_ID-STACK, FGS_ID-IMAGE, FGS_ACQ1,  FGS_ACQ2, FGS_TRACK, and FGS_FINEGUIDE.

In support of #597.