### PR TITLE
Fix typo in ramp_fitting doc index

### DIFF
--- a/docs/jwst/ramp_fitting/index.rst
+++ b/docs/jwst/ramp_fitting/index.rst
@@ -9,4 +9,4 @@ Ramp Fitting
    reference_files.rst
 
 
-..automodapi:: jwst.ramp_fitting
+.. automodapi:: jwst.ramp_fitting


### PR DESCRIPTION
automodapi command in index.rst was missing a white space, causing it to fail.