### PR TITLE
Change the model container iterator to open one model at a time

### DIFF
--- a/jwst/cube_build/cube_build_io_util.py
+++ b/jwst/cube_build/cube_build_io_util.py
@@ -489,7 +489,8 @@ class IFUCubeASN(object):
             with datamodels.ModelContainer(input) as input_model:
                 self.output_name =input_model.meta.asn_table.products[0].name
 
-            for model in input:
+            for i in range(len(input)):
+                model = input[i]
                 self.input_models.append(model)
                 self.filenames.append(model.meta.filename)
 #            print('number of models',len(self.filenames))

--- a/jwst/cube_build/data_types.py
+++ b/jwst/cube_build/data_types.py
@@ -70,7 +70,8 @@ class DataTypes(object):
                 with datamodels.ModelContainer(input) as input_model:
                     self.output_name =input_model.meta.asn_table.products[0].name
 
-            for model in input:
+            for i in range(len(input)):
+                model = input[i]
                 self.input_models.append(model)
                 self.filenames.append(model.meta.filename)
 #            print('number of models',len(self.filenames))

--- a/jwst/datamodels/tests/test_models.py
+++ b/jwst/datamodels/tests/test_models.py
@@ -374,6 +374,10 @@ def test_image_with_extra_keyword_to_multislit():
 @pytest.fixture(scope="module")
 def container():
     with ModelContainer(ASN_FILE) as c:
+        # To force the models open
+        for i in range(len(c)):
+            m = c[i]
+
         for m in c:
             m.meta.observation.program_number = '0001'
             m.meta.observation.observation_number = '1'

--- a/jwst/datamodels/tests/test_models.py
+++ b/jwst/datamodels/tests/test_models.py
@@ -373,11 +373,7 @@ def test_image_with_extra_keyword_to_multislit():
 
 @pytest.fixture(scope="module")
 def container():
-    with ModelContainer(ASN_FILE) as c:
-        # To force the models open
-        for i in range(len(c)):
-            m = c[i]
-
+    with ModelContainer(ASN_FILE, persist=True) as c:
         for m in c:
             m.meta.observation.program_number = '0001'
             m.meta.observation.observation_number = '1'

--- a/jwst/mrs_imatch/mrs_imatch_step.py
+++ b/jwst/mrs_imatch/mrs_imatch_step.py
@@ -44,7 +44,7 @@ class MRSIMatchStep(Step):
     reference_file_types = []
 
     def process(self, images):
-        all_models2d = datamodels.ModelContainer(images)
+        all_models2d = datamodels.ModelContainer(images, persist=True)
 
         chm = {}
 

--- a/jwst/tweakreg/tweakreg_step.py
+++ b/jwst/tweakreg/tweakreg_step.py
@@ -61,7 +61,7 @@ class TweakRegStep(Step):
 
     def process(self, input):
 
-        img = datamodels.ModelContainer(input)
+        img = datamodels.ModelContainer(input, persist=True)
 
         if len(img) == 0:
             raise ValueError("Input must contain at least one image model.")

--- a/jwst/tweakreg_catalog/tweakreg_catalog_step.py
+++ b/jwst/tweakreg_catalog/tweakreg_catalog_step.py
@@ -27,7 +27,7 @@ class TweakregCatalogStep(Step):
         catalog_format = self.catalog_format
         kernel_fwhm = self.kernel_fwhm
         snr_threshold = self.snr_threshold
-
+        # TODO: fix
         model = ModelContainer(input)
 
         for image_model in model:
@@ -53,7 +53,6 @@ class TweakregCatalogStep(Step):
             image_model.meta.tweakreg_catalog.filename = catalog_filename
             image_model.catalog = catalog
 
-        model.close()
         return model
 
 

--- a/jwst/tweakreg_catalog/tweakreg_catalog_step.py
+++ b/jwst/tweakreg_catalog/tweakreg_catalog_step.py
@@ -27,8 +27,7 @@ class TweakregCatalogStep(Step):
         catalog_format = self.catalog_format
         kernel_fwhm = self.kernel_fwhm
         snr_threshold = self.snr_threshold
-        # TODO: fix
-        model = ModelContainer(input)
+        model = ModelContainer(input, persist=True)
 
         for image_model in model:
             catalog = make_tweakreg_catalog(image_model, kernel_fwhm,


### PR DESCRIPTION
The iterator that is part of the model container has been rewritten so that at each iteration the current model is opened and the previous model is closed. To support this, the code in model container has been changed so that models are not opened when the container is created and random access checks if the model is open and opens it if it is not. The purpose of this change is to reduce the memory footprint of code that uses model containers.