### PR TITLE
Extract filename from hdulist for storage in metadata

### DIFF
--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -180,7 +180,10 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         # if the input is from a file, set the filename attribute
         if isinstance(init, six.string_types):
             self.meta.filename = os.path.basename(init)
-
+        elif isinstance(init, fits.HDUList):
+            filename = init.fileinfo(0)['filename']
+            self.meta.filename = os.path.basename(filename)
+        
         # if the input model doesn't have a date set, use the current date/time
         if self.meta.date is None:
             self.meta.date = Time(datetime.datetime.now())

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -181,8 +181,11 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         if isinstance(init, six.string_types):
             self.meta.filename = os.path.basename(init)
         elif isinstance(init, fits.HDUList):
-            filename = init.fileinfo(0)['filename']
-            self.meta.filename = os.path.basename(filename)
+            info = init.fileinfo(0)
+            if info is not None:
+                filename = info.get('filename')
+                if filename is not None:
+                    self.meta.filename = os.path.basename(filename)
         
         # if the input model doesn't have a date set, use the current date/time
         if self.meta.date is None:


### PR DESCRIPTION
The current version of DataModel.__init__ only extracts the filename from the input if the input is a string. This version also extracts the filename if the input is an hdulist. In that case it calls fileinfo to get the filename from the hdulist. This change was needed because in the most usual case the generic open function passes an hdulist to DataModel.__init__, so previously the filename was not
being updated in the metadata.