### PR TITLE
fix another instance of gwcs.get_axes

### DIFF
--- a/jwst/assign_wcs/util.py
+++ b/jwst/assign_wcs/util.py
@@ -114,7 +114,7 @@ def wcs_from_footprints(dmodels, refmodel=None, transform=None, bounding_box=Non
     if transform is None:
         transform = []
         wcsinfo = pointing.wcsinfo_from_model(refmodel)
-        sky_axes, _ = gwutils.get_axes(wcsinfo)
+        sky_axes, spec, other = gwutils.get_axes(wcsinfo)
         rotation = astmodels.AffineTransformation2D(np.array(wcsinfo['PC']))
         transform.append(rotation)
         if sky_axes:


### PR DESCRIPTION
Missed one call to gwcs.get_axes which now returns 3 outputs. Should fix the nightly resample test failure.