### PR TITLE
Do not include _i2d in source catalog filename

### DIFF
--- a/jwst/source_catalog/source_catalog.py
+++ b/jwst/source_catalog/source_catalog.py
@@ -1,10 +1,33 @@
+import re
+from os.path import split, splitext, join
+
 import numpy as np
 from astropy.convolution import Gaussian2DKernel
 from astropy.stats import sigma_clipped_stats, gaussian_fwhm_to_sigma
 from astropy.table import QTable
 import astropy.units as u
 import photutils
+
 from ..datamodels import DrizProductModel
+
+
+def _replace_suffix_ext(filepath, old_suffix_list, new_suffix,
+                        output_ext='escv', output_dir=None):
+    """
+    Replace suffix and extension of a filepath.
+    """
+
+    path, filename = split(filepath)
+    name, ext = splitext(filename)
+    remove_suffix = '^(.+?)(_(' + '|'.join(old_suffix_list) + '))?$'
+    match = re.match(remove_suffix, name)
+    name = match.group(1)
+
+    output_path = '{0}_{1}.{2}'.format(name, new_suffix, output_ext)
+    if output_dir is not None:
+        output_path = join(output_dir, output_path)
+
+    return output_path
 
 
 def make_source_catalog(model, kernel_fwhm, kernel_xsize, kernel_ysize,

--- a/jwst/source_catalog/source_catalog.py
+++ b/jwst/source_catalog/source_catalog.py
@@ -1,5 +1,5 @@
 import re
-from os.path import split, splitext, join
+from os.path import split, splitext, join, abspath, expanduser
 
 import numpy as np
 from astropy.convolution import Gaussian2DKernel
@@ -25,7 +25,7 @@ def _replace_suffix_ext(filepath, old_suffix_list, new_suffix,
 
     output_path = '{0}_{1}.{2}'.format(name, new_suffix, output_ext)
     if output_dir is not None:
-        output_path = join(output_dir, output_path)
+        output_path = abspath(expanduser(join(output_dir, output_path)))
 
     return output_path
 

--- a/jwst/source_catalog/source_catalog.py
+++ b/jwst/source_catalog/source_catalog.py
@@ -178,9 +178,9 @@ def make_source_catalog(model, kernel_fwhm, kernel_xsize, kernel_ysize,
                     model.meta.photometry.pixelarea_arcsecsq)
 
     # define AB mag
-    mask = np.isfinite(micro_Jy)
     abmag = np.full(nsources, np.nan)
-    abmag[mask] = -2.5 * np.log10(micro_Jy) + 23.9
+    mask = np.isfinite(micro_Jy)
+    abmag[mask] = -2.5 * np.log10(micro_Jy[mask]) + 23.9
     catalog['abmag'] = abmag
 
     # define AB mag error

--- a/jwst/source_catalog/source_catalog_step.py
+++ b/jwst/source_catalog/source_catalog_step.py
@@ -39,12 +39,15 @@ class SourceCatalogStep(Step):
                 npixels, deblend=deblend)
             self.log.info('Detected {0} sources'.format(len(catalog)))
 
-            catalog_filename = model.meta.filename.replace('_i2d.fits',
-                                                           '_cat.ecsv')
-            catalog.write(catalog_filename, format='ascii.ecsv')
+            old_suffixes = ['i2d']
+            output_dir = self.search_attr('output_dir')
+            cat_filepath = source_catalog._replace_suffix_ext(
+                model.meta.filename, old_suffixes, 'cat', output_ext='escv',
+                output_dir=output_dir)
+            catalog.write(cat_filepath, format='ascii.ecsv')
             self.log.info('Wrote source catalog: {0}'
-                          .format(catalog_filename))
-            model.meta.source_catalog.filename = catalog_filename
+                          .format(cat_filepath))
+            model.meta.source_catalog.filename = cat_filepath
 
         # nothing is returned because this is the last step
         return

--- a/jwst/source_catalog/source_catalog_step.py
+++ b/jwst/source_catalog/source_catalog_step.py
@@ -44,7 +44,7 @@ class SourceCatalogStep(Step):
             cat_filepath = source_catalog._replace_suffix_ext(
                 model.meta.filename, old_suffixes, 'cat', output_ext='escv',
                 output_dir=output_dir)
-            catalog.write(cat_filepath, format='ascii.ecsv')
+            catalog.write(cat_filepath, format='ascii.ecsv', overwrite=True)
             self.log.info('Wrote source catalog: {0}'
                           .format(cat_filepath))
             model.meta.source_catalog.filename = cat_filepath

--- a/jwst/source_catalog/source_catalog_step.py
+++ b/jwst/source_catalog/source_catalog_step.py
@@ -39,7 +39,7 @@ class SourceCatalogStep(Step):
                 npixels, deblend=deblend)
             self.log.info('Detected {0} sources'.format(len(catalog)))
 
-            catalog_filename = model.meta.filename.replace('.fits',
+            catalog_filename = model.meta.filename.replace('_i2d.fits',
                                                            '_cat.ecsv')
             catalog.write(catalog_filename, format='ascii.ecsv')
             self.log.info('Wrote source catalog: {0}'


### PR DESCRIPTION
This fixes #1051 **assuming** the input `DrizProductModel` filename always ends in `_i2d.fits`.  Please let me know if that's not the case and I will generalize this.

This PR also includes a small fix to the masked AB mag assignment.