### PR TITLE
Fix association reference file prefetch

### DIFF
--- a/jwst/stpipe/crds_client.py
+++ b/jwst/stpipe/crds_client.py
@@ -72,10 +72,8 @@ def get_multiple_reference_paths(input_file, reference_file_types):
     get_multiple_reference_paths() layers these additional tasks onto
     crds.getreferences():
 
-    1. It converts an input file into a flat dictionary of JWST data
-    model dotted parameters.
-
-    2. It verifies than any true filepath (not N/A) returned is openable.
+    It converts an input file into a flat dictionary of JWST data
+    model dotted parameters for defining CRDS best references.
 
     Returns { filetype : filepath or "N/A", ... }
     """
@@ -86,14 +84,10 @@ def get_multiple_reference_paths(input_file, reference_file_types):
     if not reference_file_types:   # [] interpreted as *all types*.
         return {}
 
-    if six.PY2:
-        model_types = (str, unicode, datamodels.DataModel)
-    else:
-        model_types = (str, datamodels.DataModel)
-    if isinstance(input_file, model_types):
+    if isinstance(input_file, (six.string_types, datamodels.DataModel)):
         with datamodels.open(input_file) as dm:
             data_dict = dm.to_flat_dict(include_arrays=False)
-    else:
+    else:  # XXX not sure what this does... seems unneeded.
         data_dict = _flatten_dict(input_file)
 
     gc.collect()
@@ -138,16 +132,14 @@ def get_reference_file(input_file, reference_file_type):
 
     reference_file_type : string
         The type of reference file to retrieve.  For example, to
-        retrieve a flat field reference file, this would be
-        'flat_field'.
+        retrieve a flat field reference file, this would be 'flat'.
 
     Returns
     -------
     reference_filepath : string
         The path of the reference in the CRDS file cache.
     """
-    # First item = 0,  tuple name element = 1
-    return list(get_multiple_reference_paths(input_file, [reference_file_type]).items())[0][1]
+    return get_multiple_reference_paths(input_file, [reference_file_type])[reference_file_type]
 
 def get_override_name(reference_file_type):
     """

--- a/jwst/stpipe/pipeline.py
+++ b/jwst/stpipe/pipeline.py
@@ -129,7 +129,7 @@ class Pipeline(Step):
         Precache all of the expected reference files in this Pipeline
         and all of its constituent Steps process method is called.
 
-        input_file:  a filename string, model, or container model.
+        input_file:  a filename string, model, or model container.
 
         """
         from .. import datamodels

--- a/jwst/stpipe/pipeline.py
+++ b/jwst/stpipe/pipeline.py
@@ -131,8 +131,6 @@ class Pipeline(Step):
         """
         from .. import datamodels
         gc.collect()
-        if self._is_association_file(input_file):
-            return
         try:
             with datamodels.open(input_file) as model:
                 pass

--- a/jwst/stpipe/pipeline.py
+++ b/jwst/stpipe/pipeline.py
@@ -128,21 +128,22 @@ class Pipeline(Step):
         """
         Precache all of the expected reference files in this Pipeline
         and all of its constituent Steps process method is called.
+
+        input_file:  a filename string, model, or container model.
+
         """
         from .. import datamodels
         gc.collect()
         try:
             with datamodels.open(input_file) as model:
-                pass
+                super(Pipeline, self)._precache_reference_files_opened(model)
+                for name in self.step_defs.keys():
+                    step = getattr(self, name)
+                    step._precache_reference_files_opened(model)
         except (ValueError, TypeError, IOError):
             self.log.info(
                 'First argument {0} does not appear to be a '
                 'model'.format(input_file))
-        else:
-            super(Pipeline, self)._precache_reference_files(input_file)
-            for name in self.step_defs.keys():
-                step = getattr(self, name)
-                step._precache_reference_files(input_file)
         gc.collect()
 
     def set_input_filename(self, path):

--- a/jwst/stpipe/step.py
+++ b/jwst/stpipe/step.py
@@ -651,16 +651,6 @@ class Step(object):
                 (reference_file_type, hdr_name))
         return crds_client.check_reference_open(reference_name)
 
-    @classmethod
-    def list_reference_files(cls, input_file):
-        """
-        List reference types and files name for a particular input file.
-        """
-        if cls._is_container(input_file):
-            return
-        return crds_client.get_multiple_reference_paths(
-            input_file, cls.reference_file_types)
-
     def reference_uri_to_cache_path(self, reference_uri):
         """Convert an abstract CRDS reference URI to an absolute file path in the CRDS
         cache.  Reference URI's are typically output to dataset headers to record the

--- a/jwst/stpipe/step.py
+++ b/jwst/stpipe/step.py
@@ -3,12 +3,12 @@ Step
 """
 from __future__ import absolute_import, division, print_function
 
-from astropy.extern import six
-import contextlib
 import gc
 from os.path import dirname, join, basename, splitext, abspath, split
 import re
 import sys
+
+from astropy.extern import six
 
 try:
     from astropy.io import fits
@@ -23,7 +23,7 @@ from . import utilities
 from .. import __version_commit__, __version__
 
 SUFFIX_LIST = ['rate', 'cal', 'uncal', 'i2d', 's2d', 's3d',
-    'jump', 'ramp', 'x1d', 'x2d', 'x1dints', 'calints', 'rateints']
+               'jump', 'ramp', 'x1d', 'x2d', 'x1dints', 'calints', 'rateints']
 REMOVE_SUFFIX = '^(.+?)(_(' + '|'.join(SUFFIX_LIST) + '))?$'
 
 
@@ -144,7 +144,7 @@ class Step(object):
 
     @classmethod
     def _parse_class_and_name(
-        cls, config, parent=None, name=None, config_file=None):
+            cls, config, parent=None, name=None, config_file=None):
         if 'class' in config:
             step_class = utilities.import_class(config['class'],
                                                 config_file=config_file)
@@ -332,7 +332,7 @@ class Step(object):
         result = None
 
         try:
-            if len(args):
+            if len(args) and len(self.reference_file_types) and not self.skip:
                 self._precache_reference_files(args[0])
 
             self.log.info(
@@ -382,7 +382,7 @@ class Step(object):
             else:
                 results = result
 
-            if len(self._reference_files_used) and not self._is_association_file(args[0]):
+            if len(self._reference_files_used) and not self._is_container(args[0]):
                 for result in results:
                     if isinstance(result, datamodels.DataModel):
                         for ref_name, filename in self._reference_files_used:
@@ -514,8 +514,10 @@ class Step(object):
             return value
 
     @classmethod
-    def _is_association_file(cls, input_file):
-        """Return True IFF `input_file` is an association file."""
+    def _is_container(cls, input_file):
+        """Return True IFF `input_file` is a ModelContainer or successfully
+        loads as an association.
+        """
         from ..associations import load_asn
         from .. import datamodels
         if isinstance(input_file, datamodels.ModelContainer):
@@ -531,47 +533,53 @@ class Step(object):
         """
         Precache all of the expected reference files before the Step's
         process method is called.
+
+        Perform's garbage collection before and after prefetching.
+
+        Handles opening `input_file` as a model if it is a filename.
+
+        input_file:  filename, model container, or model
+
+        returns:  None
         """
         gc.collect()
-        if self.skip:
-            return
-        if len(self.reference_file_types):
-            from .. import datamodels
-            try:
-                model = datamodels.open(input_file)
-            except (ValueError, TypeError, IOError):
-                self.log.info(
-                    'First argument {0} does not appear to be a '
-                    'model'.format(input_file))
-            else:
-                self._precache_reference_files_impl(model)
-                model.close()
+        from .. import datamodels
+        try:
+            with datamodels.open(input_file) as model:
+                self._precache_reference_files_opened(model)
+        except (ValueError, TypeError, IOError):
+            self.log.info(
+                'First argument {0} does not appear to be a '
+                'model'.format(input_file))
         gc.collect()
 
-    @classmethod
-    def list_reference_files(cls, input_file):
-        """
-        List reference types and files name for a particular input file.
-        """
-        if cls._is_association_file(input_file):
-            return
-        return crds_client.get_multiple_reference_paths(
-            input_file, cls.reference_file_types)
+    def _precache_reference_files_opened(self, model_or_container):
+        """Pre-fetches references for `model_or_container`.   
 
+        Handles recursive pre-fetches for any models inside a container,
+        or just a single model.
+        
+        Assumes model_or_container is an open model or container object,
+        not a filename.
+
+        No garbage collection.
+        """
+        if self._is_container(model_or_container):
+            # recurse on each contained model
+            for contained_model in model_or_container:
+                self._precache_reference_files_opened(contained_model)
+        else:
+            # precache a single model object
+            self._precache_reference_files_impl(model_or_container)    
+            
     def _precache_reference_files_impl(self, model):
         """Given open data `model`,  determine and cache reference files for
         any reference types which are not overridden on the command line.
 
         Verify that all CRDS and overridden reference files are readable.
-        """
-        if self.skip:
-            return
 
-        if self._is_association_file(model):
-            for mod in model:
-                self._precache_reference_files(mod)
-            return
-        
+        model:  An open Model object;  not a filename, ModelContainer, etc.
+        """
         ovr_refs = {
             reftype: self._get_ref_override(reftype)
             for reftype in self.reference_file_types
@@ -617,14 +625,11 @@ class Step(object):
 
         reference_file_type : string
             The type of reference file to retrieve.  For example, to
-            retrieve a flat field reference file, this would be
-            'flat_field'.
+            retrieve a flat field reference file, this would be 'flat'.
 
         Returns
         -------
-        reference_file : readable file-like object
-            A readable file-like object with the contents of the
-            reference file.
+        reference_file : path of reference file,  a string
         """
         override = self._get_ref_override(reference_file_type)
         if override is not None:
@@ -646,6 +651,16 @@ class Step(object):
                 (reference_file_type, hdr_name))
         return crds_client.check_reference_open(reference_name)
 
+    @classmethod
+    def list_reference_files(cls, input_file):
+        """
+        List reference types and files name for a particular input file.
+        """
+        if cls._is_container(input_file):
+            return
+        return crds_client.get_multiple_reference_paths(
+            input_file, cls.reference_file_types)
+
     def reference_uri_to_cache_path(self, reference_uri):
         """Convert an abstract CRDS reference URI to an absolute file path in the CRDS
         cache.  Reference URI's are typically output to dataset headers to record the
@@ -658,38 +673,6 @@ class Step(object):
         with default value /grp/crds/cache.   See also https://jwst-crds.stsci.edu
         """
         return crds_client.reference_uri_to_cache_path(reference_uri)
-
-    @contextlib.contextmanager
-    def get_reference_file_model(self, input_file, reference_file_type):
-        """
-        Get a reference file from CRDS as a jwst.datamodels.ModelBase
-        object.  If the configuration file or commandline parameters
-        override the reference file, it will be automatically used
-        when calling this function.
-
-        Parameters
-        ----------
-        input_file : jwst.datamodels.ModelBase instance
-            A model of the input file.  Metadata on this input file
-            will be used by the CRDS "bestref" algorithm to obtain a
-            reference file.
-
-        reference_file_type : string
-            The type of reference file to retrieve.  For example, to
-            retrieve a flat field reference file, this would be
-            'flat_field'.
-
-        Returns
-        -------
-        reference_file_model : jwst.datamodels.ModelBase instance
-            A model to access the contents of the reference file.
-        """
-        from .. import datamodels
-
-        filename = self.get_reference_file(input, reference_file_type)
-        with datamodels.open(filename) as model:
-            yield model
-        gc.collect()
 
     def set_input_filename(self, path):
         """


### PR DESCRIPTION
I refactored the stpipe reference file pre-fetching to enable association (ModelContainer) pre-fetches and to better handle model opening, closing, and garbage collection.  Hopefully it minimizes the pipeline prefetch overhead by sticking to a single open model and garbage collecting only at the top level.  (step.py, pipeline.py).  

Refactored Step methods into focused and nested goals (open a model if needed and garbage collect,  handle containers,  handle overrides and result checking, etc).  I also removed some of the "retreat logic" like "if self.skip: return" by using it to avoid calling the method instead.

I removed the seemingly unused get_reference_file_model() method.  list_reference_files(),  which does not handle associations and containers,  should likewise be considered for removal.

Simplified some code in crds_client.py,  a couple pylint tweaks,  and fixed some bad comments.

