### PR TITLE
Add NOUTPUTS keyword to core schema

### DIFF
--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -441,6 +441,11 @@ properties:
               NRSRAPID, NRSIRS2RAPID, ALLIRS2, NRSSLOW, RAPID,
               SHALLOW2, SHALLOW4, SLOW, TRACK, ANY, N/A]
             fits_keyword: READPATT
+          noutputs:
+            title: Number of detector outputs used
+            type: integer
+            enum: [1, 4]
+            fits_keyword: NOUTPUTS
           nints:
             title: Number of integrations in exposure
             type: integer


### PR DESCRIPTION
NIRCam is adding a new keyword that indicates the number of detector outputs used when reading out an exposure. The default is 4 outputs, but for some subarrays the user can choose to use just 1 amplifier output.

Implementing as documented in [JWSTKD-28](https://jira.stsci.edu/browse/JWSTKD-28)