### PR TITLE
Blot

### DIFF
--- a/jwst/cube_build/blot_cube_build.py
+++ b/jwst/cube_build/blot_cube_build.py
@@ -10,20 +10,17 @@ import logging
 
 from astropy.io import fits
 from astropy.modeling import models
-#from gwcs.utils import _domain_to_bounds
+
 from ..associations import Association
 from .. import datamodels
 from ..assign_wcs import nirspec
 from ..assign_wcs import pointing
-from . import instrument_defaults
-
-from . import file_table
-from . import spaxel
-from . import cube_overlap
-from . import cube_cloud
-from . import data_types
-
 from gwcs import wcstools
+from . import instrument_defaults
+from . import coord
+
+
+
 
 
 log = logging.getLogger(__name__)
@@ -35,20 +32,21 @@ class CubeBlot(object):
     def __init__(self, median_model,
                  input_models):
         
-        self.number_files = len(input_models)
+        #Pull out the needed information from the Median IFUCube
         self.median_skycube = median_model
         self.instrument = median_model.meta.instrument.name
         self.detector = median_model.meta.instrument.detector
+        #information on how the IFUCube was constructed 
+        self.weight_power = median_model.meta.weight_power
+        self.weighting = median_model.meta.weighting # if AREA ABORT
+        self.rois = median_model.meta.roi_spatial
+        self.roiw = median_model.meta.roi_wave
 
+        #basic information about the type of data
         self.grating = None
         self.filter = None
         self.subchannel = None
         self.channel = None
-        self.rois = median_model.meta.roi_spatial
-        self.roiw = median_model.meta.roi_wave
-        self.naxis1 = self.median_skycube.data.shape[2]
-        self.naxis2 = self.median_skycube.data.shape[1]
-        self.naxis3 =  self.median_skycube.data.shape[0]
 
         if(self.instrument == 'MIRI'):
             self.channel = median_model.meta.instrument.channel
@@ -56,41 +54,26 @@ class CubeBlot(object):
         elif(self.instrument == 'NIRSPEC'):
             self.grating = median_model.meta.instrument.grating
             self.filter = median_model.meta.instrument.filter
-            
-# initialize blotted images to be original input images
 
-        self.blot_models = datamodels.ModelContainer() 
-
-        for model in input_models:
-            blot = model.copy()  
-            blot.err = None
-            blot.dq = None
-
-            filename = model.meta.filename
-            indx = filename.rfind('.fits')
-            blot.meta.filename = filename[:indx] + '_blot.fits' #set output name
-            self.blot_models.append(blot)
-
-#        self.Cdelt1 = median_model.meta.wcsinfo.cdelt1
-#        self.Cdelt2 = median_model.meta.wcsinfo.cdelt2
-#        self.Cdelt3 = median_model.meta.wcsinfo.cdelt3
-#        self.Crpix1 = median_model.meta.wcsinfo.crpix1
-#        self.Crpix2 = median_model.meta.wcsinfo.crpix2
-#        self.Crpix3 = median_model.meta.wcsinfo.crpix3
-#        self.Crval1 = median_model.meta.wcsinfo.crval1
-#        self.Crval2 = median_model.meta.wcsinfo.crval2
-#        self.Crval3 = median_model.meta.wcsinfo.crval3
-        
+        # find the ra,dec,lambda of each element of the IFUCube
+        self.naxis1 = self.median_skycube.data.shape[2]
+        self.naxis2 = self.median_skycube.data.shape[1]
+        self.naxis3 =  self.median_skycube.data.shape[0]
 
         xcube,ycube,zcube = wcstools.grid_from_bounding_box(self.median_skycube.meta.wcs.bounding_box,
                                                 step=(1,1,1))
         
         cube_pos1,cube_pos2,cube_pos3 = self.median_skycube.meta.wcs(xcube,ycube,zcube)
         num = self.naxis1* self.naxis2 * self.naxis3
-
+        flux = self.median_skycube.data
         self.cube_ra = np.reshape(cube_pos1,num)
         self.cube_dec = np.reshape(cube_pos2,num)
         self.cube_wave = np.reshape(cube_pos3,num)
+        self.cube_flux = np.reshape(flux,num)            
+# initialize blotted images to be original input images
+
+        self.input_models = input_models
+
 
 #********************************************************************************
 # Print basic parameters of blot images and blot median
@@ -109,65 +92,150 @@ class CubeBlot(object):
             log.info('Grating %s',self.grating)
             log.info('Filter %s',self.filter)
         log.info('ROI size (spatial and wave) %f %f',self.rois,self.roiw)
-        log.info('Number of input models %i ',len(self.blot_models))
+        log.info('Number of input models %i ',len(self.input_models))
         
 #********************************************************************************
 
     def blot_images(self):
 
+
+        blot_models = datamodels.ModelContainer() 
+        lower_limit = 0.01
         instrument_info = instrument_defaults.InstrumentInfo()
-        print('First 10 elements cube - ra  ',self.cube_ra[0:10])
-        print('First 10 elements cube - dec%',self.cube_dec[0:10])
-        print('First 10 elements cube - wave',self.cube_wave[0:10])        
-        for model in self.blot_models:
+
+        for model in self.input_models:
+            blot = model.copy()  
+            blot.err = None
+            blot.dq = None
+
+            filename = model.meta.filename
+            indx = filename.rfind('.fits')
+            blot.meta.filename = filename[:indx] + '_blot.fits' #set output name
+            print('Blotting back model',model.meta.filename)
 
             if(self.instrument =='MIRI'):
+                
                 this_par1 = self.channel # only one channel is blotted at a time
+                # get the detector values for this model
                 xstart, xend = instrument_info.GetMIRISliceEndPts(this_par1)
-                y, x = np.mgrid[:1024, xstart:xend]
-                y = np.reshape(y, y.size)
-                x = np.reshape(x, x.size)
+#                xdet,ydet = wcstools.grid_from_bounding_box(model.meta.wcs.bounding_box, step=(1,1))
+                ydet, xdet = np.mgrid[:1024, :1032]                                    
 
-                ra,dec,lam = model.meta.wcs(x,y)
+                blot_flux = np.zeros(model.shape,dtype=np.float32)
+                blot_weight = np.zeros(model.shape,dtype=np.float32)
+                blot_iflux = np.zeros(model.shape,dtype=np.float32)
+
+                pixel_mask = np.full(model.shape,False,dtype=bool)
+                pixel_mask[:,xstart:xend] = True
+                ra_det,dec_det,wave_det = model.meta.wcs(xdet,ydet)
+
+#                print('xstart and xend',xstart,xend)
+#                print('size of blot flux',blot_flux.size)                
+
+                valid1 = np.isfinite(ra_det)
+                valid2 = np.isfinite(dec_det)
+                valid3 = np.isfinite(wave_det)
+                value = valid1 & valid2 & valid3 & pixel_mask
+                good_data =  np.where( value == True)
+                y,x = good_data
+
+#                print('size of value',value.size,value.shape)                
+#                print(value[0,0:100])
+#                print('x', x[0:100])
+#                print(valid1[10,0:100])
+#                print(pixel_mask[10,0:100])
+
+#                print('length of index ',len(good_data[0]))                       
+#                print('good data',good_data)
+                
+                ra_blot = ra_det[good_data]
+                dec_blot = dec_det[good_data]
+                wave_blot = wave_det[good_data]
+                
+                crval1 = model.meta.wcsinfo.crval1
+                crval2 = model.meta.wcsinfo.crval2
+                xi_blot,eta_blot = coord.radec2std(crval1, crval2,ra_blot,dec_blot) # for each x,y pixel
+
+                xi_cube,eta_cube = coord.radec2std(crval1, crval2, # cube values
+                                                   self.cube_ra,self.cube_dec) 
+
+                print('size of xi_blot',xi_blot.shape)
+                num = ra_blot.size
+                print('Size of pixel detectors looping over/1024',num/1024)
+                iprint = 0 
+#________________________________________________________________________________  
+                # loop over the valid pixels on the detector
+                for ipt in range(0, num - 1):
+                    
+                    # xx,yy are the index value of the orginal detector frame -
+                    # blot image
+                    yy = y[ipt]
+                    xx = x[ipt]                    
+                    # find the cube values that fall withing ROI of detector xx,yy
+                    xdistance = (xi_blot[ipt] - xi_cube)
+                    ydistance = (eta_blot[ipt] - eta_cube)
+                    radius = np.sqrt(xdistance * xdistance + ydistance * ydistance)
+                
+                    index =  np.where(np.logical_and( 
+                            (radius  <=self.rois),  
+                            (abs(wave_blot[ipt] - self.cube_wave) <= self.roiw)
+                            ))
+#                    print('for detector point',ipt,xi_blot[ipt],eta_blot[ipt],wave_blot[ipt])
+#                    print(' original x,y index',x[ipt],y[ipt])
+#                    print(' index, # and value ',len(index[0]),index)
 
 
-#            outsci = np.zeros(model.shape,dtype=np.float32)
-#            xdet,ydet = model.meta.wcs.backward_transform(self.cube_ra,
-#                                                          self.cube_dec,
-#                                                          self.cube_wave)
-#            print('transform world to detector',xdet.shape)
-#            print('x',xdet[0:50])
-#            print('y',ydet[0:50])
+                    wave_found = self.cube_wave[index]        # z Cube values falling in wavelength roi
+                    xi_found = xi_cube[index]   # x Cube values within radius 
+                    eta_found = eta_cube[index]  # y cube values with the radius
+#                    print('wave found',wave_found)
+#                    print('xi_found',xi_found)
+#                    print('eta found',eta_found)
+
+#________________________________________________________________________________  
+                    #loop over the median cube pixels that fall within the ROI
+                    # of the detector center
+                    if(iprint == 0):
+                        print ('on pixel ipt',ipt,len(index[0]))
+                        
+#                    print(xi_found.shape)     
+                    d1 = xi_found- xi_blot[ipt]
+                    d2 = eta_found - eta_blot[ipt]
+                    d3 = wave_found - wave_blot[ipt]
+                    d = d1*d1 + d2*d2 + d3*d3
+
+                    for ii, ij in enumerate(index[0]):
+                        #print(ipt,ii,ij,xx,yy)
+                        #print(xi_found[ii],xi_blot[ipt],eta_found[ii],eta_blot[ipt])
+#                        d1 = xi_found[ii] - xi_blot[ipt]
+#                        d2 = eta_found[ii] - eta_blot[ipt]
+#                        d3 = wave_found[ii] - wave_blot[ipt]
+#                        weight_distance = math.sqrt(d1*d1 + d2*d2 + d3*d3)
+#                        weight_distance = math.pow(weight_distance,self.weight_power)
+#                        if weight_distance < lower_limit: weight_distance = lower_limit
+#                        weight_distance = 1.0 / weight_distance
+                        #print('index',index[0][j])
 
 
+                        weight_distance = math.sqrt(d[ii])
+                        weight_distance = math.pow(weight_distance,self.weight_power)
+                        if weight_distance < lower_limit: weight_distance = lower_limit
+                        weight_distance = 1.0 / weight_distance
+
+                        blot_flux[yy,xx] = blot_flux[yy,xx]  + weight_distance*self.cube_flux[ij]
+                        blot_weight[yy,xx] =blot_weight[yy,xx]  + weight_distance
+                        blot_iflux[yy,xx] = blot_iflux[yy,xx] + 1
+                        
+                    # determine finnal flux    
+                    if(blot_iflux[yy,xx] > 0) :
+                        blot_flux[yy,xx] = blot_flux[yy,xx]/blot_weight[yy,xx]
+                    
+                    iprint = iprint+1
+                    if(iprint == 2048):
+                        iprint = 0 
+                        
+                blot.data = blot_flux
+            blot_models.append(blot)
+        return blot_models
 
 #********************************************************************************
-
-    def create_spaxel(self):
-        """
-        Short Summary
-        -------------
-        # now you have the size of cube - create an instance for each spaxel
-        # create an empty spaxel list - this will become a list of Spaxel classses
-
-        Parameter
-        ----------
-
-        Returns
-        -------
-        list of classes contained in spaxel
-        """
-#________________________________________________________________________________
-
-
-        total_num = self.naxis1*self.naxis2*self.naxis3
-
-        if(self.interpolation == 'pointcloud'):
-            for t in range(total_num):
-                self.spaxel.append(spaxel.Spaxel())
-        else:
-            for t in range(total_num):
-                self.spaxel.append(spaxel.SpaxelAB())
-
-        return self.spaxel
-

--- a/jwst/cube_build/cube_build.py
+++ b/jwst/cube_build/cube_build.py
@@ -163,6 +163,7 @@ class CubeData(object):
 # store the input_filenames and input_models
         num = 0
         num = len(self.input_filenames)
+        
         self.number_files = num
         self.detector = detector
         self.instrument = instrument
@@ -209,7 +210,13 @@ class CubeData(object):
         # parameter file
 
         if self.roiw == 0.0: self.roiw = roi[0]
-        if self.rois == 0.0: self.rois = roi[1]
+        if self.rois == 0.0:  # user did not set so use defaults 
+            self.rois = roi[1]
+            if self.single or self.number_files < 4:
+                self.rois = self.rois * 1.5
+                log.info('Increasing spatial region of interest' + \
+                             ' default value set for 4 dithers %f', \
+                             self.rois)
         if self.interpolation == 'pointcloud':
             log.info('Region of interest  %f %f',self.rois,self.roiw)
 
@@ -643,7 +650,7 @@ class CubeData(object):
 
         instrument  = self.instrument
         nfiles = len(self.master_table.FileMap[instrument][this_par1][this_par2])
-        log.debug('Number of files in cube %i', nfiles)
+        log.info('Number of files/models in band %i', nfiles)
 
     # loop over the files that cover the spectral range the cube is for
 

--- a/jwst/cube_build/cube_build.py
+++ b/jwst/cube_build/cube_build.py
@@ -51,7 +51,6 @@ class CubeData(object):
         self.par_filename = par_filename
         self.resol_filename = resol_filename
         
-
         self.single = pars.get('single')
         self.channel = pars.get('channel')
         self.subchannel = pars.get('subchannel')
@@ -436,7 +435,6 @@ class CubeData(object):
 
         IFUCube = CubeData.setup_IFUCube(self,0)
 
-
 #_______________________________________________________________________
 # shove Flux and iflux in the  final IFU cube
         CubeData.update_IFUCube(self,IFUCube, self.spaxel)
@@ -470,7 +468,7 @@ class CubeData(object):
         this_par1 = self.band_channel[0] # only one channel is used in this approach
         this_par2 = None # not import for this type of mapping
 
-        self.weighting =='standard'
+        self.weighting =='msm'
         c1_offset = 0
         c2_offset = 0
         for j in range(n):
@@ -886,15 +884,56 @@ class CubeData(object):
         IFUCube.meta.dq_extension = 'DQ'
         IFUCube.meta.roi_spatial = self.rois    
         IFUCube.meta.roi_wave = self.roiw
+        IFUCube.meta.weighting = self.weighting
+        IFUCube.meta.weight_power = self.weight_power
 
 #        IFUCube.meta.data_model_type = 'IFUCubeModel'
         IFUCube.error_type = 'ERR'
 
-        if(self.coord_system == 'alpha-beta'):
-            IFUCube.meta.wcsinfo.ctype1 = 'ALPHA'
-            IFUCube.meta.wcsinfo.ctype2 = 'BETA'
+        if self.coord_system == 'alpha-beta' :
             IFUCube.meta.wcsinfo.cunit1 = 'arcsec'
             IFUCube.meta.wcsinfo.cunit2 = 'arcsec'
+
+            if self.channel == '1' and self.band == 'SHORT' :
+                IFUCube.meta.wcsinfo.ctype1 = 'MRSAL1A'
+                IFUCube.meta.wcsinfo.ctype2 = 'MRSBE1A'
+            if self.channel == '2' and self.band == 'SHORT':
+                IFUCube.meta.wcsinfo.ctype1 = 'MRSAL2A'
+                IFUCube.meta.wcsinfo.ctype2 = 'MRSBE2A'
+            if self.channel == '3' and self.band == 'SHORT':
+                IFUCube.meta.wcsinfo.ctype1 = 'MRSAL3A'
+                IFUCube.meta.wcsinfo.ctype2 = 'MRSBE3A'
+            if self.channel == '4' and self.band == 'SHORT':
+                IFUCube.meta.wcsinfo.ctype1 = 'MRSAL4A'
+                IFUCube.meta.wcsinfo.ctype2 = 'MRSBE4A'
+
+            if self.channel == '1' and self.band == 'MEDIUM':
+                IFUCube.meta.wcsinfo.ctype1 = 'MRSAL1B'
+                IFUCube.meta.wcsinfo.ctype2 = 'MRSBE1B'
+            if self.channel == '2' and self.band == 'MEDIUM':
+                IFUCube.meta.wcsinfo.ctype1 = 'MRSAL2B'
+                IFUCube.meta.wcsinfo.ctype2 = 'MRSBE2B'
+            if self.channel == '3' and self.band == 'MEDIUM':
+                IFUCube.meta.wcsinfo.ctype1 = 'MRSAL3B'
+                IFUCube.meta.wcsinfo.ctype2 = 'MRSBE3B'
+            if self.channel == '4' and self.band == 'MEDIUM':
+                IFUCube.meta.wcsinfo.ctype1 = 'MRSAL4B'
+                IFUCube.meta.wcsinfo.ctype2 = 'MRSBE4B'
+
+            if self.channel == '1' and self.band == 'LONG':
+                IFUCube.meta.wcsinfo.ctype1 = 'MRSAL1C'
+                IFUCube.meta.wcsinfo.ctype2 = 'MRSBE1C'
+            if self.channel == '2' and self.band == 'LONG':
+                IFUCube.meta.wcsinfo.ctype1 = 'MRSAL2C'
+                IFUCube.meta.wcsinfo.ctype2 = 'MRSBE2C'
+            if self.channel == '3' and self.band == 'LONG':
+                IFUCube.meta.wcsinfo.ctype1 = 'MRSAL3C'
+                IFUCube.meta.wcsinfo.ctype2 = 'MRSBE3C'
+            if self.channel == '4' and self.band == 'LONG':
+                IFUCube.meta.wcsinfo.ctype1 = 'MRSAL4C'
+                IFUCube.meta.wcsinfo.ctype2 = 'MRSBE4C'
+
+
 
 
         wcsobj = pointing.create_fitswcs(IFUCube)

--- a/jwst/cube_build/cube_build_step.py
+++ b/jwst/cube_build/cube_build_step.py
@@ -90,14 +90,19 @@ class CubeBuildStep (Step):
         # 1. alpha-beta (only valid for MIRI Single Cubes)
         # 2. ra-dec
         self.interpolation = 'pointcloud' # true for self.weighting  = 'msm' or 'miripsf'
-        
+
+        # if the weighting is area then interpolation is area
         if self.weighting == 'area':
             self.interpolation = 'area'
             self.coord_system = 'alpha-beta'
 
         if self.coord_system == 'alpha-beta':
             self.weighting = 'area'
+            self.interpolation = 'area'
 
+        # if interpolation is point cloud then weighting can be
+        # 1. MSM: modified shepard method
+        # 2. miripsf - weighting for MIRI based on PSF and LSF
         if self.coord_system == 'ra-dec':
             self.interpolation = 'pointcloud'  # can not be area
 

--- a/jwst/cube_build/cube_build_step.py
+++ b/jwst/cube_build/cube_build_step.py
@@ -29,8 +29,7 @@ class CubeBuildStep (Step):
          scale1 = float(default=0.0)
          scale2 = float(default=0.0)
          scalew = float(default=0.0)
-         interpolation = option(,'pointcloud','area','POINTCLOUD','AREA',default='pointcloud')
-         weighting = option('standard','miripsf','STANDARD','MIRIPSF',default = 'standard')
+         weighting = option('msm','miripsf','area','MSM','MIRIPSF','AREA',default = 'msm')
          coord_system = option('ra-dec','alpha-beta','ALPHA-BETA',default='ra-dec')
          rois = float(default=0.0)
          roiw = float(default=0.0)
@@ -57,7 +56,6 @@ class CubeBuildStep (Step):
         if(not self.filter.isupper()): self.filter = self.filter.upper()
         if(not self.grating.isupper()): self.grating = self.grating.upper()
         if(not self.coord_system.islower()): self.coord_system = self.coord_system.lower()
-        if(not self.interpolation.islower()): self.interpolation = self.interpolation.lower()
         if(not self.weighting.islower()): self.weighting = self.weighting.lower()
 
         if(self.scale1 != 0.0): self.log.info('Input Scale of axis 1 %f', self.scale1)
@@ -91,12 +89,14 @@ class CubeBuildStep (Step):
         # valid coord_system:
         # 1. alpha-beta (only valid for MIRI Single Cubes)
         # 2. ra-dec
-
-        if self.interpolation == 'area':
+        self.interpolation = 'pointcloud' # true for self.weighting  = 'msm' or 'miripsf'
+        
+        if self.weighting == 'area':
+            self.interpolation = 'area'
             self.coord_system = 'alpha-beta'
 
         if self.coord_system == 'alpha-beta':
-            self.interpolation = 'area'
+            self.weighting = 'area'
 
         if self.coord_system == 'ra-dec':
             self.interpolation = 'pointcloud'  # can not be area

--- a/jwst/cube_build/cube_build_wcs_util.py
+++ b/jwst/cube_build/cube_build_wcs_util.py
@@ -323,17 +323,6 @@ def set_geometry(self, footprint):
         for i in range(self.naxis2):
             self.ycoord[i] = ystart
             ystart = ystart + self.Cdelt2
-#            print('ycoord',self.ycoord[i],i)
-
-#        print('ycoord xcoord shape',self.ycoord.shape,self.xcoord.shape)
-        
-#_______________________________________________________________________
-        
-#        ystart = self.ycoord[0]
-#        yend = self.ycoord[0] + self.Cdelt2*(self.naxis2)
-        
-#        xstart = self.xcoord[0]
-#        xend = self.xcoord[0] + self.Cdelt1*(self.naxis1)
 
 #        yy,xx = np.mgrid[ystart:yend:self.Cdelt2,
 #                         xstart:xend:self.Cdelt1]

--- a/jwst/cube_build/cube_cloud.py
+++ b/jwst/cube_build/cube_cloud.py
@@ -151,6 +151,8 @@ def match_det2cube(self, input_model,
 # now loop over the pixel values for this region and find the spaxels that fall 
 # withing the region of interest.
     nn  = coord1.size
+
+#    print('looping over n points mapping to cloud',nn)
 #________________________________________________________________________________
     for ipt in range(0, nn - 1):
 #________________________________________________________________________________        
@@ -161,6 +163,8 @@ def match_det2cube(self, input_model,
 #        if(ipt > 2): sys.exit('STOP')
 #        print('For point ',coord1[ipt],coord2[ipt],wave[ipt],ipt)
 
+#        if(ipt == 0):
+#            print('size of Xcenters',self.Xcenters.size)
         xdistance = (self.Xcenters - coord1[ipt])
         ydistance = (self.Ycenters - coord2[ipt])
         radius = np.sqrt(xdistance * xdistance + ydistance * ydistance)

--- a/jwst/cube_build/cube_cloud.py
+++ b/jwst/cube_build/cube_cloud.py
@@ -165,9 +165,7 @@ def match_det2cube(self, input_model,
         ydistance = (self.Ycenters - coord2[ipt])
         radius = np.sqrt(xdistance * xdistance + ydistance * ydistance)
 
-#        print(radius.shape[0]) 
-#        for ii in range(radius.shape[0]):
-#            print(radius[ii],ii,(radius[ii] <= self.rois),Cube.Xcenters[ii],Cube.Ycenters[ii])
+
         indexr = np.where(radius  <=self.rois)
         indexz = np.where(abs(self.zcoord - wave[ipt]) <= self.roiw)
 
@@ -185,24 +183,20 @@ def match_det2cube(self, input_model,
         for iz, zz in enumerate(indexz[0]):
             istart = zz * nplane
             for ir, rr in enumerate(indexr[0]):
-
                 yy_cube = int(rr/self.naxis1)
                 xx_cube = rr - yy_cube*self.naxis1
 #                print('xx yy cube',rr,self.naxis1,xx_cube,yy_cube)
 #________________________________________________________________________________
-                if self.weighting =='standard':
+                if self.weighting =='msm':
 
                     d1 = (xi_cube[ir] - coord1[ipt])/self.Cdelt1
                     d2 = (eta_cube[ir] - coord2[ipt])/self.Cdelt2
                     d3 = (zlam[iz] - wave[ipt])/self.Cdelt3
-#                    print('d1,d2,d3',d1,d2,d3)
                     
                     weight_distance = math.sqrt(d1*d1 + d2*d2 + d3*d3)
                     weight_distance = math.pow(weight_distance,self.weight_power)
-#                    print('weight_distance',weight_distance)
 #________________________________________________________________________________
 # if weight is miripsf -distances determined in alpha-beta coordinate system 
-
                 elif self.weighting =='miripsf':
                     weights = FindNormalizationWeights(wave[ipt], 
                                                          wave_resol,

--- a/jwst/datamodels/schemas/ifucube.schema.yaml
+++ b/jwst/datamodels/schemas/ifucube.schema.yaml
@@ -26,6 +26,15 @@ allOf:
           title: Size of ROI in wavelength dimension microns
           type: number
           fits_keyword: ROIW
+        weighting:
+          title: Type of weighting type (MSM,MIRIPSF,AREA)
+          type: string
+          fits_keyword: WTYPE
+        weight_power:
+          title: Weighting power for Modified Shepard Method
+          type: number
+          fits_keyword: WPOWER
+
 - type: object
   properties:
     data:


### PR DESCRIPTION
First version to blot IFUcubes back to detector plane is finished. 
First run cube_build with single='true' and input is association table or datamodel and for miri data the 'ch' option must be set to 1,2, 3 or 4,
Take the single IFUcubes and combine according to outlier detection step. For this example have med_image be the data created by the outlier step from the single IFUcubes
to blot the data

from jwst.cube_build import blot_cube_build
cubeblot  = blot_cube_build.CubeBlot(med_image, container_of_input_data) 
here container_of_input_data are the original data output from calwebb_spec2
blot_models = cubeblot.blot_images
blot_models contains the blotted images (1 to 1 mapping with container_of_input_data)
@hbushouse 
@jdavies-st 
