### PR TITLE
Save results from each association product as produced

### DIFF
--- a/jwst/pipeline/calwebb_spec2.cfg
+++ b/jwst/pipeline/calwebb_spec2.cfg
@@ -1,7 +1,6 @@
 name = "Spec2Pipeline"
 class = "jwst.pipeline.Spec2Pipeline"
 save_bsub = False
-output_use_model = True
 save_results = True
 
     [steps]

--- a/jwst/pipeline/calwebb_spec2.py
+++ b/jwst/pipeline/calwebb_spec2.py
@@ -72,14 +72,8 @@ class Spec2Pipeline(Pipeline):
         # Retrieve the input(s)
         asn = LoadAsLevel2Asn.load(input)
 
-        # Setup output creation
-        make_output_path = self.search_attr(
-            'make_output_path', parent_first=True
-        )
-
         # Each exposure is a product in the association.
         # Process each exposure.
-        results = []
         for product in asn['products']:
             self.log.info('Processing product {}'.format(product['name']))
             self.output_basename = product['name']
@@ -88,22 +82,15 @@ class Spec2Pipeline(Pipeline):
                 asn['asn_pool'],
                 asn.filename
             )
-            results.append(result)
 
-            # Setup filename
+            # Save result
             suffix = 'cal'
             if isinstance(input, datamodels.CubeModel):
                 suffix = 'calints'
-            result.meta.filename = make_output_path(
-                self,
-                result,
-                suffix=suffix,
-                ignore_use_model=True
-            )
+            self.save_model(result, suffix)
 
         # We're done
         self.log.info('Ending calwebb_spec2')
-        return results
 
     # Process each exposure
     def process_exposure_product(

--- a/jwst/pipeline/tests/data/calwebb_spec2_basic.cfg
+++ b/jwst/pipeline/tests/data/calwebb_spec2_basic.cfg
@@ -1,7 +1,6 @@
 name = "Spec2Pipeline"
 class = "jwst.pipeline.Spec2Pipeline"
 save_bsub = False
-output_use_model = True
 
     [steps]
       [[assign_wcs]]


### PR DESCRIPTION
Previously, the pipeline retained results from each product in an
association, saving all only at the end of processing. This was both
memory-inefficient and, if the process crashed, would cause loss of
results.