### PR TITLE
Fix bugs in resample_spec

### DIFF
--- a/jwst/pipeline/calwebb_image2.py
+++ b/jwst/pipeline/calwebb_image2.py
@@ -17,20 +17,19 @@ __version__ = "3.0"
 
 class Image2Pipeline(Pipeline):
     """
-
-    CalWebbImage2: Processes JWST imaging-mode slope images from
-                   Level-2a to Level-2b.
+    Image2Pipeline: Processes JWST imaging-mode slope data from Level-2a to
+    Level-2b.
 
     Included steps are:
     assign_wcs, flat_field, and photom.
-
     """
 
     # Define alias to steps
-    step_defs = {'assign_wcs': assign_wcs_step.AssignWcsStep,
-                 'flat_field': flat_field_step.FlatFieldStep,
-                 'photom': photom_step.PhotomStep,
-                 }
+    step_defs = {
+        'assign_wcs': assign_wcs_step.AssignWcsStep,
+        'flat_field': flat_field_step.FlatFieldStep,
+        'photom': photom_step.PhotomStep,
+        }
 
     def process(self, input):
 

--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -71,6 +71,7 @@ class ResampleData(object):
 
         # Define output WCS based on all inputs, including a reference WCS
         self.output_wcs = resample_utils.make_output_wcs(self.input_models)
+        log.debug('Output mosaic size: {}'.format(self.output_wcs.data_size))
         self.blank_output = datamodels.DrizProductModel(self.output_wcs.data_size)
         self.blank_output.meta.wcs = self.output_wcs
 

--- a/jwst/resample/resample_spec.py
+++ b/jwst/resample/resample_spec.py
@@ -17,7 +17,6 @@ from astropy.modeling import fitting
 from gwcs import wcstools, WCS
 from gwcs.utils import _compute_lon_pole
 
-from ..stpipe import crds_client
 from .. import datamodels
 from ..assign_wcs import util
 from . import gwcs_drizzle

--- a/jwst/resample/resample_spec.py
+++ b/jwst/resample/resample_spec.py
@@ -100,7 +100,7 @@ class ResampleSpecData(object):
         ### TO DO:
         ###    replace this with a call to a generalized version of fitsblender
         ###
-        self.blank_output.update(self.input_models[0])
+        self.blank_output.update(datamodels.ImageModel(self.input_models[0]._instance))
         self.output_models = datamodels.ModelContainer()
 
 
@@ -222,13 +222,15 @@ class ResampleSpecData(object):
         roll_ref = input_model.meta.wcsinfo.roll_ref
         min_lam = np.nanmin(lam)
         offset = Shift(-slit_center_pix) & Shift(-slit_center_pix)
+
         # TODO: double-check the signs on the following rotation angles
         rot = Rotation2D(roll_ref + slit_rot_angle)
-        scale = Scale(spatial_scale) & Scale(spatial_scale)
+        scale = Scale(spatial_scale.value) & Scale(spatial_scale.value)
         tan = Pix2Sky_TAN()
         lon_pole = _compute_lon_pole(slit_center_sky, tan)
-        skyrot = RotateNative2Celestial(slit_center_sky.ra, slit_center_sky.dec,
-            lon_pole)
+        skyrot = RotateNative2Celestial(slit_center_sky.ra.value, slit_center_sky.dec.value,
+            lon_pole.value)
+
         spatial_trans = offset | rot | scale | tan | skyrot
         spectral_trans = Scale(spectral_scale) | Shift(min_lam)
         mapping = Mapping((1, 1, 0))

--- a/jwst/resample/resample_utils.py
+++ b/jwst/resample/resample_utils.py
@@ -1,7 +1,6 @@
 from __future__ import (division, print_function, unicode_literals,
     absolute_import)
 
-import logging
 import numpy as np
 import numpy.ma as ma
 from scipy import interpolate
@@ -16,14 +15,9 @@ from gwcs import WCS, utils, wcstools
 
 from .. import assign_wcs
 
+import logging
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
-
-
-DEFAULT_DOMAIN = {'lower': None,
-                  'upper': None,
-                  'includes_lower': True,
-                  'includes_upper': False}
 
 
 def make_output_wcs(input_models):


### PR DESCRIPTION
- take out units in `astropy.modeling.models` instances
- compensate for `SourceModelContainer` replacing `ModelContainer`. I.e. when iterating through `SourceModelContainer`, one does not get datamodel instances, instead one gets nodes.
