### PR TITLE
Nirspec wavelength zero-point correction

### DIFF
--- a/docs/jwst/extract_2d/main.rst
+++ b/docs/jwst/extract_2d/main.rst
@@ -6,12 +6,13 @@ Overview
 --------
 The ``extract_2d`` step extracts 2D arrays from spectral images. The extractions
 are performed within all of the SCI, ERR, and DQ arrays of the input image
-model. The extracted SCI, ERR, and DQ arrays are stored as one or more ``slit``
-objects in an output MultiSlitModel.
+model. It also computes an array of wavelengths. The SCI, ERR, DQ and WAVELENGTH
+arrays are stored as one or more ``slit`` objects in an output MultiSlitModel
+and saved as separate extensions in the output FITS file.
 
 Assumptions
 -----------
-This step uses the ``domain`` attribute of the WCS stored in the data model,
+This step uses the ``bounding_box`` attribute of the WCS stored in the data model,
 which is populated by the ``assign_wcs`` step. Hence the ``assign_wcs`` step
 must be applied to the science exposure before running this step.
 
@@ -32,7 +33,7 @@ To find out what slits are available for extraction:
 
 
 The corner locations of the regions to be extracted are determined from the
-``domain`` contained in the exposure's WCS, which defines the range of valid inputs
+``bounding_box`` contained in the exposure's WCS, which defines the range of valid inputs
 along each axis. The input coordinates are in the image frame, i.e. subarray shifts
 are accounted for.
 
@@ -50,6 +51,13 @@ The extract_2d step has one optional argument:
   instrument mode to be extracted. Currently only used for NIRspec fixed slit
   exposures.
 
+* ``--apply_wavecorr``: bool (default is True). Flag indicating whether to apply the
+   Nirspec wavelength zero-point correction.
+
 Reference Files
 ===============
-This step does not require any reference files.
+To apply the Nirspec wavelength zero-point correction, this step uses the
+WAVECORR reference file. The zero-point correction is applied to observations
+with EXP_TYPE of "NRS_FIXEDSLT", "NRS_BRIGHTOBJ" or "NRS_MSASPEC". This is an optional
+correction (on by default). It can be turned off by specifying ``apply_wavecorr=False``
+when running the step.

--- a/docs/jwst/ref_file_doc_DMS_653/assign_wcs.rst
+++ b/docs/jwst/ref_file_doc_DMS_653/assign_wcs.rst
@@ -2,9 +2,9 @@
 Assign_wcs
 ==========
 
-For each observing mode, assign_wcs collects all reference files and creates a pipeline of transforms which
-may include intermediate coordinate frames and the corresponding transformations
-between them. 
+assign_wcs creates and assigns a WCS object to observations. The WCS object is a pipeline of transforms
+from detector to world coordinates. It may include intermediate coordinate frames and the
+corresponding transformations between them. The transforms are stored in reference files in CRDS.
 
 .. toctree::
    :maxdepth: 4

--- a/docs/jwst/ref_file_doc_DMS_653/extract_2d.rst
+++ b/docs/jwst/ref_file_doc_DMS_653/extract_2d.rst
@@ -1,0 +1,18 @@
+===========
+Extract_2d
+===========
+
+
+The extract_2d step extracts a 2-D cutout for each spectrum in an exposure.
+It is saved as a "SCI" extension. It also computes and saves the wavelengths
+in a separate extension with EXTNAME "WAVELENGTH". It works on Nirspec MSA and
+fixed slits, as well as on NIRISS and NIRCAM slitless observations. Point source
+Nirspec wavelengths are (optionally) corrected for 
+An optional wavelength zero-point correction is applied to Nirspec point source
+observations when the source is not centered in the slit. The data for the correction
+is saved in a WAVECORR reference file.
+
+.. toctree::
+   :maxdepth: 4
+
+   extract_2d_reference_files

--- a/docs/jwst/ref_file_doc_DMS_653/extract_2d_reference_files.rst
+++ b/docs/jwst/ref_file_doc_DMS_653/extract_2d_reference_files.rst
@@ -1,0 +1,39 @@
+Reference File Types
+--------------------
+
+The extract_2d step uses the following reference files:
+
+===================    ==========================================================   ============================
+reftype                                     description                              Instrument
+===================    ==========================================================   ============================
+**wavecorr**           NIRSPEC wavelength zero-point correction                      NIRSPEC
+===================    ==========================================================   ============================
+
+
+CRDS Selection Criteria For Each Reference File Type 
+----------------------------------------------------
+
+WAVECORR
+::::::::
+The WAVECORR reference file is selected based on EXP_TYPE of the science data.
+The reference file s relevant only for Nirspec observations with EXP_TYPE of
+NRS_FIXEDSLIT, NRS_MSASPEC, NRS_BRIGHTOBJ.
+
+
+Reference File Formats For Each Reference File Type 
+---------------------------------------------------
+
+WAVECORR
+::::::::
+The WAVECORR file contains reference data about the NIRSPEC wavelength zero-point correction.
+The reference data is described in the NIRSPEC Technical Note ESA-JWST–SCI-NRS-TN-2016-018.
+
+:apertures:
+   :aperture_name: Aperture name.
+    :variance: Estimated variance on the zero-point offset.
+    :width: Aperture width [SLIT] or pitch [MOS].
+    :zero_point_offset: Zero-point offset as a function of wavelength (in m)
+                        and source offset within the aperture (in units of fraction of the aperture width
+                        [SLIT] or pitch [MOS]).
+    
+

--- a/jwst/datamodels/__init__.py
+++ b/jwst/datamodels/__init__.py
@@ -137,7 +137,7 @@ __all__ = [
     'RSCDModel', 'SaturationModel', 'SpecModel',
     'StrayLightModel', 'SuperBiasModel', 'SpecwcsModel',
     'TrapDensityModel', 'TrapParsModel', 'TrapsFilledModel',
-    'WavelengthrangeModel']
+    'WavelengthrangeModel', 'WaveCorrModel']
 
 _all_models = __all__[1:]
 _local_dict = dict(locals())

--- a/jwst/datamodels/image.py
+++ b/jwst/datamodels/image.py
@@ -33,7 +33,7 @@ class ImageModel(model_base.DataModel):
     schema_url = "image.schema.yaml"
 
     def __init__(self, init=None, data=None, dq=None, err=None, relsens=None,
-                 relsens2d=None, zeroframe=None, area=None, **kwargs):
+                 relsens2d=None, zeroframe=None, area=None, wavelength=None, **kwargs):
         super(ImageModel, self).__init__(init=init, **kwargs)
 
         if data is not None:
@@ -57,6 +57,8 @@ class ImageModel(model_base.DataModel):
         if area is not None:
             self.area = area
 
+        if wavelength is not None:
+            self.wavelength = wavelength
         # Implicitly create arrays
         self.dq = self.dq
         self.err = self.err

--- a/jwst/datamodels/multislit.py
+++ b/jwst/datamodels/multislit.py
@@ -41,6 +41,7 @@ class MultiSlitModel(model_base.DataModel):
             self.slits[0].err = init.err
             self.slits[0].relsens = init.relsens
             self.slits[0].area = init.area
+            self.slits[0].wavelength = init.wavelength
             return
 
         super(MultiSlitModel, self).__init__(init=init, **kwargs)

--- a/jwst/datamodels/schemas/image.schema.yaml
+++ b/jwst/datamodels/schemas/image.schema.yaml
@@ -37,6 +37,12 @@ allOf:
       fits_hdu: RELSENS2D
       default: 1.0
       datatype: float32
+    wavelength:
+      title: wavelength array 
+      fits_hdu: WAVELENGTH
+      ndim: 2
+      default: 0.0
+      datatype: float32
 - type: object
   properties:
     pathloss_pointsource:

--- a/jwst/datamodels/schemas/wavecorr.schema.yaml
+++ b/jwst/datamodels/schemas/wavecorr.schema.yaml
@@ -1,0 +1,36 @@
+title: NirSpec WAVECORR (wavelength zero-point correction) reference file model
+definitions:
+  zero_point_correction:
+    - type: object
+      properties:
+        aperture_name:
+          type: string
+          enum: [S200A1, S200A2, S400A1, S1600A1, S200B1, MOS]
+        zero_point_offset:
+          $ref: http://stsci.edu/schemas/asdf/transform/transform-1.1.0
+          title: Zero-point offset
+          description: |
+            Zero-point offset (in units of detector pixel) as a function of wavelength (in m)
+            and source offset within the aperture (in units of fraction of the aperture width
+            [SLIT] or pitch [MOS])
+          datatype: float32
+        variance:
+          $ref: http://stsci.edu/schemas/asdf/core/ndarray-1.0.0
+          title: Variance of the zero-point offset
+          description: |
+            Estimated variance on the zero-point offset (in units of detector pixel)
+            as a function of wavelength (in m) and source position within the aperture
+            (in units of fraction of [MOS]
+          datatype: float32
+        width:
+          type: number
+          title: Aperture or pitch width [in m]
+allOf:
+- $ref: referencefile.schema.yaml
+- $ref: keyword_exptype.schema.yaml
+- type: object
+  properties:
+    apertures:
+      type: array
+      items:
+        $ref: "#definitions/zero_point_correction"

--- a/jwst/datamodels/wcs_ref_models.py
+++ b/jwst/datamodels/wcs_ref_models.py
@@ -13,7 +13,7 @@ __all__ = ['DistortionModel', 'DistortionMRSModel', 'SpecwcsModel', 'RegionsMode
            'WavelengthrangeModel', 'CameraModel', 'CollimatorModel', 'OTEModel',
            'FOREModel', "FPAModel", 'IFUPostModel', 'IFUFOREModel', 'IFUSlicerModel',
            'MSAModel', 'FilteroffsetModel', 'DisperserModel',
-           'NIRCAMGrismModel', 'NIRISSGrismModel']
+           'NIRCAMGrismModel', 'NIRISSGrismModel', 'WaveCorrModel']
 
 
 class _SimpleModel(ReferenceFileModel):
@@ -634,3 +634,31 @@ class FOREModel(_SimpleModel):
         super(FOREModel, self).validate()
         assert self.meta.instrument.filter in ["CLEAR", "F070LP", "F100LP", "F110W",
                                                "F140X", "F170LP", "F290LP"]
+
+
+class WaveCorrModel(ReferenceFileModel):
+
+    reftype = "wavecorr"
+    schema_url = "wavecorr.schema.yaml"
+
+    def __init__(self, init=None, apertures=None, **kwargs):
+        super(WaveCorrModel, self).__init__(init, **kwargs)
+        if apertures is not None:
+            self.apertures = apertures
+        if init is None:
+            self.populate_meta()
+
+    @property
+    def aperture_names(self):
+        return [getattr(ap, 'aperture_name') for ap in self.apertures]
+        
+    def populate_meta(self):
+        self.meta.instrument.name = "NIRSPEC"
+
+    def on_save(self, path=None):
+        self.meta.reftype = self.reftype
+
+    def validate(self):
+        super(WaveCorrModel, self).validate()
+        assert self.aperture_names is not None
+        assert self.apertures is not None

--- a/jwst/extract_2d/extract_2d.py
+++ b/jwst/extract_2d/extract_2d.py
@@ -27,14 +27,14 @@ def extract2d(input_model, which_subarray=None, apply_wavecorr=False, reffile=""
     exp_type = input_model.meta.exposure.type.upper()
     log.info('EXP_TYPE is {0}'.format(exp_type))
 
-    wavecorr_supportd_modes = ['NRS_FIXEDSLIT', 'NRS_MSASPEC', 'NRS_BRIGHTOBJ']
+    wavecorr_supported_modes = ['NRS_FIXEDSLIT', 'NRS_MSASPEC', 'NRS_BRIGHTOBJ']
     if exp_type in wavecorr_supported_modes:
-        if refftype and refftype.strip().upper() == 'N/A':
+        if reffile and reffile.strip().upper() == 'N/A':
             apply_wavecorr = False
             log.info("WAVECORR reference file missing - skipping correction")
     else:
         apply_wavecorr = False
-        log.info("Skipping wavecorr correction for EXP_TYPE {0}".format(exp_type)
+        log.info("Skipping wavecorr correction for EXP_TYPE {0}".format(exp_type))
 
     if exp_type not in supported_modes:
         input_model.meta.cal_step.extract_2d = 'SKIPPED'

--- a/jwst/extract_2d/extract_2d.py
+++ b/jwst/extract_2d/extract_2d.py
@@ -9,8 +9,10 @@ import numpy as np
 from astropy.io import fits
 from astropy.modeling.models import Shift
 from gwcs.utils import _toindex
+from gwcs import wcstools
 
 from .. import datamodels
+from ..transforms import models as trmodels
 from asdf import AsdfFile
 from ..assign_wcs import nirspec
 
@@ -19,10 +21,20 @@ log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
 
-def extract2d(input_model, which_subarray=None):
+def extract2d(input_model, which_subarray=None, apply_wavecorr=False, reffile=""):
     supported_modes = ['NRS_FIXEDSLIT', 'NRS_MSASPEC', 'NRS_BRIGHTOBJ', 'NRS_LAMP']
+    
     exp_type = input_model.meta.exposure.type.upper()
     log.info('EXP_TYPE is {0}'.format(exp_type))
+
+    wavecorr_supportd_modes = ['NRS_FIXEDSLIT', 'NRS_MSASPEC', 'NRS_BRIGHTOBJ']
+    if exp_type in wavecorr_supported_modes:
+        if refftype and refftype.strip().upper() == 'N/A':
+            apply_wavecorr = False
+            log.info("WAVECORR reference file missing - skipping correction")
+    else:
+        apply_wavecorr = False
+        log.info("Skipping wavecorr correction for EXP_TYPE {0}".format(exp_type)
 
     if exp_type not in supported_modes:
         input_model.meta.cal_step.extract_2d = 'SKIPPED'
@@ -39,7 +51,8 @@ def extract2d(input_model, which_subarray=None):
         if which_subarray is not None:
             open_slits = [sub for sub in open_slits if sub.name==which_subarray]
         log.debug('open slits {0}'.format(open_slits))
-
+        if apply_wavecorr and exp_type in ['NRS_FIXEDSLIT', 'NRS_BRIGHTOBJ']:
+            msa_model = get_msa_model(input_model)
         for slit in open_slits:
             slit_wcs = nirspec.nrs_wcs_set_input(input_model, slit.name)
             xlo, xhi = _toindex(slit_wcs.bounding_box[0])
@@ -57,11 +70,33 @@ def extract2d(input_model, which_subarray=None):
             ext_data = input_model.data[ylo: yhi + 1, xlo: xhi + 1].copy()
             ext_err = input_model.err[ylo: yhi + 1, xlo: xhi + 1].copy()
             ext_dq = input_model.dq[ylo: yhi + 1, xlo: xhi + 1].copy()
-            new_model = datamodels.ImageModel(data=ext_data, err=ext_err, dq=ext_dq)
+
             shape = ext_data.shape
             bounding_box= ((0, shape[1] - 1), (0, shape[0] - 1))
             slit_wcs.bounding_box = bounding_box
+
+            # compute wavelengths
+            x, y = wcstools.grid_from_bounding_box(slit_wcs.bounding_box, step=(1, 1))
+            ra, dec, lam = slit_wcs(x, y)
+            if apply_wavecorr and _is_point_source(slit, exp_type, input_model.meta.target.source_type):
+                if exp_type in ['NRS_FIXEDSLIT', 'NRS_BRIGHTOBJ']:
+                    # pass lam = 2microns
+                    source_xpos = get_source_xpos(input_model, slit, slit_wcs, lam=2, msa_model=msa_model)
+                    aperture_name = slit.name
+                else:
+                    source_xpos = slit.source_xpos
+                    # For the MSA the aperture name is "MOS"
+                    aperture_name = "MOS"
+                corr, dq_lam = compute_zero_point_correction(lam, reffile, source_xpos, aperture_name, slit_wcs)
+                ## TODO: set a DQ flag to a TBD value for pixels where dq_lam == 0.
+                ## The only purpose of dq_lam is to set that flag.
+                lam = lam - corr
+                log.info("Slit {0}: Wavelength zero-point correction applied.".format(slit.name))
+            else:
+                log.info("Slit {0}: Wavelength zero-point correction was not applied.".format(slit.name))
+            new_model = datamodels.ImageModel(data=ext_data, err=ext_err, dq=ext_dq, wavelength=lam)
             new_model.meta.wcs = slit_wcs
+
             output_model.slits.append(new_model)
             # set x/ystart values relative to the image (screen) frame.
             # The overall subarray offset is recorded in model.meta.subarray.
@@ -96,3 +131,174 @@ def extract2d(input_model, which_subarray=None):
 # upper_lam = wrange[-1][fselect2][1]
 # input_model.meta.wcsinfo.waverange_start = lower_lam
 # input_model.meta.wcsinfo.waverange_end = upper_lam
+
+
+
+def compute_zero_point_correction(lam, freference, source_xpos, aperture_name, slit_wcs):
+    """
+    Compute the Nirspec wavelength zero-point correction.
+    
+    Parameters
+    ----------
+    lam : nd-array like
+        Wavelength array
+    freference : str
+        WAVECORR reference file name.
+    source_xpos : float
+        X position of the source as a fraction of the slit size.
+    aperture_name : str
+        Aperture name.
+    slit_wcs : `~gwcs.wcs.WCS`
+        The WCS object for this slit.
+
+    Returns
+    -------
+    lambda_corr : ndarray like
+        Wavelength correction.
+    lam : ndarray like
+        Interpolated wavelengths. Extrapolated values are reset to 0.
+        This is returned so that the DQ array can be updated with a flag
+        which indicates that no zero-point correction was done.
+    """
+    with datamodels.WaveCorrModel(freference) as wavecorr:
+        for ap in wavecorr.apertures:
+            if ap.aperture_name == aperture_name:
+                log.info("Using wavelength zero-point correction for aperture {0}".format(ap.aperture_name))
+                offset_model = ap.zero_point_offset.copy()
+                variance = ap.variance.copy()
+                width = ap.width
+                break
+        else:
+            log.info("No wavelength zero-point correction found for slit {0}".format(aperture_name))
+        
+    dispersion = compute_dispersion(slit_wcs)
+    deltax = source_xpos * width
+    lam = lam.copy()
+    l = lam[~np.isnan(lam)]
+    offset_model.bounds_error = False
+    correction = offset_model(l * 10 ** -6, [deltax]*l.size)
+    lam[~np.isnan(lam)] = correction
+    # The correction for pixels outside the slit and wavelengths
+    # outside the wave_range is 0.
+    lam[np.isnan(lam)] = 0.
+    lambda_cor = dispersion * lam
+    return lambda_cor, lam
+
+
+def compute_dispersion(wcs):
+    """
+    Compute the pixel dispersion.
+
+    Parameters
+    ----------
+    wcs : `~gwcs.wcs.WCS`
+        The WCS object for this slit.
+
+    Returns
+    -------
+    dispersion : ndarray-like
+        The pixel dispersion [in m].
+
+    """
+    xpix, ypix = wcstools.grid_from_bounding_box(wcs.bounding_box, step=(1,1))
+    xleft = xpix - 0.5
+    xright = xpix + 0.5
+    _, _, lamright = wcs(xright, ypix)
+    _, _, lamleft = wcs(xleft, ypix)
+    return (lamright - lamleft) * 10 ** -6
+
+
+def _is_point_source(slit, exp_type, user_type):
+    result = False
+    if exp_type == 'NRS_MSASPEC':
+        if slit.stellarity > 0.75:
+            result = True
+            log.info("Detected a point source in slit {0}, stelarity is {1}".format(slit.name, slit.stellarity))
+        else:
+            result = False
+            log.info("Detected an extended source in slit {0}, stelarity is {1}".format(slit.name, slit.stellarity))
+    else:
+        # Get the value the user specified (if any)
+        if (user_type is not None) and (user_type in ['POINT', 'EXTENDED']):
+            # Use the value supplied by the user
+            log.info('Detected a {0} source type in slit {1}'.format(user_type, slit.name))
+            if user_type.strip().upper() == 'POINT':
+                result = True
+            else:
+                result = False
+        else:
+            log.info("Unknown source type")
+
+    return result
+
+    
+def get_source_xpos(input_model, slit, slit_wcs, lam, msa_model):
+    """
+    Compute the source position within the slit for a NIRSPEC FS.
+
+    Parameters
+    ----------
+    input_model : `~jwst/datamodels/model_base.DataModel`
+        The input to ``extract_2d``.
+    slit : `~jwst/transforms/models/Slit`
+        The slit tuple.
+    slit_wcs : `~gwcs.wcs.WCS`
+        The WCS object for this slit.
+    lam : float
+        Wavelength in microns.
+
+    Returns
+    -------
+    xpos : float
+        X coordinate of the source as a fraction of the slit size.
+    """
+    xoffset = input_model.meta.dither.xoffset # in arcsec
+    yoffset = input_model.meta.dither.yoffset # in arcsec
+    v2ref = input_model.meta.wcsinfo.v2_ref # in arcsec
+    v3ref = input_model.meta.wcsinfo.v3_ref # in arcsec
+    v3idlyangle = input_model.meta.wcsinfo.v3yangle # in deg
+    vparity = input_model.meta.wcsinfo.vparity
+    
+    idl2v23 = trmodels.IdealToV2V3(v3idlyangle, v2ref, v3ref, vparity)
+    # Compute the location in V2,V3 [in arcsec]
+    xv, yv = idl2v23(xoffset, yoffset)
+    # The NIRSPEC transforms expect V2,V3 positions in deg
+    xv = xv / 3600.
+    yv = yv / 3600.
+    
+    v2v3_to_msa_frame = slit_wcs.get_transform("v2v3", "msa_frame")
+    xpos_abs, ypos_abs, lam = v2v3_to_msa_frame(xv, yv, lam)
+    xpos_frac = absolute2fractional(msa_model, slit, xpos_abs, ypos_abs)
+    return xpos_frac
+
+
+def get_msa_model(input_model):
+    # Get the reference file used in constructing the WCS.
+    msa_ref = input_model.meta.ref_file.msa.name
+    from .. import assign_wcs
+    from .. datamodels import MSAModel
+    step = assign_wcs.AssignWcsStep()
+    msa = MSAModel(step.reference_uri_to_cache_path(msa_ref))
+    return msa
+
+
+def absolute2fractional(msa_model, slit, xposabs, yposabs):
+    """
+    Compute the fractional position in ``x`` within the slit in MSA coordinates. 
+
+    Parameters
+    ----------
+    input_model : `~jwst/datamodels/model_base.DataModel`
+        The input to ``extract_2d``.
+    slit : `~jwst/transforms/models/Slit`
+        The slit tuple.
+    xposabs, yposabs : float
+        (x, y) positions in the ``msa_frame``.
+
+    Returns
+    -------
+    xpos : float
+        The fractional X coordinates within the slit.
+    """
+    num, xcenter, ycenter, xsize, ysize = msa_model.Q5.data[slit.shutter_id]
+    return (xposabs - xcenter) / (xsize/ 2.)

--- a/jwst/extract_2d/extract_2d_step.py
+++ b/jwst/extract_2d/extract_2d_step.py
@@ -4,6 +4,7 @@ from ..stpipe import Step
 from .. import datamodels
 from . import extract_2d
 
+
 class Extract2dStep(Step):
     """
     This Step performs a 2D extraction of spectra.
@@ -11,14 +12,18 @@ class Extract2dStep(Step):
 
     spec = """
         which_subarray = string(default = None)
+        apply_wavecorr = boolean(default=True)
     """
 
-    def process(self, input_file):
+    reference_file_types = ['wavecorr']
+    
 
-        with datamodels.open(input_file) as dm:
-
-            output_model = extract_2d.extract2d(dm, self.which_subarray)
-
+    def process(self, input_model):
+        reffile = self.get_reference_file(input_model, "wavecorr")
+        with datamodels.open(input_model) as dm:
+            output_model = extract_2d.extract2d(dm, self.which_subarray,
+                                                self.apply_wavecorr, reffile=reffile)
+            
         return output_model
 
 


### PR DESCRIPTION
First cut at nirspec zero-point correction. As agreed on it is part of the extract_2d step. `ImageModel` and its schema were modified to include a `wavelength` array. This will eventually be changed after #1070 and #1031 or variants of these are merged.

Currently this only works on MSA data. Still need to 

[x ] add code for fixed slit  
[x ] make sure this runs only on point source
[ ] deliver reference files
[x ] docs