### PR TITLE
Fix assign_wcs test_nirspec_imaging

### DIFF
--- a/jwst/assign_wcs/nirspec.py
+++ b/jwst/assign_wcs/nirspec.py
@@ -72,7 +72,7 @@ def imaging(input_model, reference_files):
     dircos2unitless = DirCos2Unitless(name='directional_cosines2unitless')
 
     col_model = CollimatorModel(reference_files['collimator'])
-    col = col.model
+    col = col_model.model
     col_model.close()
 
     # Get the default spectral order and wavelength range and record them in the model.

--- a/jwst/assign_wcs/tests/test_nirspec.py
+++ b/jwst/assign_wcs/tests/test_nirspec.py
@@ -57,7 +57,7 @@ def create_hdul():
     phdu.header['instrume'] = 'NIRSPEC'
     phdu.header['detector'] = 'NRS1'
     phdu.header['time-obs'] = '8:59:37'
-    phdu.header['date-obs'] = '2014-09-05'
+    phdu.header['date-obs'] = '2016-09-05'
 
     for item in wcs_kw.items():
         phdu.header[item[0]] = item[1]


### PR DESCRIPTION
Fixes a small bug in `assign_wcs/nirspec.py` and updates `DATE-OBS` in the generated data so that the tests use the latest CV3 NIRSpec reffiles.