### PR TITLE
Updates to level 2 pipelines an use of output_file

### DIFF
--- a/docs/jwst/associations/index.rst
+++ b/docs/jwst/associations/index.rst
@@ -1,3 +1,5 @@
+.. _associations:
+
 =============
 Associations
 =============

--- a/docs/jwst/introduction.rst
+++ b/docs/jwst/introduction.rst
@@ -200,6 +200,14 @@ the entire pipeline using the `--output_file` argument also
     $ strun calwebb_sloper.cfg jw00017001001_01101_00001_nrca1_uncal.fits
         --output_file='sloper_processed.fits'
 
+Output File and Associations
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The Level 2 pipelines can take both individual file or an
+:ref:`association <associations>` as input. When given an association, `output_file` is
+ignored, in favor of using the product names defined in the
+associations. Level 3 pipelines always require an association, hence
+`output_file` is never used for them.
 
 Output Directory
 ----------------

--- a/jwst/associations/lib/rules_level2_base.py
+++ b/jwst/associations/lib/rules_level2_base.py
@@ -219,7 +219,7 @@ class DMSLevel2bBase(DMSBaseMixin, Association):
         self.update_asn()
 
     def _add_items(self, items, meta=None, product_name_func=None, **kwargs):
-        """ Force adding items to the association
+        """Force adding items to the association
 
         Parameters
         ----------
@@ -247,10 +247,18 @@ class DMSLevel2bBase(DMSBaseMixin, Association):
         This is a low-level shortcut into adding members, such as file names,
         to an association. All defined shortcuts and other initializations are
         by-passed, resulting in a potentially unusable association.
+
+        `product_name_func` is used if the product name has not been
+        determined by any other means. The call signature is:
+
+            product_name_func(item, idx)
+
+        where `item` is each item being added and `idx` is the count of items.
+
         """
         if meta is None:
             meta = {}
-        for item in items:
+        for idx, item in enumerate(items, start=1):
             self.new_product()
             members = self.current_product['members']
             entry = {
@@ -265,7 +273,7 @@ class DMSLevel2bBase(DMSBaseMixin, Association):
             # the function, if given
             if self.current_product['name'] == PRODUCT_NAME_DEFAULT and \
                product_name_func is not None:
-                self.current_product['name'] = product_name_func(item)
+                self.current_product['name'] = product_name_func(item, idx)
 
         self.data.update(meta)
         self.sequence = next(self._sequence)

--- a/jwst/associations/lib/rules_level2_base.py
+++ b/jwst/associations/lib/rules_level2_base.py
@@ -248,8 +248,8 @@ class DMSLevel2bBase(DMSBaseMixin, Association):
         to an association. All defined shortcuts and other initializations are
         by-passed, resulting in a potentially unusable association.
 
-        `product_name_func` is used if the product name has not been
-        determined by any other means. The call signature is:
+        `product_name_func` is used to define the product names instead of
+        the default methods. The call signature is:
 
             product_name_func(item, idx)
 
@@ -269,11 +269,16 @@ class DMSLevel2bBase(DMSBaseMixin, Association):
             self.update_validity(entry)
             self.update_asn()
 
-            # If product name is still undefined, try
-            # the function, if given
-            if self.current_product['name'] == PRODUCT_NAME_DEFAULT and \
-               product_name_func is not None:
-                self.current_product['name'] = product_name_func(item, idx)
+            # If a product name function is given, attempt
+            # to use.
+            if product_name_func is not None:
+                try:
+                    self.current_product['name'] = product_name_func(item, idx)
+                except Exception:
+                    logger.debug(
+                        'Attempted use of product_name_func failed.'
+                        ' Default product name used.'
+                    )
 
         self.data.update(meta)
         self.sequence = next(self._sequence)

--- a/jwst/associations/load_as_asn.py
+++ b/jwst/associations/load_as_asn.py
@@ -140,7 +140,7 @@ class LoadAsLevel2Asn(LoadAsAssociation):
         return asn
 
     @staticmethod
-    def model_product_name(model):
+    def model_product_name(model, *args, **kwargs):
         """Product a model product name based on the model.
 
         Parameters

--- a/jwst/associations/load_as_asn.py
+++ b/jwst/associations/load_as_asn.py
@@ -1,6 +1,7 @@
 """Treat various objects as Associations"""
 
-from os.path import splitext
+from functools import partial
+from os import path as os_path
 
 from ..associations import (
     Association,
@@ -106,13 +107,16 @@ class LoadAsLevel2Asn(LoadAsAssociation):
     """
 
     @classmethod
-    def load(cls, obj):
+    def load(cls, obj, basename=None):
         """ Open object and return a Level2 association of it
 
         Parameters
         ----------
         obj: Association, str, Datamodel, [str[,...]], [Datamodel[,...]]
             The obj to return as an association
+
+        basename: str
+            If specified, use as the basename, with an index appended.
 
         Attributes
         ----------
@@ -128,6 +132,10 @@ class LoadAsLevel2Asn(LoadAsAssociation):
         association: DMSLevel2bBase
             An association created using given obj
         """
+        product_name_func = cls.model_product_name
+        if basename is not None:
+            product_name_func = partial(cls.name_with_index, basename)
+
         asn = super(LoadAsLevel2Asn, cls).load(
             obj,
             registry=AssociationRegistry(
@@ -135,7 +143,7 @@ class LoadAsLevel2Asn(LoadAsAssociation):
                 include_default=False
             ),
             rule=DMSLevel2bBase,
-            product_name_func=cls.model_product_name
+            product_name_func=product_name_func
         )
         return asn
 
@@ -147,6 +155,40 @@ class LoadAsLevel2Asn(LoadAsAssociation):
         ----------
         model: DataModel
             The model to get the name from
+
+        Returns
+        -------
+        product_name: str
+            The basename of filename from the model
         """
-        product_name, ext = splitext(model.meta.filename)
+        product_name, ext = os_path.splitext(model.meta.filename)
         return product_name
+
+    @staticmethod
+    def name_with_index(basename, obj, idx, *args, **kwargs):
+        """Produce a name with the basename and index appended
+
+        Parameters
+        ----------
+        basename: str
+            The base of the file name
+
+        obj: object
+            The object being added to the association _(unused)_
+
+        idx: int
+            The current index of the added item.
+
+        Returns
+        -------
+        product_name: str
+            The concatentation of basename, '_', idx
+
+        Notes
+        -----
+        If the index is less than or equal to 1, no appending is done.
+        """
+        basename, extension = os_path.splitext(os_path.basename(basename))
+        if idx > 1:
+            basename = basename + '_' + str(idx)
+        return basename

--- a/jwst/pipeline/calwebb_image2.py
+++ b/jwst/pipeline/calwebb_image2.py
@@ -36,7 +36,6 @@ class Image2Pipeline(Pipeline):
         self.log.info('Starting calwebb_image2 ...')
 
         # Retrieve the input(s)
-        self.log.debug('output_file="{}" type="{}"'.format(self.output_file, type(self.output_file)))
         asn = LoadAsLevel2Asn.load(input, basename=self.output_file)
 
         # Each exposure is a product in the association.

--- a/jwst/pipeline/calwebb_image2.py
+++ b/jwst/pipeline/calwebb_image2.py
@@ -36,19 +36,8 @@ class Image2Pipeline(Pipeline):
         self.log.info('Starting calwebb_image2 ...')
 
         # Retrieve the input(s)
-        asn = LoadAsLevel2Asn.load(input)
-
-        # If `output_file` is specified and there is only
-        # one product, go ahead an apply
-        if self.output_file:
-            if len(asn['products']) > 1:
-                self.log.warn(
-                    '"output_file" specified, but more than one product'
-                    'will be created. Ignoring.'
-                    '\nConsider using "output_dir" instead'
-                )
-            else:
-                asn['products'][0]['name'] = self.output_file
+        self.log.debug('output_file="{}" type="{}"'.format(self.output_file, type(self.output_file)))
+        asn = LoadAsLevel2Asn.load(input, basename=self.output_file)
 
         # Each exposure is a product in the association.
         # Process each exposure.

--- a/jwst/pipeline/calwebb_spec2.py
+++ b/jwst/pipeline/calwebb_spec2.py
@@ -70,7 +70,7 @@ class Spec2Pipeline(Pipeline):
         self.log.info('Starting calwebb_spec2 ...')
 
         # Retrieve the input(s)
-        asn = LoadAsLevel2Asn.load(input)
+        asn = LoadAsLevel2Asn.load(input, basename=self.output_file)
 
         # Each exposure is a product in the association.
         # Process each exposure.

--- a/jwst/pipeline/tests/test_calwebb_image2.py
+++ b/jwst/pipeline/tests/test_calwebb_image2.py
@@ -105,27 +105,3 @@ def test_file_outputdir(mk_tmp_dirs):
     result_name, result_ext = path.splitext(outfile)
     result_path = path.join(tmp_data_path, result_name + '_cal.fits')
     assert path.isfile(result_path)
-
-
-@require_bigdata
-def test_file_output_fail(caplog, mk_tmp_dirs):
-    """Test for fail if output_file is specified with multiple products"""
-    exppath = path.join(DATAPATH, EXPFILE)
-    lv2_meta = {
-        'program': 'test',
-        'target': 'test',
-        'asn_pool': 'test',
-    }
-    asn = asn_from_list([exppath, exppath], rule=DMSLevel2bBase, meta=lv2_meta)
-    asn_file, serialized = asn.dump()
-    with open(asn_file, 'w') as fp:
-        fp.write(serialized)
-
-    args = [
-        path.join(SCRIPT_DATA_PATH, 'calwebb_image2_save.cfg'),
-        asn_file,
-        '--output_file=junk'
-    ]
-    Step.from_cmdline(args)
-
-    assert '"output_file" specified, but more than one product' in caplog.text


### PR DESCRIPTION
Re-enabled use of `output_file` when specifying individual files to the Level 2 pipelines.