### PR TITLE
Create WCS objects for the 1-D extracted spectra.

### DIFF
--- a/jwst/extract_1d/ifu.py
+++ b/jwst/extract_1d/ifu.py
@@ -10,6 +10,7 @@ from photutils import CircularAperture, CircularAnnulus, \
 
 from .. import datamodels
 from .. datamodels import dqflags
+from . import spec_wcs
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
@@ -54,8 +55,8 @@ def ifu_extract1d(input_model, refname, source_type):
     extract_params = ifu_extract_parameters(refname, slitname, source_type)
 
     if extract_params:
-        (wavelength, net, background, dq) = extract_ifu(input_model,
-                                source_type, extract_params)
+        (ra, dec, wavelength, net, background, dq) = extract_ifu(
+                        input_model, source_type, extract_params)
     else:
         log.critical('Missing extraction parameters.')
         raise ValueError('Missing extraction parameters.')
@@ -95,7 +96,11 @@ def ifu_extract1d(input_model, refname, source_type):
                          net, nerror, background, berror)),
                     dtype=spec.spec_table.dtype)
     spec = datamodels.SpecModel(spec_table=otab)
+    spec.meta.wcs = spec_wcs.create_spectral_wcs(ra, dec, wavelength)
     output_model.spec.append(spec)
+
+    # See output_model.spec[0].meta.wcs instead.
+    output_model.meta.wcs = None
 
     return output_model
 
@@ -146,7 +151,7 @@ def extract_ifu(input_model, source_type, extract_params):
 
     Returns
     -------
-        (wavelength, net, background, dq)
+        (ra, dec, wavelength, net, background, dq)
     """
 
     data = input_model.data
@@ -248,9 +253,10 @@ def extract_ifu(input_model, source_type, extract_params):
             log.error("Background region extends outside the image.")
 
     if outside:
+        (ra, dec) = (0., 0.)
         wavelength = np.zeros(shape[0], dtype=np.float64)
         dq[:] = dqflags.pixel['DO_NOT_USE']
-        return (wavelength, net, background, dq)        # all bad
+        return (ra, dec, wavelength, net, background, dq)       # all bad
 
     if hasattr(input_model.meta, 'wcs'):
         wcs = input_model.meta.wcs
@@ -264,8 +270,12 @@ def extract_ifu(input_model, source_type, extract_params):
         y_array = np.empty(shape[0], dtype=np.float64)
         y_array.fill(float(shape[1]) / 2.)
         z_array = np.arange(shape[0], dtype=np.float64) # for wavelengths
-        _, _, wavelength = wcs(x_array, y_array, z_array)
+        ra, dec, wavelength = wcs(x_array, y_array, z_array)
+        nelem = len(wavelength)
+        ra = ra[nelem // 2]
+        dec = dec[nelem // 2]
     else:
+        (ra, dec) = (0., 0.)
         wavelength = np.arange(1, shape[0] + 1, dtype=np.float64)
 
     position = (x_center, y_center)
@@ -289,4 +299,4 @@ def extract_ifu(input_model, source_type, extract_params):
             background[k] = float(bkg_table['aperture_sum'][0])
             net[k] = net[k] - background[k] * normalization
 
-    return (wavelength, net, background, dq)
+    return (ra, dec, wavelength, net, background, dq)

--- a/jwst/extract_1d/spec_wcs.py
+++ b/jwst/extract_1d/spec_wcs.py
@@ -1,0 +1,56 @@
+from __future__ import (absolute_import, unicode_literals, division,
+                        print_function)
+
+import numpy as np
+
+from astropy.modeling.models import Mapping, Const1D, Tabular1D
+from astropy import units as u
+from astropy import coordinates as coord
+
+from gwcs.wcs import WCS
+from gwcs import coordinate_frames as cf
+
+
+def create_spectral_wcs(ra, dec, wavelength):
+    """Assign a WCS for sky coordinates and a table of wavelengths
+
+    Parameters
+    ----------
+    ra: float
+        The right ascension (in degrees) at the nominal location of the
+        entrance aperture (slit).
+
+    dec: float
+        The declination (in degrees) at the nominal location of the
+        entrance aperture.
+
+    wavelength: ndarray
+        The wavelength in microns at each pixel of the extracted spectrum.
+
+    Returns:
+    --------
+    wcs: a gwcs.wcs.WCS object
+        This takes a float or sequence of float and returns a tuple of
+        the right ascension, declination, and wavelength (or sequence of
+        wavelengths) at the pixel(s) specified by the input argument.
+    """
+
+    # Only the first coordinate is used.
+    input_frame = cf.Frame2D(axes_order=(0, 1), unit=(u.pix, u.pix),
+                             name="pixel_frame")
+
+    sky = cf.CelestialFrame(name='sky', axes_order=(0, 1),
+                            reference_frame=coord.ICRS())
+    spec = cf.SpectralFrame(name='spectral', axes_order=(2,), unit=(u.micron,),
+                            axes_names=('wavelength',))
+
+    pixel = np.arange(len(wavelength), dtype=np.float)
+    tab = Mapping((0, 0, 0)) | \
+          Const1D(ra) & Const1D(dec) & Tabular1D(pixel, wavelength)
+
+    world = cf.CompositeFrame([sky, spec], name='world')
+
+    pipeline = [(input_frame, tab),
+                (world, None)]
+
+    return WCS(pipeline)


### PR DESCRIPTION
For each 1-D extracted spectrum, a WCS object is created that includes the right ascension and declination at the nominal center of the slit, plus the wavelength array that is also stored as a column in the output table.