### PR TITLE
tool to move WCS keywords from Primary to SCI extension

### DIFF
--- a/scripts/move_wcs.py
+++ b/scripts/move_wcs.py
@@ -47,7 +47,10 @@ def _collect_wcs_keywords(f):
 
     # Remove kw added by wcslib from the new header
     for kw in wcslib_kw_to_remove:
-        del new_hdr[kw]
+        try:
+            del new_hdr[kw]
+        except KeyError:
+            continue
 
     # Add STScI specific kw to new_hdr
     for kw in stsci_wcs_kw:

--- a/scripts/move_wcs.py
+++ b/scripts/move_wcs.py
@@ -22,6 +22,15 @@ def move_wcs(files):
         new_hdr = _collect_wcs_keywords(f)
         update_sci_extension(f, new_hdr)
         clean_primary_header(f, new_hdr)
+
+        # Remove ASDF extension if present:
+        for i, hdu in enumerate(f):
+            try:
+                if hdu.header['EXTNAME'] == 'ASDF':
+                    break
+            except KeyError:
+                continue
+        del f[i]
         f.close()
     
     

--- a/scripts/move_wcs.py
+++ b/scripts/move_wcs.py
@@ -24,13 +24,14 @@ def move_wcs(files, remove_asdf=False):
         clean_primary_header(f, new_hdr)
 
         # Remove ASDF extension if present:
-        for i, hdu in enumerate(f):
-            try:
-                if hdu.header['EXTNAME'] == 'ASDF':
-                    break
-            except KeyError:
-                continue
-        del f[i]
+        if remove_asdf:
+            for i, hdu in enumerate(f):
+                try:
+                    if hdu.header['EXTNAME'] == 'ASDF':
+                        break
+                except KeyError:
+                    continue
+            del f[i]
         f.close()
     
     

--- a/scripts/move_wcs.py
+++ b/scripts/move_wcs.py
@@ -11,7 +11,7 @@ stsci_wcs_kw = ['PA_V3', 'V2_REF', 'V3_REF', 'PA_APER', 'VPARITY',
 wcslib_kw_to_remove = ['LONPOLE', 'LATPOLE', 'MJD-OBS', 'DATE-OBS']
 
 
-def move_wcs(files):
+def move_wcs(files, remove_asdf=False):
     for name in files:
         print('Working on file {0}.'.format(name))
         f = fits.open(name, mode='update')

--- a/scripts/move_wcs.py
+++ b/scripts/move_wcs.py
@@ -1,0 +1,97 @@
+import glob
+from astropy.io import fits
+from astropy import wcs
+from astropy.wcs import InvalidTransformError
+import six
+
+"""
+More Kw to consider 
+radesys - I think it should be moved - "OTHER" in HST
+velocity aberrration related kw - move them
+  DVA_RA< DVA_DEC, VA_SCALE
+
+TARG_RA, TARG_DEC
+"""
+stsci_wcs_kw = ['PA_V3', 'V2_REF', 'V3_REF', 'PA_APER', 'VPARITY',
+                'RA_V1', 'DEC_V1', 'ROLL_REF', 'RA_REF', 'DEC_REF']
+
+wcslib_kw_to_remove = ['LONPOLE', 'LATPOLE', 'MJD-OBS', 'DATE-OBS']
+
+
+def move_wcs(files):
+    for name in files:
+        print('Working on file {0}.'.format(name))
+        f = fits.open(name, mode='update')
+        if f[0].header['telescop'] != 'JWST':
+            f.close()
+            continue
+
+        new_hdr = _collect_wcs_keywords(f)
+        update_sci_extension(f, new_hdr)
+        clean_primary_header(f, new_hdr)
+        f.close()
+    
+    
+def _collect_wcs_keywords(f):
+    # Convert the WCS to a header
+    try:
+        w = wcs.WCS(f[0].header)
+    except InvalidTransformError:
+        if f[0].header['cunit3'] and f[0].header['cunit3'] == 'micron':
+            f[0].header['cunit3'] = 'um'
+            w = wcs.WCS(f[0].header)
+    new_hdr = w.to_header()
+
+    # Remove kw added by wcslib from the new header
+    for kw in wcslib_kw_to_remove:
+        del new_hdr[kw]
+
+    # Add STScI specific kw to new_hdr
+    for kw in stsci_wcs_kw:
+        try:
+            new_hdr[kw] = f[0].header[kw]
+        except KeyError:
+            pass
+    return new_hdr
+        
+
+def clean_primary_header(f, new_hdr):
+    # f is a fits file opened in 'update' mode.
+    for kw in new_hdr:
+        try:
+            del f[0].header[kw]
+        except KeyError:
+            pass
+
+
+def update_sci_extension(f, new_hdr):
+    # Update the SCI extension header
+    f[('SCI', 1)].header.update(new_hdr)
+    for kw in new_hdr:
+        try:
+            f[('SCI', 1)].header.comments[kw] = f[0].header.comments[kw]
+        except KeyError:
+            pass
+
+
+
+
+if __name__ == '__main__':
+    import argparse
+    import os
+    import six
+    parser = argparse.ArgumentParser(description="Move WCS keywords from Primary to SCI extension.")
+    parser.add_argument('files', help='A list of FITS filenames or a path to a directory with FITS files.')
+    res = parser.parse_args()
+    files = res.files
+
+    if isinstance(files, six.string_types):
+        files = os.path.abspath(files)
+        if os.path.isdir(files):
+            files = glob.glob("files/*.fits")
+        else:
+            files = glob.glob(files)
+
+    move_wcs(files)
+        
+


### PR DESCRIPTION
This is the initial commit tested on one file only.
Needs more testing and some documentation.

It moves the following keywords:
```
['PA_V3', 'V2_REF', 'V3_REF', 'PA_APER', 'VPARITY',
'RA_V1', 'DEC_V1', 'ROLL_REF', 'RA_REF', 'DEC_REF',
'PCi_j', 'CRVAL', 'CRPIX', CDELT', 'CUNIT', 'CTYPE', 'RADESYS'
```

We should consider moveing the velocity aberration keywords as well. We don't currently correct for this but I imagine we will (similar to HST).