### PR TITLE
Updates for the FGS guiding data calibration

### DIFF
--- a/jwst/datamodels/guidercal.py
+++ b/jwst/datamodels/guidercal.py
@@ -16,10 +16,10 @@ class GuiderCalModel( model_base.DataModel):
         Any of the initializers supported by `~jwst.datamodels.DataModel`.
 
     data: numpy array
-        The science data. 4-D
+        The science data. 3-D
 
     dq: numpy array
-        The data quality array. 2-D.
+        The data quality array. 2-D
 
     plan_star_table: table
         The planned reference star table

--- a/jwst/flatfield/flat_field.py
+++ b/jwst/flatfield/flat_field.py
@@ -107,14 +107,8 @@ def do_flat_field(output_model, flat_model):
 
     any_updated = False # will set True if any flats applied
 
-    # Apply flat to simple ImageModels
-    if isinstance(output_model, datamodels.ImageModel):
-        log.debug('Applying flat to ImageModel ...')
-        apply_flat_field(output_model, flat_model)
-        any_updated = True
-
     # Apply flat to MultiSlits
-    elif isinstance(output_model, datamodels.MultiSlitModel):
+    if isinstance(output_model, datamodels.MultiSlitModel):
 
         # Apply flat to each slit contained in the input
         for slit in output_model.slits:
@@ -122,9 +116,8 @@ def do_flat_field(output_model, flat_model):
             apply_flat_field(slit, flat_model)
             any_updated = True
 
-    # Apply flat to multiple-integration dataset
-    elif isinstance(output_model, datamodels.CubeModel):
-        log.debug('Applying flat to CubeModel')
+    # Apply flat to all other models
+    else:
         apply_flat_field(output_model, flat_model)
         any_updated = True
 
@@ -178,8 +171,16 @@ def apply_flat_field(science, flat):
     wh_dq = np.bitwise_and(flat_dq, dqflags.pixel['NO_FLAT_FIELD'])
     flat_data[wh_dq == dqflags.pixel['NO_FLAT_FIELD']] = 1.0
 
+    # For GuiderCalModel data, only apply flat to science data array;
+    # there isn't an error array.
+    if isinstance(science, datamodels.GuiderCalModel):
+            # Flatten data array
+            science.data /= flat_data
+            # Combine the science and flat DQ arrays
+            science.dq = np.bitwise_or(science.dq, flat_dq)
+
     # For CubeModel science data, apply flat to each integration
-    if isinstance(science, datamodels.CubeModel):
+    elif isinstance(science, datamodels.CubeModel):
         for integ in range(science.data.shape[0]):
             # Flatten data and error arrays
             science.data[integ] /= flat_data
@@ -187,8 +188,8 @@ def apply_flat_field(science, flat):
             # Combine the science and flat DQ arrays
             science.dq[integ] = np.bitwise_or(science.dq[integ], flat_dq)
 
+    # For 2D ImageModel science data, apply flat to entire arrays
     else:
-
         # Flatten data and error arrays
         science.data /= flat_data
         science.err /= flat_data

--- a/jwst/flatfield/flat_field_step.py
+++ b/jwst/flatfield/flat_field_step.py
@@ -48,6 +48,8 @@ class FlatFieldStep(Step):
             self.log.debug('Input is an ImageModel')
         elif isinstance(input_model, datamodels.MultiSlitModel):
             self.log.debug('Input is a MultiSlitModel')
+        elif isinstance(input_model, datamodels.GuiderCalModel):
+            self.log.debug('Input is a GuiderCalModel')
 
         if input_model.meta.instrument.name.upper() == "NIRSPEC":
             if (exposure_type not in NRS_SPEC_MODES and

--- a/jwst/pipeline/__init__.py
+++ b/jwst/pipeline/__init__.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 from .calwebb_ami3 import Ami3Pipeline
 from .calwebb_coron3 import Coron3Pipeline
 from .calwebb_dark import DarkPipeline
+from .calwebb_guider import GuiderPipeline
 from .calwebb_image2 import Image2Pipeline
 from .calwebb_image3 import Image3Pipeline
 from .calwebb_sloper import SloperPipeline
@@ -10,4 +11,4 @@ from .calwebb_spec2 import Spec2Pipeline
 from .calwebb_spec3 import Spec3Pipeline
 from .linear_pipeline import TestLinearPipeline
 
-__version__ = '0.7.8'
+__version__ = '0.7.1.1'

--- a/jwst/pipeline/calwebb_guider.cfg
+++ b/jwst/pipeline/calwebb_guider.cfg
@@ -3,8 +3,5 @@ class = "jwst.pipeline.GuiderPipeline"
 
     [steps]
       [[dq_init]]
-        config_file = dq_init.cfg
       [[guider_cds]]
-        config_file = guider_cds.cfg
       [[flat_field]]
-        config_file = flat_field.cfg

--- a/jwst/pipeline/calwebb_guider.py
+++ b/jwst/pipeline/calwebb_guider.py
@@ -28,13 +28,18 @@ class GuiderPipeline(Pipeline):
                  'flat_field': flat_field_step.FlatFieldStep,
                  }
 
-    # start the actual processing
+    # Start the processing
     def process(self, input):
+
+        # Set the output product type
+        self.suffix = 'cal'
 
         log.info('Starting calwebb_guider ...')
 
-        # open the input
+        # Open the input
         input = datamodels.GuiderRawModel(input) 
+
+        # Apply the steps
         input = self.dq_init(input)  
         input = self.guider_cds(input)
         input = self.flat_field(input)

--- a/jwst/pipeline/guider_cds.cfg
+++ b/jwst/pipeline/guider_cds.cfg
@@ -1,0 +1,2 @@
+name = "GuiderCDS"
+class = "jwst.guider_cds.GuiderCdsStep"


### PR DESCRIPTION
Modified the flat-field step to handle Guide mode data models. Misc other little updates to the guider pipeline, adding its import to the pipeline package, adding a .cfg file for the guider_cds step, etc.

As far as I can tell this really does complete the work on the guider calibration pipeline. All steps now work on all modes of guiding data. All we're missing is mask reference files in CRDS that match the size of the ID mode stacked images.