### PR TITLE
A few more updates to FGS guider calibration

### DIFF
--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -1595,7 +1595,7 @@ properties:
             type: string
             fits_keyword: S_RESAMP
           cube_build:
-            title: IFU  resampling
+            title: IFU resampling
             type: string
             fits_keyword: S_IFUCUB
           source_catalog:
@@ -1603,7 +1603,7 @@ properties:
             type: string
             fits_keyword: S_SRCCAT
           guider_cds:
-            title: Guider CDS Calculation
+            title: Guide Mode CDS Computation
             type: string
             fits_keyword: S_GUICDS
       background:

--- a/jwst/dq_init/dq_init_step.py
+++ b/jwst/dq_init/dq_init_step.py
@@ -17,12 +17,12 @@ class DQInitStep(Step):
 
     def process(self, input):
         # Determine Model type from EXP_TYPE of RampModel
-        input_model = datamodels.open( input )
+        input_model = datamodels.open(input)
 
         # Set flag for guider mode operations
         if input_model.meta.exposure.type in dq_initialization.guider_list: # Reopen as GuiderRawModel
             input_model.close()
-            input_model = datamodels.GuiderRawModel( input )
+            input_model = datamodels.GuiderRawModel(input)
 
         # Check for consistency between keyword values and data shape
         nints, ngroups, ysize, xsize = input_model.data.shape
@@ -32,16 +32,16 @@ class DQInitStep(Step):
         xsize_kwd = input_model.meta.subarray.xsize
 
         if nints != nints_kwd:
-            self.log.error("Keyword 'NINTS' value of '{0} does not match data array size of '{1}'".format(nints_kwd,nints))
+            self.log.error("Keyword 'NINTS' value of '{0} does not match data array size of '{1}'".format(nints_kwd, nints))
             raise ValueError("Bad data dimensions")
         if ngroups != ngroups_kwd:
-            self.log.error("Keyword 'NGROUPS' value of '{0}' does not match data array size of '{1}'".format(ngroups_kwd,ngroups))
+            self.log.error("Keyword 'NGROUPS' value of '{0}' does not match data array size of '{1}'".format(ngroups_kwd, ngroups))
             raise ValueError("Bad data dimensions")
         if ysize != ysize_kwd and 'IRS2' not in input_model.meta.exposure.readpatt.upper():
-            self.log.error("Keyword 'SUBSIZE2' value of '{0}' does not match data array size of '{1}'".format(ysize_kwd,ysize))
+            self.log.error("Keyword 'SUBSIZE2' value of '{0}' does not match data array size of '{1}'".format(ysize_kwd, ysize))
             raise ValueError("Bad data dimensions")
         if xsize != xsize_kwd:
-            self.log.error("Keyword 'SUBSIZE1' value of '{0}' does not match data array size of '{1}'".format(xsize_kwd,xsize))
+            self.log.error("Keyword 'SUBSIZE1' value of '{0}' does not match data array size of '{1}'".format(xsize_kwd, xsize))
             raise ValueError("Bad data dimensions")
 
         # Retreive the mask reference file name

--- a/jwst/dq_init/dq_initialization.py
+++ b/jwst/dq_init/dq_initialization.py
@@ -34,8 +34,8 @@ def do_dqinit(input_model, mask_model):
     check_dimensions(input_model)
 
     # Make sure the mask array is not smaller than the science array
-    if (input_model.dq.shape[-1] > mask_model.dq.shape[-1]) or \
-       (input_model.dq.shape[-2] > mask_model.dq.shape[-2]):
+    if (input_model.data.shape[-1] > mask_model.dq.shape[-1]) or \
+       (input_model.data.shape[-2] > mask_model.dq.shape[-2]):
         log.warning("Reference data shape is smaller than science data")
         log.warning("Step will be skipped")
         input_model.meta.cal_step.dq_init = 'SKIPPED'

--- a/jwst/flatfield/flat_field.py
+++ b/jwst/flatfield/flat_field.py
@@ -107,8 +107,14 @@ def do_flat_field(output_model, flat_model):
 
     any_updated = False # will set True if any flats applied
 
+    # Check to see if flat data array is smaller than science data
+    if (output_model.data.shape[-1] > flat_model.data.shape[-1]) or \
+       (output_model.data.shape[-2] > flat_model.data.shape[-2]):
+        log.warning('Reference data array is smaller than science data')
+        log.warning('Step will be skipped')
+
     # Apply flat to MultiSlits
-    if isinstance(output_model, datamodels.MultiSlitModel):
+    elif isinstance(output_model, datamodels.MultiSlitModel):
 
         # Apply flat to each slit contained in the input
         for slit in output_model.slits:


### PR DESCRIPTION
Updates to dq_init and flat_field to handle the case of reference files not matching the weird size of the ID mode images that have the strips stacked into a larger than 2048x2048 shape. Eventually there should be reference files in CRDS to match the size of this mode, but for now these checks will cause the dq_init and flat_field steps to be skipped.

Also minor updates to core schema and some pep8 cleanup.