### PR TITLE
Activate persistence step in calwebb_sloper

### DIFF
--- a/jwst/pipeline/calwebb_sloper.cfg
+++ b/jwst/pipeline/calwebb_sloper.cfg
@@ -24,7 +24,7 @@ save_calibrated_ramp = False
       [[dark_current]]
         config_file = dark_current.cfg
       [[persistence]]
-        skip = True
+        config_file = persistence.cfg
       [[jump]]
         config_file = jump.cfg
       [[ramp_fit]]


### PR DESCRIPTION
Remove "skip = True" in the default calwebb_sloper.cfg so that the persistence step will get executed in normal runs of the calwebb_sloper pipeline.