### PR TITLE
Move remaining pointing keywords to SCI header

### DIFF
--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -63,6 +63,7 @@ properties:
             default: ICRS
             fits_keyword: RADESYS
             enum: [ICRS]
+            fits_hdu: SCI
       asn:
         title: Association information
         type: object
@@ -728,6 +729,7 @@ properties:
             title: Position angle of aperture used (deg)
             type: number
             fits_keyword: PA_APER
+            fits_hdu: SCI
       wcsinfo:
         title: WCS parameters
         type: object
@@ -972,6 +974,7 @@ properties:
             title: Velocity aberration scale factor
             type: number
             fits_keyword: VA_SCALE
+            fits_hdu: SCI
       time:
         title: Time information
         type: object

--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -945,14 +945,17 @@ properties:
             title: RA of telescope V1 axis [deg]
             type: number
             fits_keyword: RA_V1
+            fits_hdu: SCI
           dec_v1:
             title: Dec of telescope V1 axis [deg]
             type: number
             fits_keyword: DEC_V1
+            fits_hdu: SCI
           pa_v3:
             title: Position angle of telescope V3 axis [deg]
             type: number
             fits_keyword: PA_V3
+            fits_hdu: SCI
       velocity_aberration:
         title: Velocity aberration correction information
         type: object


### PR DESCRIPTION
Move remaining V1 axis pointing keywords RA_V1, DEC_V1, PA_V3 from primary to SCI header. Now all pointing related keywords are in the SCI header.