### PR TITLE
Update velocity aberration script for relocated keywords

### DIFF
--- a/scripts/set_velocity_aberration.py
+++ b/scripts/set_velocity_aberration.py
@@ -169,11 +169,12 @@ def add_dva(filename):
     '''
     hdulist = fits.open(filename, 'update')
     pheader = hdulist[0].header
+    sheader = hdulist[1].header
     jwst_dx = float(pheader['JWST_DX'])
     jwst_dy = float(pheader['JWST_DY'])
     jwst_dz = float(pheader['JWST_DZ'])
-    ra_ref = float(pheader['RA_REF'])
-    dec_ref = float(pheader['DEC_REF'])
+    ra_ref = float(sheader['RA_REF'])
+    dec_ref = float(sheader['DEC_REF'])
 
     # compute the velocity aberration information
     scale_factor = aberration_scale(jwst_dx, jwst_dy, jwst_dz,
@@ -184,7 +185,7 @@ def add_dva(filename):
     # update header
     pheader['DVA_RA'] = ra_off
     pheader['DVA_DEC'] = dec_off
-    pheader['VA_SCALE'] = scale_factor
+    sheader['VA_SCALE'] = scale_factor
     hdulist.flush()
     hdulist.close()
 


### PR DESCRIPTION
Quick-n-dirty update to the set_velocity_aberration script to account for the fact that the RA_REF, DEC_REF, and VA_SCALE keywords have moved from the primary header to the SCI header. In the future this should be updated to use a Level1bModel to access the file, which would make it immune to keyword moves (as has been done for set_telescope_pointing).

The set_bary_helio_times script uses keywords that still reside in the primary header, so it doesn't need updating.