### PR TITLE
Fix hdulist warning message caused by double close

### DIFF
--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -220,12 +220,11 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         self.close()
 
     def close(self):
-        if not self._iscopy:
-            for fd in self._files_to_close:
-                if fd is not None:
-                    fd.close()
-            if self._asdf is not None:
-                self._asdf.close()
+        for fd in self._files_to_close:
+            if fd is not None:
+                fd.close()
+        if not self._iscopy and self._asdf is not None:
+            self._asdf.close()
 
     @staticmethod
     def clone(target, source, deepcopy=False, memo=None):
@@ -239,7 +238,7 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
             target._instance = source._instance
             target._iscopy = True
 
-        target._files_to_close = source._files_to_close[:]
+        target._files_to_close = []
         target._schema = source._schema
         target._shape = source._shape
         target._ctx = target


### PR DESCRIPTION
Under some circumstances, users would get a warning message when closing a model file that said the hdulist was already closed. The warning has been traced to the list of files to close contained in the model. When a model is copied, the same file is on the list of both models, so the same file gets closed twice. The code has been changed to truncate the list of files to close when a model is copied, so the file is only on a single list.

This problem was first reported by @philhodge 