### PR TITLE
Remove all occurrences of MSA catalog_id

### DIFF
--- a/jwst/assign_wcs/nirspec.py
+++ b/jwst/assign_wcs/nirspec.py
@@ -444,8 +444,8 @@ def get_open_msa_slits(msa_file, msa_metadata_id):
 
             shutter_id = xcen + (ycen - 1) * 365
             source_id = slitlets_sid[0]['source_id']
-            source_name, source_alias, catalog_id, stellarity = [
-                (s['source_name'], s['alias'], s['catalog_id'], s['stellarity']) \
+            source_name, source_alias, stellarity = [
+                (s['source_name'], s['alias'], s['stellarity']) \
                 for s in msa_source if s['source_id'] == source_id][0]
             # Create the output list of tuples that contain the required
             # data for further computations
@@ -462,7 +462,7 @@ def get_open_msa_slits(msa_file, msa_metadata_id):
             source_ypos = source_ypos - 0.5
             slitlets.append(Slit(slitlet_id, shutter_id, xcen, ycen, ymin, ymax,
                                  quadrant, source_id, nshutters, source_name, source_alias,
-                                 catalog_id, stellarity, source_xpos, source_ypos))
+                                 stellarity, source_xpos, source_ypos))
     return slitlets
 
 

--- a/jwst/assign_wcs/tests/test_nirspec.py
+++ b/jwst/assign_wcs/tests/test_nirspec.py
@@ -31,7 +31,7 @@ slit_fields_num = ["shutter_id", "xcen", "ycen",
                    "stellarity", "source_xpos", "source_ypos"]
 
 
-slit_fields_str = ["name", "source_name", "source_alias", "catalog_id"]
+slit_fields_str = ["name", "source_name", "source_alias"]
 
 
 def _compare_slits(s1, s2):

--- a/jwst/assign_wcs/tests/test_nirspec.py
+++ b/jwst/assign_wcs/tests/test_nirspec.py
@@ -290,7 +290,7 @@ def test_msa_configuration_normal():
     msaconfl = get_file_path('msa_configuration.fits')
     slitlet_info = nirspec.get_open_msa_slits(msaconfl, msa_meta_id)
     ref_slit = Slit(55, 9376, 251, 26, -5.15, 0.55, 4, 1, 5, '95065_1', '2122',
-                      '2122', 0.13, -0.31716078999999997, -0.18092266)
+                      0.13, -0.31716078999999997, -0.18092266)
     _compare_slits(slitlet_info[0], ref_slit)
 
 
@@ -315,7 +315,7 @@ def test_msa_configuration_all_background():
     msaconfl = get_file_path('msa_configuration.fits')
     slitlet_info = nirspec.get_open_msa_slits(msaconfl, msa_meta_id)
     ref_slit = Slit(57, 616, 251, 2, 22.45, 25.85, 4, 1, 3, '95065_1', '2122',
-                    '2122', 0.13, -0.5, -0.5)
+                    0.13, -0.5, -0.5)
     _compare_slits(slitlet_info[0], ref_slit)
 
 
@@ -330,7 +330,7 @@ def test_msa_configuration_row_skipped():
     msaconfl = get_file_path('msa_configuration.fits')
     slitlet_info = nirspec.get_open_msa_slits(msaconfl, msa_meta_id)
     ref_slit = Slit(58, 8646, 251, 24, -2.85, 5.15, 4, 1, 6, '95065_1', '2122',
-                      '2122', 0.130, -0.31716078999999997, -0.18092266)
+                      0.130, -0.31716078999999997, -0.18092266)
     _compare_slits(slitlet_info[0], ref_slit)
 
 
@@ -343,8 +343,8 @@ def test_msa_configuration_multiple_returns():
     msaconfl = get_file_path('msa_configuration.fits')
     slitlet_info = nirspec.get_open_msa_slits(msaconfl, msa_meta_id)
     ref_slit1 = Slit(59, 8651, 256, 24, -2.85, 5.15, 4, 1, 6, '95065_1', '2122',
-                     '2122', 0.13000000000000003, -0.31716078999999997, -0.18092266)
+                     0.13000000000000003, -0.31716078999999997, -0.18092266)
     ref_slit2 = Slit(60, 11573, 258, 32, -2.85, 4, 4, 2, 6, '95065_2', '172',
-                     '172', 0.70000000000000007, -0.31716078999999997, -0.18092266)
+                     0.70000000000000007, -0.31716078999999997, -0.18092266)
     _compare_slits(slitlet_info[0], ref_slit1)
     _compare_slits(slitlet_info[1], ref_slit2)

--- a/jwst/datamodels/schemas/multiproduct.schema.yaml
+++ b/jwst/datamodels/schemas/multiproduct.schema.yaml
@@ -79,11 +79,6 @@ allOf:
               type: string
               fits_keyword: SRCALIAS
               fits_hdu: SCI
-            catalog_id:
-              title: Catalog ID
-              type: string
-              fits_keyword: CATLOGID
-              fits_hdu: SCI
             stellarity:
               title: Source stellarity
               type: number

--- a/jwst/datamodels/schemas/multislit.schema.yaml
+++ b/jwst/datamodels/schemas/multislit.schema.yaml
@@ -101,11 +101,6 @@ allOf:
               type: string
               fits_keyword: SRCALIAS
               fits_hdu: SCI
-            catalog_id:
-              title: Catalog ID
-              type: string
-              fits_keyword: CATLOGID
-              fits_hdu: SCI
             stellarity:
               title: Source stellarity
               type: number

--- a/jwst/extract_2d/extract_2d.py
+++ b/jwst/extract_2d/extract_2d.py
@@ -76,7 +76,6 @@ def extract2d(input_model, which_subarray=None):
                 output_model.slits[nslit].source_id = int(slit.source_id)
                 output_model.slits[nslit].source_name = slit.source_name
                 output_model.slits[nslit].source_alias = slit.source_alias
-                output_model.slits[nslit].catalog_id  = slit.catalog_id
                 output_model.slits[nslit].stellarity = float(slit.stellarity)
                 output_model.slits[nslit].source_xpos = float(slit.source_xpos)
                 output_model.slits[nslit].source_ypos = float(slit.source_ypos)

--- a/jwst/msaflagopen/msaflag_open.py
+++ b/jwst/msaflagopen/msaflag_open.py
@@ -195,11 +195,11 @@ def create_slitlets(input_model, shutter_refname):
     
     Slit = namedtuple('Slit', ["name", "shutter_id", "xcen", "ycen",
                            "ymin", "ymax", "quadrant", "source_id", "nshutters",
-                           "source_name", "source_alias", "catalog_id", "stellarity",
+                           "source_name", "source_alias", "stellarity",
                            "source_xpos", "source_ypos"])
     "shutter_id" is an integer that uniquely defines the shutter in the quadrant, it is calculated
     from the x and y using the function 
-    Slit.__new__.__defaults__= ("", 0, 0.0, 0.0, 0.0, 0.0, 0, 0, 0, "", "", "", 0.0, 0.0, 0.0)
+    Slit.__new__.__defaults__= ("", 0, 0.0, 0.0, 0.0, 0.0, 0, 0, 0, "", "", 0.0, 0.0, 0.0)
 
     The only ones that matter are "name" (must be unique), xcen, ycen, quadrant (from msaoper
     file), ymin, ymax (should be -0.5, 0.5), nshutters (should be 1) 
@@ -215,7 +215,7 @@ def create_slitlets(input_model, shutter_refname):
         y = shutter['y']
         shutter_id = id_from_xy(x, y)
         slitlets.append(Slit(str(counter), shutter_id, x, y, -0.5, 0.5,
-                             shutter['Q'], 0, 1, "", "", "", 0.0, 0.0, 0.0)
+                             shutter['Q'], 0, 1, "", "", 0.0, 0.0, 0.0)
                         )
     return slitlets
 

--- a/jwst/resample/resample_spec.py
+++ b/jwst/resample/resample_spec.py
@@ -469,8 +469,8 @@ class ResampleSpecData(object):
             try:
                 for attr in ['name', 'xstart', 'xsize', 'ystart', 'ysize',
                     'slitlet_id', 'source_id', 'source_name', 'source_alias',
-                    'catalog_id', 'stellarity', 'source_type', 'source_xpos',
-                    'source_ypos', 'nshutters', 'relsens']:
+                    'stellarity', 'source_type', 'source_xpos', 'source_ypos',
+                    'nshutters', 'relsens']:
                     if hasattr(img, attr):
                         setattr(output_model, attr, getattr(img, attr))
             except:

--- a/jwst/transforms/models.py
+++ b/jwst/transforms/models.py
@@ -28,7 +28,7 @@ N_SHUTTERS_QUADRANT = 62415
 # Nirspec slit definition
 Slit = namedtuple('Slit', ["name", "shutter_id", "xcen", "ycen",
                            "ymin", "ymax", "quadrant", "source_id", "nshutters",
-                           "source_name", "source_alias", "catalog_id", "stellarity",
+                           "source_name", "source_alias", "stellarity",
                            "source_xpos", "source_ypos"])
 Slit.__new__.__defaults__= ("", 0, 0.0, 0.0, 0.0, 0.0, 0, 0, 0, "", "", "", 0.0, 0.0, 0.0)
 


### PR DESCRIPTION
Remove all occurrences of the NIRSpec MSA catalog_id field in all calspec2 steps, because that field is going away from the MSA metadata files that we use as input. We never did anything with the value other than copy it from the MSA metadata source table to a header keyword for each slit instance created. This removes it from all code modules and also removes it from the keyword schemas in which it appeared.

Fixes #1118 