### PR TITLE
Add attributes slit_ra and slit_dec to MultiSpecModel.

### DIFF
--- a/jwst/datamodels/schemas/multispec.schema.yaml
+++ b/jwst/datamodels/schemas/multispec.schema.yaml
@@ -28,4 +28,71 @@ allOf:
               datatype: float64
             - name: BERROR
               datatype: float64
+          name:
+            title: Name of the slit
+            type: string
+            fits_keyword: SLTNAME
+            fits_hdu: EXTRACT1D
+          slitlet_id:
+            title: Slitlet ID
+            type: integer
+            default: 0
+            fits_keyword: SLITID
+            fits_hdu: EXTRACT1D
+          source_id:
+            title: Source ID
+            type: integer
+            default: 0
+            fits_keyword: SOURCEID
+            fits_hdu: EXTRACT1D
+          source_name:
+            title: Source name
+            type: string
+            fits_keyword: SRCNAME
+            fits_hdu: EXTRACT1D
+          source_alias:
+            title: Source alias
+            type: string
+            fits_keyword: SRCALIAS
+            fits_hdu: EXTRACT1D
+          stellarity:
+            title: Source stellarity
+            type: number
+            fits_keyword: STLARITY
+            fits_hdu: EXTRACT1D
+          source_type:
+            title: Source type (point/extended)
+            type: string
+            fits_keyword: SRCTYPE
+            fits_hdu: EXTRACT1D
+          source_xpos:
+            title: Source position in slit (x-axis)
+            type: number
+            default: 0.0
+            fits_keyword: SRCXPOS
+            fits_hdu: EXTRACT1D
+          source_ypos:
+            title: Source position in slit (y-axis)
+            type: number
+            default: 0.0
+            fits_keyword: SRCYPOS
+            fits_hdu: EXTRACT1D
+          nshutters:
+            title: Number of open shutters
+            type: integer
+            default: 0
+            fits_keyword: NSHUT
+            fits_hdu: EXTRACT1D
+          slit_ra:
+            title: Right ascension (deg) at middle of slit
+            type: number
+            default: 0.0
+            fits_keyword: SLIT_RA
+            fits_hdu: EXTRACT1D
+          slit_dec:
+            title: Declination (deg) at middle of slit
+            type: number
+            default: 0.0
+            fits_keyword: SLIT_DEC
+            fits_hdu: EXTRACT1D
 $schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -1081,6 +1081,8 @@ def do_extract1d(input_model, refname, smoothing_length, bkg_order):
                             dtype=spec.spec_table.dtype)
             spec = datamodels.SpecModel(spec_table=otab)
             spec.meta.wcs = spec_wcs.create_spectral_wcs(ra, dec, wavelength)
+            spec.slit_ra = ra
+            spec.slit_dec = dec
             output_model.spec.append(spec)
     else:
         slitname = input_model.meta.exposure.type
@@ -1126,6 +1128,8 @@ def do_extract1d(input_model, refname, smoothing_length, bkg_order):
                             dtype=spec.spec_table.dtype)
             spec = datamodels.SpecModel(spec_table=otab)
             spec.meta.wcs = spec_wcs.create_spectral_wcs(ra, dec, wavelength)
+            spec.slit_ra = ra
+            spec.slit_dec = dec
             output_model.spec.append(spec)
 
         elif isinstance(input_model, datamodels.CubeModel):
@@ -1171,6 +1175,8 @@ def do_extract1d(input_model, refname, smoothing_length, bkg_order):
                 spec = datamodels.SpecModel(spec_table=otab)
                 spec.meta.wcs = spec_wcs.create_spectral_wcs(ra, dec,
                                                              wavelength)
+                spec.slit_ra = ra
+                spec.slit_dec = dec
                 output_model.spec.append(spec)
 
         elif isinstance(input_model, datamodels.IFUCubeModel):

--- a/jwst/extract_1d/ifu.py
+++ b/jwst/extract_1d/ifu.py
@@ -97,6 +97,8 @@ def ifu_extract1d(input_model, refname, source_type):
                     dtype=spec.spec_table.dtype)
     spec = datamodels.SpecModel(spec_table=otab)
     spec.meta.wcs = spec_wcs.create_spectral_wcs(ra, dec, wavelength)
+    spec.slit_ra = ra
+    spec.slit_dec = dec
     output_model.spec.append(spec)
 
     # See output_model.spec[0].meta.wcs instead.


### PR DESCRIPTION
The right ascension and declination at the center of the extraction
region are now assigned to these new attributes.  These are the same
values as are returned by the wcs object, which is possible because
the coordinates are independent of row number in the table of extracted
values.  See issue #1034.

Additional metadata attributes have also been added to the MultiSpecModel.
These are based on attributes that were added not very long ago to the
MultiSlitModel, but not all are included in MultiSpecModel.  The extract_1d
step does not actually populate these yet.  See issue #1042.