### PR TITLE
Support skipping reference file prefetch, OutlierDetectionStep

### DIFF
--- a/jwst/outlier_detection/outlier_detection_step.py
+++ b/jwst/outlier_detection/outlier_detection_step.py
@@ -36,6 +36,7 @@ class OutlierDetectionStep(Step):
         good_bits = integer(default=4)
     """
     reference_file_types = ['gain', 'readnoise']
+    prefetch_references = False
 
     def process(self, input):
 

--- a/jwst/stpipe/step.py
+++ b/jwst/stpipe/step.py
@@ -45,7 +45,7 @@ class Step(object):
     suffix = string(default=None)           # Default suffix for output files
     """
 
-    # Reference types for both command line override definitiion and reference prefetch
+    # Reference types for both command line override definition and reference prefetch
     reference_file_types = []
     
     # Set to False in subclasses to skip prefetch,  but by default attempt to prefetch

--- a/jwst/stpipe/step.py
+++ b/jwst/stpipe/step.py
@@ -45,7 +45,11 @@ class Step(object):
     suffix = string(default=None)           # Default suffix for output files
     """
 
+    # Reference types for both command line override definitiion and reference prefetch
     reference_file_types = []
+    
+    # Set to False in subclasses to skip prefetch,  but by default attempt to prefetch
+    prefetch_references = True
 
     @classmethod
     def merge_config(cls, config, config_file):
@@ -336,7 +340,8 @@ class Step(object):
         result = None
 
         try:
-            if len(args) and len(self.reference_file_types) and not self.skip:
+            if (len(args) and len(self.reference_file_types) and not self.skip
+                and self.prefetch_references):
                 self._precache_reference_files(args[0])
 
             self.log.info(


### PR DESCRIPTION
This pull adds a class level flag to Step named `prefetch_references`. 

Subclasses of Step that wish to skip the reference file prefetch (pre-caching) should define prefetch_references=False.   Other classes don't need to define it,  the default will do.

Also defined prefetch_references=False for OutlierDetectionStep which was the original motivation for this feature and use case.


