### PR TITLE
More subarray library function updates

### DIFF
--- a/jwst/flatfield/flat_field.py
+++ b/jwst/flatfield/flat_field.py
@@ -9,6 +9,7 @@ import numpy as np
 import logging
 from .. import datamodels
 from .. datamodels import dqflags
+from .. lib import reffile_utils
 from .. assign_wcs import nirspec       # for NIRSpec IFU data
 
 log = logging.getLogger(__name__)
@@ -154,15 +155,16 @@ def apply_flat_field(science, flat):
     None
     """
 
-    # If the input science data model is a subarray, extract the same
-    # subarray from the flatfield model
-    if ref_matches_sci(flat, science):
+    # Extract subarray from reference data, if necessary
+    if reffile_utils.ref_matches_sci(science, flat):
         flat_data = flat.data
         flat_dq = flat.dq
     else:
         log.info("Extracting matching subarray from flat")
-        flat_data = get_subarray(flat.data, science)
-        flat_dq = get_subarray(flat.dq, science)
+        sub_flat = reffile_utils.get_subarray_model(science, flat)
+        flat_data = sub_flat.data.copy()
+        flat_dq = sub_flat.dq.copy()
+        sub_flat.close()
 
     # For pixels whose flat is either NaN or NO_FLAT_FIELD, update their DQ to
     # indicate that no flat is applied to those pixels
@@ -202,110 +204,6 @@ def apply_flat_field(science, flat):
 
         # Combine the science and flat DQ arrays
         science.dq = np.bitwise_or(science.dq, flat_dq)
-
-
-def ref_matches_sci(ref_model, sci_model):
-    """
-    Short Summary
-    -------------
-    Check if the science model has the same subarray parameters as the
-    reference model.
-
-    Parameters
-    ----------
-    ref_model: JWST data model
-        data model containing flat-field
-
-    sci_model: JWST data model
-        input science data model to be flat-fielded
-
-    Returns
-    -------
-    True if the science model has the same subarray parameters as the
-    reference model, False otherwise.
-
-    """
-    # Get the science model subarray parameters
-    try:
-        sxstart = sci_model.xstart
-        sxsize = sci_model.xsize
-        systart = sci_model.ystart
-        sysize = sci_model.ysize
-    except:
-        sxstart = sci_model.meta.subarray.xstart
-        sxsize = sci_model.meta.subarray.xsize
-        systart = sci_model.meta.subarray.ystart
-        sysize = sci_model.meta.subarray.ysize
-
-    # Get the flat model subarray parameters
-    rxstart = ref_model.meta.subarray.xstart
-    rxsize = ref_model.meta.subarray.xsize
-    rystart = ref_model.meta.subarray.ystart
-    rysize = ref_model.meta.subarray.ysize
-
-    if rxstart is None:
-        rxstart = 1
-    if rxsize is None:
-        rxsize = ref_model.data.shape[-1]
-    if rystart is None:
-        rystart = 1
-    if rysize is None:
-        rysize = ref_model.data.shape[-2]
-
-    log.debug(' sci xstart=%d, xsize=%d', sxstart, sxsize)
-    log.debug(' sci ystart=%d, ysize=%d', systart, sysize)
-    log.debug(' ref xstart=%d, xsize=%d', rxstart, rxsize)
-    log.debug(' ref ystart=%d, ysize=%d', rystart, rysize)
-
-    # See if they match the reference model subarray parameters
-    if (rxstart == sxstart and rxsize == sxsize and
-        rystart == systart and rysize == sysize):
-        return True
-    else:
-        return False
-
-
-def get_subarray(input_array, sci_model):
-    """
-    Short Summary
-    -------------
-    Return the slice from the input array using the subarray parameters of the
-    science model.
-
-    Parameters
-    ----------
-    input_array: 2D numpy array
-        input array from which a subarray is extracted
-
-    sci_model: JWST data model
-        input science data model
-
-    Returns
-    -------
-    A slice: 2D numpy array
-        slice from the input array
-    """
-
-    # Get the science model subarray parameters
-    try:
-        xstart = sci_model.xstart
-        xsize = sci_model.xsize
-        ystart = sci_model.ystart
-        ysize = sci_model.ysize
-    except:
-        xstart = sci_model.meta.subarray.xstart
-        xsize = sci_model.meta.subarray.xsize
-        ystart = sci_model.meta.subarray.ystart
-        ysize = sci_model.meta.subarray.ysize
-
-    # Compute the slicing indexes
-    xstart = xstart - 1
-    xstop = xstart + xsize
-    ystart = ystart - 1
-    ystop = ystart + ysize
-
-    # Return the slice from the input array
-    return input_array[ystart:ystop, xstart:xstop]
 
 
 #

--- a/jwst/jump/jump.py
+++ b/jwst/jump/jump.py
@@ -44,17 +44,17 @@ def detect_jumps (input_model, gain_model, readnoise_model,
     nframes = input_model.meta.exposure.nframes
 
     # Get 2D gain and read noise values from their respective models
-    if reffile_utils.is_subarray(input_model):
+    if reffile_utils.ref_matches_sci(input_model, gain_model):
+        gain_2d = gain_model.data
+    else:
         log.info('Extracting gain subarray to match science data')
         gain_2d = reffile_utils.get_subarray_data(input_model, gain_model)
-    else:
-        gain_2d = gain_model.data
 
-    if reffile_utils.is_subarray(input_model):
+    if reffile_utils.ref_matches_sci(input_model, readnoise_model):
+        readnoise_2d = readnoise_model.data
+    else:
         log.info('Extracting readnoise subarray to match science data')
         readnoise_2d = reffile_utils.get_subarray_data(input_model, readnoise_model)
-    else:
-        readnoise_2d = readnoise_model.data
 
     # Flag the pixeldq where the gain is <=0 or NaN so they will be ignored
     wh_g = np.where( gain_2d <= 0.)  
@@ -105,6 +105,3 @@ def detect_jumps (input_model, gain_model, readnoise_model,
     output_model.pixeldq = pdq
 
     return output_model
-
-
-

--- a/jwst/lib/reffile_utils.py
+++ b/jwst/lib/reffile_utils.py
@@ -1,3 +1,4 @@
+from jwst import datamodels
 import logging
 
 log = logging.getLogger(__name__)
@@ -6,12 +7,28 @@ log.setLevel(logging.DEBUG)
 
 def is_subarray(input_model):
 
+    """
+    Check to see if a data model comes from a subarray readout.
+    If the data dimensions are less than 2048x2048 (or 1032x1024
+    for MIRI), it is assumed to be a subarray.
+
+    Parameters
+    ----------
+    input_model: JWST data model
+        input data model to be checked
+
+    Returns
+    -------
+    True is the primary data array of the model is smaller than
+    full-frame, False otherwise.
+    """
+
+    # Get the dimensions of the model's primary data array
     nrows = input_model.data.shape[-2]
     ncols = input_model.data.shape[-1]
 
-    instrument = input_model.meta.instrument.name
-
-    if instrument == 'MIRI':
+    # Compare the dimensions to a full-frame
+    if input_model.meta.instrument.name.upper() == 'MIRI':
         if ncols < 1032 or nrows < 1024:
             log.debug('Input exposure is a subarray readout')
             return True
@@ -25,11 +42,133 @@ def is_subarray(input_model):
             return False
 
 
-def get_subarray_data(input_model, ref_model):
+def ref_matches_sci(sci_model, ref_model):
+
+    """
+    Short Summary
+    -------------
+    Check to see if the science model has the same subarray
+    characteristics as the reference model. Also performs error
+    checking on the subarray keywords in both the reference file
+    and science data.
+
+    Parameters
+    ----------
+    sci_model: JWST data model
+        science data model
+
+    ref_model: JWST data model
+        reference file data model
+
+    Returns
+    -------
+    True if the science model has the same subarray parameters
+    as the reference model, False otherwise.
+    """
+
+    # Get the reference file subarray parameters
+    xstart_ref = ref_model.meta.subarray.xstart
+    xsize_ref = ref_model.meta.subarray.xsize
+    ystart_ref = ref_model.meta.subarray.ystart
+    ysize_ref = ref_model.meta.subarray.ysize
+
+    # Make sure the attributes were populated
+    if (xstart_ref is None) or (xsize_ref is None) or \
+       (ystart_ref is None) or (ysize_ref is None):
+        log.error('Missing subarray corner/size keywords in reference file')
+        raise ValueError("Can't determine ref file subarray properties")
+    else:
+        log.debug(" ref xstart=%d, xsize=%d, ystart=%d, ysize=%d" % \
+            (xstart_ref, xsize_ref, ystart_ref, ysize_ref))
+
+    # Make sure the starting corners are valid
+    if (xstart_ref < 1) or (ystart_ref < 1):
+        log.errr("Reference file subarray corners are invalid")
+        raise ValueError("Bad subarray corners")
+
+    # Make sure the size attributes are consistent with data array
+    if hasattr(ref_model, 'coeffs'):
+        xsize_data = ref_model.coeffs.shape[-1]
+        ysize_data = ref_model.coeffs.shape[-2]
+    else:
+        xsize_data = ref_model.shape[-1]
+        ysize_data = ref_model.shape[-2]
+
+    if (xsize_ref != xsize_data) or (ysize_ref != ysize_data):
+        log.warning("Reference file data array size doesn't match subarray params")
+        log.warning("Using actual array size")
+        xsize_ref = xsize_data
+        ysize_ref = ysize_data
+
+    # Get the science model subarray parameters
+    try:
+        # If the science data model has already gone through
+        # extract_2d, the metadata is in the top level of the model
+        xstart_sci = sci_model.xstart
+        xsize_sci = sci_model.xsize
+        ystart_sci = sci_model.ystart
+        ysize_sci = sci_model.ysize
+    except:
+        # Otherwise the metadata is in the meta tree
+        xstart_sci = sci_model.meta.subarray.xstart
+        xsize_sci = sci_model.meta.subarray.xsize
+        ystart_sci = sci_model.meta.subarray.ystart
+        ysize_sci = sci_model.meta.subarray.ysize
+
+    # Make sure the attributes were populated
+    if (xstart_sci is None) or (xsize_sci is None) or \
+       (ystart_sci is None) or (ysize_sci is None):
+        log.error('Missing subarray corner/size keywords in science file')
+        raise ValueError("Can't determine science file subarray properties")
+    else:
+        log.debug(" sci xstart=%d, xsize=%d, ystart=%d, ysize=%d" % \
+            (xstart_sci, xsize_sci, ystart_sci, ysize_sci))
+
+    # Make sure the starting corners are valid
+    if (xstart_sci < 1) or (ystart_sci < 1):
+        log.errr("Science file subarray corners are invalid")
+        raise ValueError("Bad subarray corners")
+
+    # Make sure the size attributes are consistent with data array
+    if (xsize_sci != sci_model.shape[-1]) or \
+       (ysize_sci != sci_model.shape[-2]):
+        log.warning("Science file data array size doesn't match subarray params")
+        log.warning("Using actual array size")
+        xsize_sci = sci_model.shape[-1]
+        ysize_sci = sci_model.shape[-2]
+
+    # Finally, see if all of the science file subarray params match those
+    # of the reference file
+    if (xstart_ref == xstart_sci and xsize_ref == xsize_sci and
+        ystart_ref == ystart_sci and ysize_ref == ysize_sci):
+        return True
+    else:
+        return False
+
+
+def get_subarray_data(sci_model, ref_model):
+
+    """
+    Extract a subarray from the data attribute of a reference file
+    data model that matches the subarray characteristics of a
+    science data model. Only the extracted data array is returned.
+
+    Parameters
+    ----------
+    sci_model: JWST data model
+        science data model
+
+    ref_model: JWST data model
+        reference file data model
+
+    Returns
+    -------
+    array: 2-D extracted data array
+    """
 
     # Make sure xstart/ystart exist in science data model
-    if (input_model.meta.subarray.xstart is None or
-        input_model.meta.subarray.ystart is None):
+    if (sci_model.meta.subarray.xstart is None or
+        sci_model.meta.subarray.ystart is None):
         raise ValueError('xstart or ystart metadata values ' \
                          + 'not found in input model')
 
@@ -40,11 +179,11 @@ def get_subarray_data(input_model, ref_model):
                          + 'not found in reference model')
 
     # Get subarray limits from metadata of input model
-    xstart_sci = input_model.meta.subarray.xstart
-    xsize_sci = input_model.meta.subarray.xsize
+    xstart_sci = sci_model.meta.subarray.xstart
+    xsize_sci = sci_model.meta.subarray.xsize
     xstop_sci = xstart_sci + xsize_sci - 1
-    ystart_sci = input_model.meta.subarray.ystart
-    ysize_sci = input_model.meta.subarray.ysize
+    ystart_sci = sci_model.meta.subarray.ystart
+    ysize_sci = sci_model.meta.subarray.ysize
     ystop_sci = ystart_sci + ysize_sci - 1
     log.debug('science xstart=%d, xstop=%d, ystart=%d, ystop=%d',
               xstart_sci, xstop_sci, ystart_sci, ystop_sci)
@@ -59,15 +198,17 @@ def get_subarray_data(input_model, ref_model):
     log.debug('reference xstart=%d, xstop=%d, ystart=%d, ystop=%d',
               xstart_ref, xstop_ref, ystart_ref, ystop_ref)
 
-    # Compute slice limits, in 1-indexed units
-    xstart = xstart_sci - xstart_ref + 1
-    xstop = xstart + xsize_sci - 1
-    ystart = ystart_sci - ystart_ref + 1
-    ystop = ystart + ysize_sci - 1
+    # Compute slice limits, in 0-indexed python notation
+    xstart = xstart_sci - xstart_ref
+    ystart = ystart_sci - ystart_ref
+    xstop = xstart + xsize_sci
+    ystop = ystart + ysize_sci
     log.debug('slice xstart=%d, xstop=%d, ystart=%d, ystop=%d',
               xstart, xstop, ystart, ystop)
 
-    if (xstart < 1 or ystart < 1 or
+    # Make sure that the slice limits are within the bounds of
+    # the reference file data array
+    if (xstart < 0 or ystart < 0 or
         xstop > ref_model.meta.subarray.xsize or
         ystop > ref_model.meta.subarray.ysize):
         log.error('Computed reference file slice indexes are ' \
@@ -79,4 +220,104 @@ def get_subarray_data(input_model, ref_model):
                    ref_model.meta.subarray.ysize)
         raise ValueError('Bad reference file slice indexes')
 
-    return ref_model.data[ystart-1:ystop, xstart-1:xstop]
+    return ref_model.data[ystart:ystop, xstart:xstop]
+
+
+def get_subarray_model(sci_model, ref_model):
+
+    """
+    Create a subarray version of a reference file model that matches
+    the subarray characteristics of a science data model. An new
+    model is created that contains subarrays of all data arrays
+    contained in the reference file model.
+
+    Parameters
+    ----------
+    sci_model: JWST data model
+        science data model
+
+    ref_model: JWST data model
+        reference file data model
+
+    Returns
+    -------
+    sub_model: JWST data model
+        subarray version of the reference file model
+    """
+
+    # Get the science model subarray params
+    xstart_sci = sci_model.meta.subarray.xstart
+    xsize_sci = sci_model.meta.subarray.xsize
+    ystart_sci = sci_model.meta.subarray.ystart
+    ysize_sci = sci_model.meta.subarray.ysize
+
+    # Get the reference model subarray params
+    xstart_ref = ref_model.meta.subarray.xstart
+    xsize_ref = ref_model.meta.subarray.xsize
+    ystart_ref = ref_model.meta.subarray.ystart
+    ysize_ref = ref_model.meta.subarray.ysize
+
+    # Compute the slice indexes, in 0-indexed python frame
+    xstart = xstart_sci - xstart_ref
+    ystart = ystart_sci - ystart_ref
+    xstop = xstart + xsize_sci
+    ystop = ystart + ysize_sci
+    log.debug("slice xstart=%d, xstop=%d, ystart=%d, ystop=%d",
+              xstart, xstop, ystart, ystop)
+
+    # Make sure that the slice limits are within the bounds of
+    # the reference file data array
+    if (xstart < 0 or ystart < 0 or
+        xstop > ref_model.meta.subarray.xsize or
+        ystop > ref_model.meta.subarray.ysize):
+        log.error('Computed reference file slice indexes are ' \
+                  + 'incompatible with size of reference data array')
+        log.error('xstart=%d, xstop=%d, ystart=%d, ystop=%d',
+                   xstart, xstop, ystart, ystop)
+        log.error('Reference xsize=%d, ysize=%d',
+                   ref_model.meta.subarray.xsize,
+                   ref_model.meta.subarray.ysize)
+        raise ValueError('Bad reference file slice indexes')
+
+    # Extract subarrays from each data attribute in the particular
+    # type of reference file model and return a new copy of the
+    # data model
+    if isinstance(ref_model, datamodels.FlatModel):
+        sub_data = ref_model.data[ystart:ystop, xstart:xstop]
+        sub_err = ref_model.err[ystart:ystop, xstart:xstop]
+        sub_dq = ref_model.dq[ystart:ystop, xstart:xstop]
+        sub_model = datamodels.FlatModel(data=sub_data, err=sub_err, dq=sub_dq)
+        sub_model.update(ref_model)
+    elif isinstance(ref_model, datamodels.GainModel):
+        sub_data = ref_model.data[ystart:ystop, xstart:xstop]
+        sub_model = datamodels.GainModel(data=sub_data)
+        sub_model.update(ref_model)
+    elif isinstance(ref_model, datamodels.LinearityModel):
+        sub_data = ref_model.coeffs[:, ystart:ystop, xstart:xstop]
+        sub_dq = ref_model.dq[ystart:ystop, xstart:xstop]
+        sub_model = datamodels.LinearityModel(coeffs=sub_data, dq=sub_dq)
+        sub_model.update(ref_model)
+    elif isinstance(ref_model, datamodels.MaskModel):
+        sub_dq = ref_model.dq[ystart:ystop, xstart:xstop]
+        sub_model = datamodels.MaskModel(dq=sub_dq)
+        sub_model.update(ref_model)
+    elif isinstance(ref_model, datamodels.ReadnoiseModel):
+        sub_data = ref_model.data[ystart:ystop, xstart:xstop]
+        sub_model = datamodels.ReadnoiseModel(data=sub_data)
+        sub_model.update(ref_model)
+    elif isinstance(ref_model, datamodels.SaturationModel):
+        sub_data = ref_model.data[ystart:ystop, xstart:xstop]
+        sub_dq = ref_model.dq[ystart:ystop, xstart:xstop]
+        sub_model = datamodels.SaturationModel(data=sub_data, dq=sub_dq)
+        sub_model.update(ref_model)
+    elif isinstance(ref_model, datamodels.SuperBiasModel):
+        sub_data = ref_model.data[ystart:ystop, xstart:xstop]
+        sub_err = ref_model.err[ystart:ystop, xstart:xstop]
+        sub_dq = ref_model.dq[ystart:ystop, xstart:xstop]
+        sub_model = datamodels.SuperBiasModel(data=sub_data, err=sub_err, dq=sub_dq)
+        sub_model.update(ref_model)
+    else:
+        log.warning('Unsupported reference file model type')
+        sub_model = None
+
+    return sub_model

--- a/jwst/ramp_fitting/utils.py
+++ b/jwst/ramp_fitting/utils.py
@@ -861,17 +861,17 @@ def get_ref_subs(model, readnoise_model, gain_model):
         gain subarray
     """
 
-    if reffile_utils.is_subarray(model):
-        log.info('Extracting readnoise subarray to match science data')
-        readnoise_2d = reffile_utils.get_subarray_data(model, readnoise_model)
+    if reffile_utils.ref_matches_sci(model, gain_model):
+        gain_2d = gain_model.data
     else:
-        readnoise_2d = readnoise_model.data
-
-    if reffile_utils.is_subarray(model):
         log.info('Extracting gain subarray to match science data')
         gain_2d = reffile_utils.get_subarray_data(model, gain_model)
+
+    if reffile_utils.ref_matches_sci(model, readnoise_model):
+        readnoise_2d = readnoise_model.data
     else:
-        gain_2d = gain_model.data
+        log.info('Extracting readnoise subarray to match science data')
+        readnoise_2d = reffile_utils.get_subarray_data(model, readnoise_model)
 
     readnoise_2d *= gain_2d # convert read noise to correct units
 


### PR DESCRIPTION
Fleshed out some more library functions for handling subarray extractions from reference file data. Also updated many (all?) of the steps that had been using private routines to use the new library functions. I believe they include enough error checking to handle all the bad reference files still lurking in CRDS.

All steps first call the function `ref_matches_sci` to see if the reference data match the science data and, if so, just use the reference data directly. This is more appropriate than testing whether the science data are full-frame or subarray (via `is_subarray`), because there are cases where science data can be subarray and yet still have matching (subarray) reference files and hence no extraction is needed. They have to match in more than just size. They must have an exact match in terms of the indexes of the pixels contained in the subarray.

The steps then call either the `get_subarray_data` or `get_subarray_model` function. `get_subarray_data` extracts a subarray from only the `data` attribute of the reference file model and returns that extracted data array. The `get_subarray_model` function extracts a subarray from all array attributes contained in the reference file model, creates a new subarray-based reference file model using those arrays, and returns the new model.