### PR TITLE
Updates for gain_scale, including docs

### DIFF
--- a/docs/jwst/gain_scale/arguments.rst
+++ b/docs/jwst/gain_scale/arguments.rst
@@ -1,0 +1,4 @@
+Arguments
+=========
+
+The gain_scale correction has no step-specific arguments.

--- a/docs/jwst/gain_scale/description.rst
+++ b/docs/jwst/gain_scale/description.rst
@@ -36,5 +36,5 @@ header, which will cause the `gain_scale` step to be skipped. Alternatively,
 gain reference files for modes that use the standard gain can have
 `GAINFACT=1.0`, in which case the correction will be benign.
 
-Up successful completion of the step the `S_GANSCL' keyword in the
+Upon successful completion of the step, the `S_GANSCL` keyword in the
 science data will be set to "COMPLETE."

--- a/docs/jwst/gain_scale/description.rst
+++ b/docs/jwst/gain_scale/description.rst
@@ -1,0 +1,40 @@
+Description
+============
+
+The `gain_scale` step rescales pixel values in JWST countrate
+science data products in order to correct for the effect of using
+a non-standard detector gain setting. The countrate data are
+rescaled to make them appear as if they had been obtained using
+the standard gain setting.
+
+This currently only applies to NIRSpec exposures that are read out
+using a subarray pattern, in which case a gain setting of 2 is used
+instead of the standard setting of 1. Note that this only applies
+to NIRSpec subarray data obtained after April 2017, which is when
+the change was made in the instrument flight software to use gain=2.
+NIRSpec subarray data obtained previous to that time used the
+standard gain=1 setting.
+
+The `gain_scale` step is applied at the end of the `calwebb_detector1`
+pipeline, after the `ramp_fit` step has been applied. It is applied
+to both the `rate` and `rateints` products from `ramp_fit`, if both
+types of products were created. The science (`SCI`) and error (`ERR`)
+arrays are both rescaled.
+
+The scaling factor is obtained from the `GAINFACT` keyword in the
+header of the gain reference file. Normally the `ramp_fit` step will
+read that keyword value during its execution and store the value in
+the science data keyword `GAINFACT`, so that the gain reference file
+does not have to be loaded again by the `gain_scale` step. If, however,
+the step does not find that keyword populated in the science data, it
+will load the gain reference file to retreive it. If all attempts to
+find the scaling factor fail, the step will be skipped.
+
+Gain reference files for instruments or modes that use the standard
+gain setting will typically not have the `GAINFACT` keyword in their
+header, which will cause the `gain_scale` step to be skipped. Alternatively,
+gain reference files for modes that use the standard gain can have
+`GAINFACT=1.0`, in which case the correction will be benign.
+
+Up successful completion of the step the `S_GANSCL' keyword in the
+science data will be set to "COMPLETE."

--- a/docs/jwst/gain_scale/index.rst
+++ b/docs/jwst/gain_scale/index.rst
@@ -1,0 +1,13 @@
+=======================
+Gain Scale  Processing
+=======================
+
+.. toctree::
+   :maxdepth: 2
+
+   description.rst
+   arguments.rst
+   reference_files.rst
+
+.. automodapi:: jwst.gain_scale
+

--- a/docs/jwst/gain_scale/reference_files.rst
+++ b/docs/jwst/gain_scale/reference_files.rst
@@ -1,0 +1,10 @@
+Reference File
+==============
+
+The gain_scale correction step uses the gain reference file. The only purpose
+of the reference file is to retrieve the `GAINFACT` keyword value from its
+header (the reference file data are not used in any way). If the `ramp_fit`
+step, which also uses the gain reference file, succeeded in finding the
+`GAINFACT` keyword in this reference file, it will store the value in the
+`GAINFACT` keyword in the science data, in which case the `gain_scale` step
+will not reload the gain reference file.

--- a/docs/jwst/pipeline/description.rst
+++ b/docs/jwst/pipeline/description.rst
@@ -50,7 +50,7 @@ exposure at a time. The pipeline module for level-2a processing is
 often referred to as ``ramps-to-slopes`` processing, because the input raw data
 are in the form of one or more ramps (integrations) containing accumulating
 counts from the non-destructive detector readouts and the output is a corrected
-countrate (slope) image. The list of steps applied by the Build 7 calwebb_sloper
+countrate (slope) image. The list of steps applied by the Build 7.1 calwebb_sloper
 pipeline is as follows.
 
 ==============  ==============
@@ -64,10 +64,12 @@ ipc             ipc
 superbias       linearity
 refpix          rscd
 linearity       lastframe
-dark_current    dark_current
-\               refpix
+persistence     dark_current
+dark_current    refpix
+\               persistence
 jump            jump
 ramp_fit        ramp_fit
+gain_scale      gain_scale
 ==============  ==============
 
 Inputs

--- a/jwst/pipeline/calwebb_sloper.cfg
+++ b/jwst/pipeline/calwebb_sloper.cfg
@@ -29,3 +29,5 @@ save_calibrated_ramp = False
         config_file = jump.cfg
       [[ramp_fit]]
         config_file = ramp_fit.cfg
+      [[gain_scale]]
+        config_file = gain_scale.cfg

--- a/jwst/pipeline/calwebb_sloper.py
+++ b/jwst/pipeline/calwebb_sloper.py
@@ -112,10 +112,16 @@ class SloperPipeline(Pipeline):
             self.save_model(input, 'ramp')
 
         # apply the ramp_fit step
-        input = self.ramp_fit(input)
+        input, ints_model = self.ramp_fit(input)
 
-        # apply the gain_scale step
+        # apply the gain_scale step to the exposure-level product
         input = self.gain_scale(input)
+
+        # apply the gain scale step to the multi-integration product,
+        # if it exists, and then save it
+        if ints_model is not None:
+            ints_model = self.gain_scale(ints_model)
+            self.save_model(ints_model, 'rateints')
 
         # setup output_file for saving
         self.setup_output(input)

--- a/jwst/pipeline/gain_scale.cfg
+++ b/jwst/pipeline/gain_scale.cfg
@@ -1,0 +1,2 @@
+name = "gain_scale"
+class = "jwst.gain_scale.GainScaleStep"

--- a/jwst/pipeline/ramp_fit.cfg
+++ b/jwst/pipeline/ramp_fit.cfg
@@ -2,4 +2,3 @@ name = "RampFit"
 class = "jwst.ramp_fitting.RampFitStep"
 save_opt = False
 opt_name = ""
-int_name = ""


### PR DESCRIPTION
Several more updates related to the new gain_scale step.

- Added docs for the gain_scale step
- Updated the pipeline/calwebb_sloper docs to include gain_scale and persistence
- Added a gain_scale.cfg file and added an entry for it to the calwebb_sloper.cfg file
- Modified the ramp_fit step to no longer save the rateints model on its own, but rather return it (along with the rate product model) to the caller. This also means the ramp_fit step no longer applies gain_scale to the rateints model.
- Modified the calwebb_sloper pipeline to receive the rateints model from ramp_fit, apply the gain_scale step to both the rate and rateints models (if both exist), and save the rateints model to an output file

This new arrangement, which has the ramp_fit step return both the rate and rateints models, is a much cleaner flow. Ramp_fit now only saves the optional products that it's capable of creating.