### PR TITLE
Remove code that stores cube's WCS for background polynomials

### DIFF
--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -1634,12 +1634,6 @@ properties:
                   type: array
                   items:
                     type: number
-                cs_type:
-                  title: Type of coordinates
-                  type: string
-                  enum: [world, image]
-                wcs:
-                  $ref: http://stsci.edu/schemas/asdf/wcs/wcs-1.0.0
                 coefficients:
                   title: Polynomial Coefficients
                   type: array

--- a/jwst/mrs_imatch/mrs_imatch_step.py
+++ b/jwst/mrs_imatch/mrs_imatch_step.py
@@ -15,7 +15,6 @@ import numpy as np
 from .. stpipe import Step, cmdline
 from .. import datamodels
 from .. wiimatch.match import *
-from .. cube_build import CubeBuildStep
 
 try:
     from stsci.tools.bitmask import bitfield_to_boolean_mask
@@ -137,8 +136,6 @@ def _apply_sky_2d(model2d, channel):
     c = np.reshape(list(bkgmeta.coefficients), degree_p1)
     refpt = tuple(bkgmeta.refpoint)
 
-    cs_type = bkgmeta.cs_type
-
     # get pixel grid for sky computations:
     x, y = _get_2d_pixgrid(model2d, channel)
     x = x.ravel()
@@ -158,14 +155,6 @@ def _apply_sky_2d(model2d, channel):
     r = r[m]
     d = d[m]
     l = l[m]
-
-    if cs_type == "image":
-        raise ValueError("Polynomials must be defined in world CS in "
-                         "order to be able to perform sky subtraction "
-                         "on 2D DataModel.")
-
-    elif cs_type != "world":
-        raise ValueError("Unsupported background polynomial's 'cs_type'.")
 
     # compute background values:
     r -= refpt[0]
@@ -192,6 +181,8 @@ def _get_2d_pixgrid(model2d, channel):
 
 
 def _match_models(models, channel, degree, center=None, center_cs='image'):
+    from .. cube_build import CubeBuildStep
+
     # create a list of cubes:
     cbs = CubeBuildStep()
     cbs.channel = str(channel)
@@ -284,8 +275,6 @@ def _match_models(models, channel, degree, center=None, center_cs='image'):
             {
                 'degree': degree,
                 'refpoint': center,
-                'cs_type': 'world',
-                'wcs': wcs,
                 'coefficients': poly.ravel().tolist(),
                 'channel': channel
             }


### PR DESCRIPTION
It seems that models that have other WCSes in their meta currently cannot be serialized (reported by @jemorrison @nden and @drdavella). Since saving cube's WCS in input image's meta was a feature designed for the future, we can safely remove it until issues with schemas and asdf are ironed out and/or until there is an express need to save this WCS.