### PR TITLE
Make apply_background_2d a public function

### DIFF
--- a/jwst/mrs_imatch/mrs_imatch_step.py
+++ b/jwst/mrs_imatch/mrs_imatch_step.py
@@ -25,7 +25,7 @@ except ImportError:
     from stsci.tools.bitmask import interpret_bits_value as interpret_bit_flags
 
 
-__all__ = ['MRSIMatchStep']
+__all__ = ['MRSIMatchStep', 'apply_background_2d']
 
 
 class MRSIMatchStep(Step):


### PR DESCRIPTION
I have renamed ``_apply_sky_2d`` to ``apply_background_2d`` and made it a public function. I have also added the following functionality to it:

1. It can take a single channel, a list of several channels, or None. ``None`` indicates that background should be applied for all channels.

2. ``subtract`` parameter can be used to indicate that background be subtracted from data or added back.

CC: @hbushouse @jemorrison