### PR TITLE
Correct Level 2c filenames

### DIFF
--- a/jwst/outlier_detection/outlier_detection_scaled_step.py
+++ b/jwst/outlier_detection/outlier_detection_scaled_step.py
@@ -77,6 +77,9 @@ class OutlierDetectionScaledStep(Step):
                         **pars)
             step.do_detection()
 
+            for model in self.input_models:
+                model.meta.cal_step.outlier_detection = 'COMPLETE'
+
             return self.input_models
 
     def _build_reffile_container(self, reftype):

--- a/jwst/outlier_detection/outlier_detection_stack_step.py
+++ b/jwst/outlier_detection/outlier_detection_stack_step.py
@@ -84,6 +84,9 @@ class OutlierDetectionStackStep(Step):
                 reffiles=reffiles, **pars)
             step.do_detection()
 
+            for model in self.input_models:
+                model.meta.cal_step.outlier_detection = 'COMPLETE'
+
             return self.input_models
 
     def _build_reffile_container(self, reftype):

--- a/jwst/outlier_detection/outlier_detection_step.py
+++ b/jwst/outlier_detection/outlier_detection_step.py
@@ -76,6 +76,9 @@ class OutlierDetectionStep(Step):
                 reffiles=reffiles, **pars)
             step.do_detection()
 
+            for model in self.input_models:
+                model.meta.cal_step.outlier_detection = 'COMPLETE'
+
             return self.input_models
 
     def _build_reffile_container(self, reftype):

--- a/jwst/pipeline/calwebb_coron3.py
+++ b/jwst/pipeline/calwebb_coron3.py
@@ -16,10 +16,6 @@ from ..resample import resample_step
 
 __version__ = "0.7.1"
 
-# Define logging
-import logging
-log = logging.getLogger()
-log.setLevel(logging.DEBUG)
 
 class Coron3Pipeline(Pipeline):
     """
@@ -33,19 +29,21 @@ class Coron3Pipeline(Pipeline):
     """
 
     spec = """
+        suffix = string(default='i2d')
     """
 
     # Define aliases to steps
     step_defs = {'stack_refs': stack_refs_step.StackRefsStep,
                  'align_refs': align_refs_step.AlignRefsStep,
                  'klip': klip_step.KlipStep,
-                 'outlier_detection': outlier_detection_stack_step.OutlierDetectionStackStep,
+                 'outlier_detection':
+                     outlier_detection_stack_step.OutlierDetectionStackStep,
                  'resample': resample_step.ResampleStep
                  }
 
     def process(self, input):
 
-        log.info('Starting calwebb_coron3 ...')
+        self.log.info('Starting calwebb_coron3 ...')
 
         # Load the input association table
         with open(input, 'r') as input_fh:
@@ -60,13 +58,13 @@ class Coron3Pipeline(Pipeline):
 
         # Make sure we found some PSF and target members
         if len(psf_files) == 0:
-            log.error('No reference PSF members found in association table')
-            log.error('Calwebb_coron3 processing will be aborted')
+            self.log.error('No reference PSF members found in association table')
+            self.log.error('Calwebb_coron3 processing will be aborted')
             return
 
         if len(targ_files) == 0:
-            log.error('No science target members found in association table')
-            log.error('Calwebb_coron3 processing will be aborted')
+            self.log.error('No science target members found in association table')
+            self.log.error('Calwebb_coron3 processing will be aborted')
             return
 
         # Assemble all the input psf files into a single ModelContainer
@@ -76,15 +74,13 @@ class Coron3Pipeline(Pipeline):
             psf_models.append(psf_input)
             psf_input.close()
 
-        # Call the stack_refs step to stack all the PSF images into
-        # a single CubeModel
+        # Stack all the PSF images into a single CubeModel
         psf_stack = self.stack_refs(psf_models)
         psf_models.close()
 
         # Save the resulting PSF stack
-        output_file = mk_prodname(self.output_dir, prod['name'], 'psfstack')
-        log.info('Saving psfstack file %s', output_file)
-        psf_stack.save(output_file)
+        psf_stack.meta.filename = prod['name']
+        self.save_model(psf_stack, suffix='psfstack')
 
         # Call the sequence of steps align_refs, klip, and outlier_detection
         # once for each input target exposure
@@ -92,28 +88,23 @@ class Coron3Pipeline(Pipeline):
         for target_file in targ_files:
 
             # Call align_refs
-            log.debug('Calling align_refs for member %s', target_file)
+            self.log.debug('Calling align_refs for member %s', target_file)
             psf_aligned = self.align_refs(target_file, psf_stack)
 
             # Save the alignment results
-            filename = mk_filename(self.output_dir, target_file, 'psfalign')
-            log.info('Saving psfalign file %s', filename)
-            psf_aligned.save(filename)
+            self.save_model(psf_aligned, suffix='psfalign')
 
             # Call KLIP
-            log.debug('Calling klip for member %s', target_file)
-            #psf_sub, psf_fit = self.klip(target_file, psf_aligned)
+            self.log.debug('Calling klip for member %s', target_file)
             psf_sub = self.klip(target_file, psf_aligned)
             psf_aligned.close()
 
             # Save the psf subtraction results
-            filename = mk_filename(self.output_dir, target_file, 'psfsub')
-            log.info('Saving psfsub file %s', filename)
-            psf_sub.save(filename)
+            self.save_model(psf_sub, suffix='psfsub')
 
             # Create a ModelContainer of the psf_sub results to send to
             # outlier_detection
-            log.debug('Building ModelContainer of klip results')
+            self.log.debug('Building ModelContainer of klip results')
             target_models = datamodels.ModelContainer()
             for i in range(psf_sub.data.shape[0]):
                 image = datamodels.ImageModel(data=psf_sub.data[i],
@@ -125,15 +116,16 @@ class Coron3Pipeline(Pipeline):
             # Call outlier_detection
             target_models = self.outlier_detection(target_models)
 
-            # Create a level-2c output product
-            log.debug('Creating and saving Level-2C result')
-            lev2c_name = mk_filename(self.output_dir, target_file, 'calints-'+asn['asn_id'])
-            lev2c_model = psf_sub.copy()
-            # Update/replace L2B product DQ array with L2C results
-            for i in range(len(target_models)):
-                lev2c_model.dq[i] = target_models[i].dq
-            lev2c_model.meta.cal_step.outlier_detection = 'COMPLETE'
-            lev2c_model.save(lev2c_name)
+            # Create Level 2c products
+            if target_models[0].meta.cal_step.outlier_detection == 'COMPLETE':
+                self.log.info("Creating Level 2c output with updated DQ arrays...")
+                lev2c_model = psf_sub.copy()
+                # Replace Level 2b product DQ array with Level 2c DQ array
+                for i in range(len(target_models)):
+                    lev2c_model.dq[i] = target_models[i].dq
+                lev2c_model.meta.cal_step.outlier_detection = 'COMPLETE'
+                suffix_2c = '{}_{}'.format(asn['asn_id'], 'crfints')
+                self.save_model(lev2c_model, suffix=suffix_2c)
 
             # Append results from this target exposure to resample input model
             for i in range(len(target_models)):
@@ -143,101 +135,23 @@ class Coron3Pipeline(Pipeline):
         result = self.resample(resample_input)
 
         # TEMPORARY HACK UNTIL RESAMPLE IS VIABLE
-        log.warning('Creating fake resample results until step is available')
+        self.log.warning('Creating fake resample results until step is available')
         result = datamodels.DrizProductModel(data=resample_input[0].data,
                                              con=resample_input[0].dq,
                                              wht=resample_input[0].err)
         result.update(resample_input[0])
-        output_file = mk_prodname(self.output_dir, prod['name'], 'i2d')
-        log.debug('Blending metadata for {}'.format(output_file))
+
+        self.log.debug('Blending metadata for {}'.format(result.meta.filename))
         blend.blendfitsdata(targ_files, result)
+
         result.meta.asn.pool_name = asn['asn_pool']
         result.meta.asn.table_name = input
-        result.meta.cal_step.outlier_detection = 'COMPLETE'
-        result.meta.cal_step.resample = 'COMPLETE'
-        result.meta.model_type = 'DrizProductModel'
 
         # Save the final result
-        log.info('Saving final result to %s', output_file)
-        result.save(output_file)
-        result.close()
+        result.meta.filename = prod['name']
+        self.save_model(result, suffix=self.suffix)
 
         # We're done
-        log.info('... ending calwebb_coron3')
+        self.log.info('... ending calwebb_coron3')
 
         return
-
-
-def mk_filename(output_dir, filename, suffix):
-
-    """
-    Build a file name to use when saving results.
-
-    An existing input file name is used as a template. A user-specified
-    output directory path is prepended to the root of the input file name.
-    The last product type suffix contained in the input file name is
-    replaced with the specified new suffix. Any existing file name
-    extension (e.g. ".fits") is preserved.
-
-    Args:
-        output_dir (str): The output_dir requested by the user
-        filename (str): The input file name, to be reworked
-        suffix (str): The desired file type suffix for the new file name
-
-    Returns:
-        string: The new file name
-
-    Examples:
-        For output_dir='/my/path', filename='jw12345_nrca_cal.fits', and
-        suffix='i2d', the returned file name will be
-        '/my/path/jw12345_nrca_i2d.fits'
-    """
-
-    # If the user specified an output_dir, replace any existing
-    # path with output_dir
-    if output_dir is not None:
-        dirname, filename = os.path.split(filename)
-        filename = os.path.join(output_dir, filename)
-
-    # Now replace the existing suffix with the new one
-    base, ext = os.path.splitext(filename)
-    return base[:base.rfind('_')] + '_' + suffix + ext
-
-
-def mk_prodname(output_dir, filename, suffix):
-
-    """
-    Build a file name based on an ASN product name template.
-
-    The input ASN product name is used as a template. A user-specified
-    output directory path is prepended to the root of the product name.
-    The input product type suffix is appended to the root of the input
-    product name, preserving any existing file name extension
-    (e.g. ".fits").
-
-    Args:
-        output_dir (str): The output_dir requested by the user
-        filename (str): The input file name, to be reworked
-        suffix (str): The desired file type suffix for the new file name
-
-    Returns:
-        string: The new file name
-
-    Examples:
-        For output_dir='/my/path', filename='jw12345_nrca_cal.fits', and
-        suffix='i2d', the returned file name will be
-        '/my/path/jw12345_nrca_cal_i2d.fits'
-    """
-
-    # If the user specified an output_dir, replace any existing
-    # path with output_dir
-    if output_dir is not None:
-        dirname, filename = os.path.split(filename)
-        filename = os.path.join(output_dir, filename)
-
-    # Now append the new suffix to the root name, preserving
-    # any existing extension
-    base, ext = os.path.splitext(filename)
-    if len(ext) == 0:
-        ext = ".fits"
-    return base + '_' + suffix + ext

--- a/jwst/pipeline/calwebb_image3.py
+++ b/jwst/pipeline/calwebb_image3.py
@@ -60,13 +60,6 @@ class Image3Pipeline(Pipeline):
         is_container = isinstance(input_models, datamodels.ModelContainer)
         if is_container and len(input_models.group_names) > 1:
 
-            # Set up Level 2c suffix to be used later
-            suffix_2c_end = 'crf'
-            if isinstance(input_models[0], datamodels.CubeModel):
-                suffix_2c_end = 'crfints'
-            asn_id = input_models.meta.asn_table.asn_id
-            suffix_2c = '{}_{}'.format(asn_id, suffix_2c_end)
-
             self.log.info("Generating source catalogs for alignment...")
             input_models = self.tweakreg_catalog(input_models)
 
@@ -87,19 +80,29 @@ class Image3Pipeline(Pipeline):
             self.log.info("Performing outlier detection on input images...")
             input_models = self.outlier_detection(input_models)
 
-            self.log.info("Writing Level 2c images with updated DQ arrays...")
-            for model in input_models:
-                self.save_model(model, suffix=suffix_2c)
+            if input_models[0].meta.cal_step.outlier_detection == 'COMPLETE':
+                self.log.info("Writing Level 2c images with updated DQ arrays...")
+                # Set up Level 2c suffix to be used later
+                asn_id = input_models.meta.asn_table.asn_id
+                suffix_2c = '{}_{}'.format(asn_id, 'crf')
+                for model in input_models:
+                    self.save_model(model, suffix=suffix_2c)
 
-        self.log.info("Resampling images to final output...")
-        output = self.resample(input_models)
+        self.log.info("Resampling images to final result...")
+        result = self.resample(input_models)
 
-        product = input_models.meta.asn_table.products[0].name + '.fits'
-        output.meta.filename = product
-        self.save_model(output, suffix=self.suffix)
+        try:
+            result.meta.asn.pool_name = input_models.meta.asn_table.asn_pool
+            result.meta.asn.table_name = input
+        except:
+            pass
+
+        product = input_models.meta.asn_table.products[0].name
+        result.meta.filename = product
+        self.save_model(result, suffix=self.suffix)
 
         self.log.info("Creating source catalog...")
-        out_catalog = self.source_catalog(output)
+        out_catalog = self.source_catalog(result)
         # NOTE: source_catalog step writes out the catalog in .ecsv format
         # In the future it would be nice if it was returned to the pipeline,
         # and then written here.  A datamodel for .ecsv might be required.

--- a/jwst/pipeline/calwebb_tso3.py
+++ b/jwst/pipeline/calwebb_tso3.py
@@ -56,11 +56,7 @@ class Tso3Pipeline(Pipeline):
 
         self.log.info('Starting calwebb_tso3 ...')
         input_asn = datamodels.open(input)
-        product_name = input_asn.meta.asn_table.products[0].name
-
-        # Setup output creation
-        #self.output_basename = product['name']
-        self.output_basename = product_name
+        self.output_basename = input_asn.meta.asn_table.products[0].name
 
         input_exptype = None
         # Input may consist of multiple exposures, so loop over each of them
@@ -68,78 +64,77 @@ class Tso3Pipeline(Pipeline):
             if input_exptype is None:
                 input_exptype = cube.meta.exposure.type
             # Convert CubeModel into ModelContainer of 2-D DataModels
-            input_models = datamodels.ModelContainer()
+            input_asn = datamodels.ModelContainer()
             for i in range(cube.data.shape[0]):
                 # convert each plane of data cube into it own array
                 # for outlier detection...
                 image = datamodels.ImageModel(data=cube.data[i],
                         err=cube.err[i], dq=cube.dq[i])
                 image.meta = cube.meta
-                input_models.append(image)
+                input_asn.append(image)
 
             if not self.scale_detection:
                 self.log.info("Performing outlier detection on input images...")
-                results = self.outlier_detection(input_models)
+                results = self.outlier_detection(input_asn)
 
                 # Transfer updated DQ values to original input observation
                 for i in range(cube.data.shape[0]):
                     # preserve output filename
-                    orig_filename = cube.meta.filename
+                    original_filename = cube.meta.filename
                     # Update DQ arrays with those from outlier_detection step
                     cube.dq[i] = results[i].dq
-                    # reset output filename to original value
-                    cube.meta.filename = orig_filename
+                    cube.meta.filename = original_filename
 
             else:
                 self.log.info("Performing scaled outlier detection on input images...")
-                self.log.info("input cube has type: {}".format(type(cube)))
+                self.log.debug("input cube has type: {}".format(type(cube)))
                 cube = self.outlier_detection_scaled(cube)
 
 
-        self.log.info("Writing Level 2c images with updated DQ arrays...")
-        suffix_2c = 'crfints'
-        for cube in input_asn:
-            self.output_basename = cube.meta.filename
-            self.save_model(cube, suffix=suffix_2c)
+        if input_asn[0].meta.cal_step.outlier_detection == 'COMPLETE':
+            self.log.info("Writing Level 2c cubes with updated DQ arrays...")
+            suffix_2c = 'crfints'
+            for cube in input_asn:
+                self.save_model(cube, suffix=suffix_2c)
 
         # Create final photometry results as a single output
-        # regardless of how many members their may be...
+        # regardless of how many members there may be...
         phot_result_list = []
         if input_exptype in self.image_exptypes:
-            # Create name for extracted photometry (Level 3) products
-            phot_tab_name = "{}_phot.ecsv".format(product_name)
+            # Create name for extracted photometry (Level 3) product
+            phot_tab_name = "{}_phot.ecsv".format(self.output_basename)
 
-            # For each cube, extract photometry...
             for cube in input_asn:
                 # Extract Photometry from imaging data
                 phot_result_list.append(self.tso_photometry(cube))
         else:
+            # Create name for extracted white-light (Level 3) product
+            phot_tab_name = "{}_whtlt.ecsv".format(self.output_basename)
+
             # Working with spectroscopic TSO data...
             # define output for x1d (level 3) products
-            x1d_models = datamodels.MultiSpecModel()
-            x1d_models.update(input_asn)
-
-            # Create name for extracted white-light (Level 3) products
-            phot_tab_name = "{}_whtlt.ecsv".format(product_name)
+            x1d_result = datamodels.MultiSpecModel()
+            # TODO: check to make sure the following line is working
+            x1d_result.update(input_asn)
 
             # For each exposure in the TSO...
             for cube in input_asn:
                 # Process spectroscopic TSO data
                 # extract 1D
                 self.log.info("Extracting 1-D spectra...")
-                self.extract_1d.suffix = 'x1dints'
                 result = self.extract_1d(cube)
-                x1d_models.spec.extend(result.spec)
+                x1d_result.spec.extend(result.spec)
 
                 # perform white-light photometry on 1d extracted data
                 self.log.info("Performing white-light photometry...")
                 phot_result_list.append(self.white_light(result))
 
-            # Define suffix for stack of extracted 1d (level 3) products
-            #self.save_model(x1d_models,suffix="x1dints") # did not work!!!
-            x1d_prod_name = "{}_x1dints.fits".format(product_name)
-            self.log.info("Writing Level 3 X1DINTS product...")
-            x1d_models.write(x1d_prod_name)
+            # Update some metadata from the association
+            x1d_result.meta.asn.pool_name = asn['asn_pool']
+            x1d_result.meta.asn.table_name = input
+
+            # Save the final x1d Multispec model
+            self.save_model(x1d_result, suffix='x1dints')
 
         phot_results = vstack(phot_result_list)
         phot_results.write(phot_tab_name, format='ascii.ecsv')

--- a/jwst/stpipe/step.py
+++ b/jwst/stpipe/step.py
@@ -25,7 +25,7 @@ from .. import __version_commit__, __version__
 SUFFIX_LIST = [
     'rate', 'cal', 'uncal', 'i2d', 's2d', 's3d',
     'jump', 'ramp', 'x1d', 'x1dints', 'calints', 'rateints',
-    'crf', 'crfints'
+    'crf', 'crfints', 'psfsub', 'psfalign', 'psfstack'
 ]
 REMOVE_SUFFIX = '^(?P<root>.+?)((?P<separator>_|-)(' \
                 + '|'.join(SUFFIX_LIST) + '))?$'


### PR DESCRIPTION
Make filename suffixes `<ASN_ID>_crf` or `<ASN_ID>_crfints` to indicate cosmic-ray flagged 2c files.

- `outlier_detection_step` now updates to COMPLETE when finished
- the pipelines only write out 2c files if `meta.cal_step.outlier_detection` is COMPLETE
- calwebb_coron3 now uses `stpipe` `self.log` instead of importing logging separately
- the pipelines now use `stpipe` `self.save_model` to write out datamodel results.  This method has its own logging, so extra logging in the pipeline is not needed.
- remove `mk_filename` and `mk_prodname` from calwebb_coron3, this being replaced by the built-in `stpipe` infrastructure methods `save_model` and `output_basename`.
- add some extra suffixes to `stpipe` SUFFIX_LIST

Resolves #1159