### PR TITLE
Add validation to extend method

### DIFF
--- a/jwst/datamodels/properties.py
+++ b/jwst/datamodels/properties.py
@@ -378,6 +378,7 @@ class ListNode(Node):
     def extend(self, other):
         for part in _unmake_node(other):
             self.append(part)
+        self._validate()
 
     def item(self, **kwargs):
         assert isinstance(self._schema['items'], dict)


### PR DESCRIPTION
All methods which modify the metadata had calls to _validate, except extend. This was an oversight that this fix resolves.