### PR TITLE
Change creation date code

### DIFF
--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -282,9 +282,12 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         if isinstance(path, six.string_types):
             self.meta.filename = os.path.basename(path)
 
-        self.meta.date = Time(datetime.datetime.now())
-        self.meta.date.format = 'isot'
-        self.meta.date = self.meta.date.value
+        # self.meta.date = Time(datetime.datetime.now())
+        # self.meta.date.format = 'isot'
+        # self.meta.date = self.meta.date.value
+        current_date = Time(datetime.datetime.now()) # DBG
+        current_date.format = 'isot' ## DBG
+        self.meta.date = current_date.value # DBG
         self.meta.model_type = self.__class__.__name__
 
     def save(self, path, *args, **kwargs):

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -189,11 +189,10 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         
         # if the input model doesn't have a date set, use the current date/time
         if self.meta.date is None:
-            self.meta.date = Time(datetime.datetime.now())
-            if hasattr(self.meta.date, 'value'):
-                self.meta.date.format = 'isot'
-                self.meta.date = str(self.meta.date.value)
-
+            current_date = Time(datetime.datetime.now())
+            current_date.format = 'isot'
+            self.meta.date = current_date.value
+        
         # store the data model type, if not already set
         if hasattr(self.meta, 'model_type'):
             if self.meta.model_type is None:

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -282,12 +282,9 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         if isinstance(path, six.string_types):
             self.meta.filename = os.path.basename(path)
 
-        # self.meta.date = Time(datetime.datetime.now())
-        # self.meta.date.format = 'isot'
-        # self.meta.date = self.meta.date.value
-        current_date = Time(datetime.datetime.now()) # DBG
-        current_date.format = 'isot' ## DBG
-        self.meta.date = current_date.value # DBG
+        current_date = Time(datetime.datetime.now())
+        current_date.format = 'isot'
+        self.meta.date = current_date.value
         self.meta.model_type = self.__class__.__name__
 
     def save(self, path, *args, **kwargs):


### PR DESCRIPTION
Datamodels adds the creation date of a file into the metadata when saving it. The current code adds the date to the metadata and then updates the format. This assumes that saving to the metadata does not  change the format. It's safer to update the format of the date and then add it to the metadata.