### PR TITLE
Two arrays were the wrong size

### DIFF
--- a/jwst/pipeline/calwebb_tso3.py
+++ b/jwst/pipeline/calwebb_tso3.py
@@ -91,7 +91,8 @@ class Tso3Pipeline(Pipeline):
                     cube.meta.filename = orig_filename
 
             else:
-                self.log.info("Performing scaled outlier detection on input images...")
+                self.log.info("Performing scaled outlier detection "
+                              "on input images...")
                 self.log.info("input cube has type: {}".format(type(cube)))
                 cube = self.outlier_detection_scaled(cube)
 


### PR DESCRIPTION
The var_p_2d and var_r_2d arrays were too large.  Their allocation has been moved to within a loop over sections.
Some calling sequences have been simplified by eliminating variables that were never reference and by removing some variables from the tuple that is returned.