### PR TITLE
Update ami3

### DIFF
--- a/jwst/pipeline/calwebb_ami3.py
+++ b/jwst/pipeline/calwebb_ami3.py
@@ -10,7 +10,7 @@ from .. import datamodels
 from ..ami import ami_analyze_step
 from ..ami import ami_average_step
 from ..ami import ami_normalize_step
-
+from ..resample import blend
 
 __version__ = "1.2"
 
@@ -112,6 +112,11 @@ class Ami3Pipeline(Pipeline):
                 targ_avg.meta.asn.table_name = asn.filename
                 output_file = mk_prodname(self.output_dir, prod['name'], 'amiavg')
                 self.log.info('Saving averaged target results to %s', output_file)
+
+                # Perform blending of metadata for all inputs to this output file
+                log.debug('Blending metadata for {}'.format(output_file))
+                blend.blendfitsdata(targ_files, result)
+               
                 targ_avg.save(output_file)
 
         # Now that all LGAVG products have been produced, do normalization of
@@ -125,6 +130,11 @@ class Ami3Pipeline(Pipeline):
             result.meta.asn.table_name = asn.filename
             output_file = mk_prodname(self.output_dir, prod['name'], 'aminorm')
             self.log.info('Saving normalized result to %s', output_file)
+            
+            # Perform blending of metadata for all inputs to this output file
+            log.debug('Blending metadata for {}'.format(output_file))
+            blend.blendfitsdata([targ_avg, psf_avg], result)
+
             result.save(output_file)
             result.close()
 

--- a/jwst/pipeline/calwebb_ami3.py
+++ b/jwst/pipeline/calwebb_ami3.py
@@ -97,9 +97,13 @@ class Ami3Pipeline(Pipeline):
             if self.save_averages:
                 psf_avg.meta.asn.pool_name = asn['asn_pool']
                 psf_avg.meta.asn.table_name = asn.filename
-                output_file = mk_prodname(self.output_dir, prod['psf_name'], 'amiavg')
-                self.log.info('Saving averaged PSF results to %s', output_file)
-                psf_avg.save(output_file)
+                psf_avg_output_file = mk_prodname(self.output_dir, prod['psf_name'], 'amiavg')
+                self.log.info('Saving averaged PSF results to %s', psf_avg_output_file)
+                # Perform blending of metadata for all inputs to this output file
+                self.log.info('Blending metadata for averaged target {}'.format(psf_avg_output_file))
+                blend.blendfitsdata(psf_files, psf_avg)
+
+                psf_avg.save(psf_avg_output_file)
 
         # Average the science target image results
         if len(targ_files) > 0:
@@ -110,14 +114,16 @@ class Ami3Pipeline(Pipeline):
             if self.save_averages:
                 targ_avg.meta.asn.pool_name = asn['asn_pool']
                 targ_avg.meta.asn.table_name = asn.filename
-                output_file = mk_prodname(self.output_dir, prod['name'], 'amiavg')
-                self.log.info('Saving averaged target results to %s', output_file)
-
+                targ_avg_output_file = mk_prodname(self.output_dir, prod['name'], 'amiavg')
+                
                 # Perform blending of metadata for all inputs to this output file
-                log.debug('Blending metadata for {}'.format(output_file))
-                blend.blendfitsdata(targ_files, result)
-               
-                targ_avg.save(output_file)
+                self.log.info('Blending metadata for averaged target {}'.format(targ_avg_output_file))
+                blend.blendfitsdata(targ_files, targ_avg)
+                
+                self.log.info('Saving averaged target results to %s', targ_avg_output_file)
+                targ_avg.save(targ_avg_output_file)
+                
+
 
         # Now that all LGAVG products have been produced, do normalization of
         # the target results by the reference results, if reference results exist
@@ -128,14 +134,14 @@ class Ami3Pipeline(Pipeline):
             # Save the result
             result.meta.asn.pool_name = asn['asn_pool']
             result.meta.asn.table_name = asn.filename
-            output_file = mk_prodname(self.output_dir, prod['name'], 'aminorm')
-            self.log.info('Saving normalized result to %s', output_file)
+            targ_norm_output_file = mk_prodname(self.output_dir, prod['name'], 'aminorm')
             
             # Perform blending of metadata for all inputs to this output file
-            log.debug('Blending metadata for {}'.format(output_file))
-            blend.blendfitsdata([targ_avg, psf_avg], result)
+            self.log.info('Blending metadata for PSF normalized target {}'.format(targ_norm_output_file))
+            blend.blendfitsdata([targ_avg_output_file, psf_avg_output_file], result)
 
-            result.save(output_file)
+            self.log.info('Saving normalized result to %s', targ_norm_output_file)
+            result.save(targ_norm_output_file)
             result.close()
 
         # We're done

--- a/jwst/resample/blend.py
+++ b/jwst/resample/blend.py
@@ -27,6 +27,12 @@ def blendfitsdata(input_list, output_model):
     # start by building dict which maps all FITS keywords in schema to their 
     # attribute in the schema
     fits_dict = schema.build_fits_dict(output_model.schema)
+    # Need to insure that output_model does not already have an instance
+    # of hdrtab from previous processing, an instance that would be
+    # incompatible with the new table generated now...
+    if hasattr(output_model,'hdrtab'):
+        # If found, remove it to be replaced by new instance
+        del output_model.hdrtab
     # Now assign values from new_hdrs to output_model.meta using fits_dict map
     for hdr in new_hdrs:
         for kw in hdr:
@@ -35,6 +41,7 @@ def blendfitsdata(input_list, output_model):
 
     # Now, append HDRTAB as new element in datamodel
     new_schema = build_tab_schema(new_table)
+
     output_model.add_schema_entry('hdrtab', new_schema)
     output_model.hdrtab = fits_support.from_fits_hdu(new_table, new_schema)
         
@@ -68,6 +75,14 @@ def blendmetadata(input_models, output_model):
     # start by building dict which maps all FITS keywords in schema to their
     # attribute in the schema
     fits_dict = schema.build_fits_dict(output_model.schema)
+
+    # Need to insure that output_model does not already have an instance
+    # of hdrtab from previous processing, an instance that would be
+    # incompatible with the new table generated now...
+    if hasattr(output_model,'hdrtab'):
+        # If found, remove it to be replaced by new instance
+        del output_model.hdrtab
+
     # Now assign values from new_hdrs to output_model.meta using fits_dict map
     for hdr in new_hdrs:
         for kw in hdr:


### PR DESCRIPTION
These updates implement blended headers for the Level 3 products generated by the `Ami3Pipeline`.  Specifically, the averaged target product with the `_amiavg` suffix, and the PSF normalized target product with the `_aminorm` suffix have been processed with `blendheaders`.  

This required an update to the `blendfitsdata()` function in `resample.blend` in order to correctly combine products which already have blended headers from previous processing steps.