### PR TITLE
Bump minversion of pytest to 3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ select = E101,W191,W291,W292,W293,W391,E111,E112,E113,E901,E902,E101,W191,W291,W
 exclude = extern,sphinx,*parsetab.py
 
 [tool:pytest]
-minversion = 2.2
+minversion = 3
 addopts = --ignore=build
 norecursedirs = build docs/_build relic
 


### PR DESCRIPTION
`[tool:pytest]` is a `pytest` 3 feature.