### PR TITLE
Add crds context test check

### DIFF
--- a/jwst/pipeline/tests/helpers.py
+++ b/jwst/pipeline/tests/helpers.py
@@ -11,6 +11,7 @@ import tempfile
 from ...tests.helpers import (
     abspath,
     require_bigdata,
+    require_crds_context,
     runslow,
 )
 

--- a/jwst/pipeline/tests/test_calwebb_spec2_nrs_msa.py
+++ b/jwst/pipeline/tests/test_calwebb_spec2_nrs_msa.py
@@ -1,6 +1,7 @@
 """Test calwebb_spec2 for NIRSpec MSA"""
 
 from os import path
+import pytest
 from shutil import copy as file_copy
 
 from .helpers import (
@@ -8,6 +9,7 @@ from .helpers import (
     abspath,
     mk_tmp_dirs,
     require_bigdata,
+    require_crds_context,
     runslow,
     update_asn_basedir,
 )
@@ -20,6 +22,7 @@ DATAPATH = abspath(
 )
 
 
+@require_crds_context(365)
 @runslow
 @require_bigdata
 def test_run_msaflagging(mk_tmp_dirs, caplog):

--- a/jwst/tests/helpers.py
+++ b/jwst/tests/helpers.py
@@ -3,6 +3,9 @@
 import os
 from os import path
 import pytest
+import re
+
+import crds
 
 
 def abspath(filepath):
@@ -29,6 +32,30 @@ not_under_travis = pytest.mark.skipif(
     "TRAVIS" in os.environ and os.environ["TRAVIS"] == "true",
     reason='Temporarily disable due to performance issues'
 )
+
+
+# Decorator to skip if CRDS_CONTEXT is not at lest a certain level.
+def require_crds_context(required_context):
+    """Ensure CRDS context is a certain level
+
+    Parameters
+    ----------
+    level: int
+        The minimal level required
+
+    Returns
+    -------
+    pytest.mark.skipif decorator
+    """
+    current_context_string = crds.get_context_name('jwst')
+    match = re.match('jwst_(\d\d\d\d)\.pmap', current_context_string)
+    current_context = int(match.group(1))
+    return pytest.mark.skipif(
+        current_context < required_context,
+        reason='CRDS context {} less than required context {}'.format(
+            current_context_string, required_context
+        )
+    )
 
 
 # Check strings based on words using length precision


### PR DESCRIPTION
New testing helper decorator `require_crds_context` for tests the require a certain level of crds context.