### PR TITLE
Fix bug in Step where ModelContainer meta.ref_file wasn't handled

### DIFF
--- a/jwst/stpipe/step.py
+++ b/jwst/stpipe/step.py
@@ -386,12 +386,12 @@ class Step(object):
             result_return = result
 
             # Update meta information
-            if not isinstance(result, (list, tuple)):
+            if not isinstance(result, (list, tuple, datamodels.ModelContainer)):
                 results = [result]
             else:
                 results = result
 
-            if len(self._reference_files_used) and not self._is_container(args[0]):
+            if len(self._reference_files_used):
                 for result in results:
                     if isinstance(result, datamodels.DataModel):
                         for ref_name, filename in self._reference_files_used:


### PR DESCRIPTION
Fixes a bug in the Step corner case where input is a single `DataModel` but output is a `ModelContainer`.  Now each member of `ModelContainer` result has its `meta.ref_file` updated with the step-specific reference files when the step finishes.

Resolves #1217.