### PR TITLE
Define intermediate product outputs correctly

### DIFF
--- a/jwst/outlier_detection/outlier_detection.py
+++ b/jwst/outlier_detection/outlier_detection.py
@@ -119,10 +119,10 @@ class OutlierDetection(object):
             sdriz.do_drizzle(**pars)
             drizzled_models = sdriz.output_models
             for model in drizzled_models:
-                model.meta.filename += ".fits"
-            if save_intermediate_results:
-                log.info("Writing out resampled exposures...")
-                drizzled_models.save()
+                model.meta.filename += "_i2d.fits"
+                if save_intermediate_results:
+                    log.info("Writing out resampled exposures...")
+                    model.save(model.meta.filename)
         else:
             drizzled_models = self.input_models
             for i in range(len(self.input_models)):
@@ -147,8 +147,9 @@ class OutlierDetection(object):
             # the original input list/ASN/ModelContainer
             blot_models = blot_median(median_model, self.input_models, **pars)
             if save_intermediate_results:
-                log.info("Writing out BLOT images...")
-                blot_models.save()
+                for model in blot_models:
+                    log.info("Writing out BLOT images...")
+                    model.save(model.meta.filename)
         else:
             # Median image will serve as blot image
             blot_models = datamodels.ModelContainer()


### PR DESCRIPTION
This set of changes defines correct output names (or at least full FITS filenames) for the intermediate products generated by the outlier_detection step.  It then writes them out to disk for as requested by the user.  

The use of `model.save()` was necessary since the `outlier_detection` class was not a sub-class of `Step`, and therefore did not have access to the `step.save_model()` method used elsewhere.  It also was not entirely appropriate, since these products are not officially supported/defined by the association naming rules anyway.  

This should address #1221.
