### PR TITLE
Fix DQ flagging for jump step

### DIFF
--- a/jwst/jump/twopoint_difference.py
+++ b/jwst/jump/twopoint_difference.py
@@ -43,7 +43,8 @@ def find_CRs(data, gdq, read_noise, rej_threshold, nframes):
 
     # Reset saturated values in input data array to NaN, so they don't get
     # used in any of the subsequent calculations
-    data[gdq == dqflags.group['SATURATED']] = np.NaN
+    wh_sat = np.where(np.bitwise_and(gdq, dqflags.group['SATURATED']))
+    data[wh_sat] = np.NaN
 
     # Loop over multiple integrations
     for integration in range(nints):

--- a/jwst/lastframe/lastframe_sub.py
+++ b/jwst/lastframe/lastframe_sub.py
@@ -39,7 +39,8 @@ def do_correction(input_model):
     # Update the step status, and if ngroups > 1, set all of the GROUPDQ in
     # the final group to 'DO_NOT_USE'
     if sci_ngroups > 1:
-        output.groupdq[:, -1, :, :] = dqflags.group['DO_NOT_USE']
+        output.groupdq[:, -1, :, :] = \
+            np.bitwise_or(output.groupdq[:,-1,:,:], dqflags.group['DO_NOT_USE'])
         log.debug("LastFrame Sub: resetting GROUPDQ in last frame to DO_NOT_USE")
         output.meta.cal_step.lastframe = 'COMPLETE'
     else:   # too few groups


### PR DESCRIPTION
MIRI team members reported oddities in slope results from ramp_fit step, which have been traced back to problems with flagging and jump detection in the jump step. These updates fix the MIRI lastframe step so that it merges (bitwise-or) the DO_NOT_USE dq flag with any other existing dq flags, rather than just setting the DQ value equal to DO_NOT_USE (so that SATURATION flags set earlier don't get wiped out) and also updates the twopoint-difference jump detection method to look for SATURATION flags as part of other flags.

Mike Regan is working on other fixes to the twopoint-difference method that address more substantial problems with how the algorithm handles saturated pixels in general.