### PR TITLE
compute nshutters from shutter_state

### DIFF
--- a/jwst/assign_wcs/util.py
+++ b/jwst/assign_wcs/util.py
@@ -424,3 +424,19 @@ def create_grism_objects(input_model, reference_files, mmag_extract=99.0):
                                              decmax=obj.decmax))
 
     return grism_objects
+
+
+def get_num_msa_open_shutters(shutter_state):
+    """
+    Return the number of open shutters in a slitlet.
+
+    Parameters
+    ----------
+    shutter_state : str
+        ``Slit.shutter_state`` attribute - a combination of
+        ``1`` - open shutter, ``0`` - closed shutter, ``x`` - main shutter.
+    """
+    num = shutter_state.count('1')
+    if 'x' in shutter_state:
+        num += 1
+    return num

--- a/jwst/datamodels/schemas/multiproduct.schema.yaml
+++ b/jwst/datamodels/schemas/multiproduct.schema.yaml
@@ -101,10 +101,10 @@ allOf:
               default: 0.0
               fits_keyword: SRCYPOS
               fits_hdu: SCI
-            nshutters:
-              title: Number of open shutters
-              type: integer
-              default: 0
-              fits_keyword: NSHUT
+            shutter_state:
+              title: All (open and close) shutters in a slit
+              type: string
+              default: ""
+              fits_keyword: SHUTSTA
               fits_hdu: SCI
 $schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/multispec.schema.yaml
+++ b/jwst/datamodels/schemas/multispec.schema.yaml
@@ -77,11 +77,11 @@ allOf:
             default: 0.0
             fits_keyword: SRCYPOS
             fits_hdu: EXTRACT1D
-          nshutters:
-            title: Number of open shutters
-            type: integer
-            default: 0
-            fits_keyword: NSHUT
+          shutter_state:
+            title: All (open and close) shutters in a slit
+            type: string
+            default: ""
+            fits_keyword: SHUTSTA
             fits_hdu: EXTRACT1D
           slit_ra:
             title: Right ascension (deg) at middle of slit

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -1243,8 +1243,8 @@ def copy_keyword_info(slit, slitname, spec):
     if "source_ypos" in slit:
         spec.source_ypos = slit.source_ypos
 
-    if "nshutters" in slit:
-        spec.nshutters = slit.nshutters
+    if "shutter_state" in slit:
+        spec.shutter_state = slit.shutter_state
 
 
 def extract_one_slit(input_model, slit, integ, **extract_params):

--- a/jwst/msaflagopen/msaflag_open.py
+++ b/jwst/msaflagopen/msaflag_open.py
@@ -158,7 +158,7 @@ def boundingbox_to_indices(data_model, bounding_box):
 def wcs_to_dq(wcs_array, FLAG):
     #
     # Convert one of the arrays in the wcs_array tuple to a DQ array,
-    # which has zeros everywhere the wcs array has the value NaN, and 
+    # which has zeros everywhere the wcs array has the value NaN, and
     # has the value FLAG everywhere the wcs array is not NaN
     dq = np.zeros((wcs_array[0].shape), dtype=np.uint32)
     non_nan = np.where(~np.isnan(wcs_array[0]))
@@ -186,23 +186,24 @@ def get_failed_open_shutters(shutter_refname):
 def create_slitlets(input_model, shutter_refname):
     """
     A slitlet looks like this:
-    
+
     slitlets : list
         A list of slitlets. Each slitlet is a named tuple with
-        ("name", "shutter_id", "xcen", "ycen", "ymin", "ymax", "quadrant", "source_id", "nshutters")
+        ("name", "shutter_id", "xcen", "ycen", "ymin", "ymax", "quadrant",
+        "source_id", "shutter_state")
 
     A slit is:
-    
+
     Slit = namedtuple('Slit', ["name", "shutter_id", "xcen", "ycen",
-                           "ymin", "ymax", "quadrant", "source_id", "nshutters",
+                           "ymin", "ymax", "quadrant", "source_id", "shutter_state",
                            "source_name", "source_alias", "stellarity",
                            "source_xpos", "source_ypos"])
     "shutter_id" is an integer that uniquely defines the shutter in the quadrant, it is calculated
-    from the x and y using the function 
-    Slit.__new__.__defaults__= ("", 0, 0.0, 0.0, 0.0, 0.0, 0, 0, 0, "", "", 0.0, 0.0, 0.0)
+    from the x and y using the function
+    Slit.__new__.__defaults__= ("", 0, 0.0, 0.0, 0.0, 0.0, 0, 0, "", "", "", 0.0, 0.0, 0.0)
 
     The only ones that matter are "name" (must be unique), xcen, ycen, quadrant (from msaoper
-    file), ymin, ymax (should be -0.5, 0.5), nshutters (should be 1) 
+    file), ymin, ymax (should be -0.5, 0.5), nshutters (should be 1)
     """
 
     failedopenlist = get_failed_open_shutters(shutter_refname)

--- a/jwst/pathloss/path_loss.py
+++ b/jwst/pathloss/path_loss.py
@@ -7,7 +7,7 @@ from __future__ import division
 import numpy as np
 import logging
 from .. import datamodels
-from jwst.assign_wcs import nirspec
+from jwst.assign_wcs import nirspec, util
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
@@ -82,7 +82,7 @@ def calculate_pathloss_vector(pathloss_refdata, pathloss_wcs, xcenter, ycenter):
     The y-center of the target (-0.5 to 0.5)
 
     """
-    
+
     wavesize = pathloss_refdata.shape[0]
     wavelength = np.zeros(wavesize, dtype=np.float32)
     #
@@ -91,7 +91,7 @@ def calculate_pathloss_vector(pathloss_refdata, pathloss_wcs, xcenter, ycenter):
     if len(pathloss_refdata.shape) == 1:
         crpix1 = pathloss_wcs.crpix1
         crval1 = pathloss_wcs.crval1
-        cdelt1 = pathloss_wcs.cdelt1    
+        cdelt1 = pathloss_wcs.cdelt1
         for i in np.arange(wavesize):
             wavelength[i] = crval1 +(float(i) - crpix1)*cdelt1
         return wavelength, pathloss_refdata
@@ -101,7 +101,7 @@ def calculate_pathloss_vector(pathloss_refdata, pathloss_wcs, xcenter, ycenter):
     else:
         crpix3 = pathloss_wcs.crpix3
         crval3 = pathloss_wcs.crval3
-        cdelt3 = pathloss_wcs.cdelt3    
+        cdelt3 = pathloss_wcs.cdelt3
         for i in np.arange(wavesize):
             wavelength[i] = crval3 +(float(i) - crpix3)*cdelt3
         # Calculate python index of object center
@@ -164,7 +164,8 @@ def do_correction(input_model, pathloss_model):
                 # Calculate the 1-d wavelength and pathloss vectors
                 # for the source position
                 # Get the aperture from the reference file that matches the slit
-                aperture = getApertureFromModel(pathloss_model, slit.nshutters)
+                nshutters = util.get_num_msa_open_shutters(slit.shutter_state)
+                aperture = getApertureFromModel(pathloss_model, nshutters)
                 if aperture is not None:
                     wavelength_pointsource, pathloss_pointsource_vector = \
                         calculate_pathloss_vector(aperture.pointsource_data,
@@ -184,7 +185,7 @@ def do_correction(input_model, pathloss_model):
                     slit.pathloss_uniformsource = pathloss_uniform_vector
                     slit.wavelength_uniformsource = wavelength_uniformsource
                 else:
-                    log.warning("Cannot find matching pathloss model for slit with size %d" % slit.nshutters)
+                    log.warning("Cannot find matching pathloss model for slit with size %d" % nshutters)
                     continue
         input_model.meta.cal_step.pathloss = 'COMPLETE'
     elif exp_type in ['NRS_FIXEDSLIT', 'NRS_BRIGHTOBJ']:
@@ -245,5 +246,5 @@ def do_correction(input_model, pathloss_model):
         input_model.wavelength_uniformsource = wavelength_uniformsource
         input_model.pathloss_uniformsource = pathloss_uniform_vector
         input_model.meta.cal_step.pathloss = 'COMPLETE'
-            
+
     return input_model.copy()

--- a/jwst/resample/resample_spec.py
+++ b/jwst/resample/resample_spec.py
@@ -1,4 +1,4 @@
-from __future__ import (division, print_function, unicode_literals, 
+from __future__ import (division, print_function, unicode_literals,
     absolute_import)
 
 import time
@@ -470,7 +470,7 @@ class ResampleSpecData(object):
                 for attr in ['name', 'xstart', 'xsize', 'ystart', 'ysize',
                     'slitlet_id', 'source_id', 'source_name', 'source_alias',
                     'stellarity', 'source_type', 'source_xpos', 'source_ypos',
-                    'nshutters', 'relsens']:
+                    'shutter_state', 'relsens']:
                     if hasattr(img, attr):
                         setattr(output_model, attr, getattr(img, attr))
             except:

--- a/jwst/transforms/models.py
+++ b/jwst/transforms/models.py
@@ -622,7 +622,8 @@ class Gwa2Slit(Model):
         open slits
         a slit is a namedtupe
         Slit("name", "shutter_id", "xcen", "ycen", "ymin", "ymax",
-             "quadrant", "source_id", "nshutters")
+             "quadrant", "source_id", "shutter_state", "source_name",
+             "source_alias", "stellarity", "source_xpos", "source_ypos"])
     models : list
         an instance of `~astropy.modeling.core.Model`
     """
@@ -666,7 +667,8 @@ class Slit2Msa(Model):
         open slits
         a slit is a namedtupe
         Slit("name", "shutter_id", "xcen", "ycen", "ymin", "ymax",
-             "quadrant", "source_id", "nshutters")
+             "quadrant", "source_id", "shutter_state", "source_name",
+             "source_alias", "stellarity", "source_xpos", "source_ypos")
     models : list
         an instance of `~astropy.modeling.core.Model`
     """


### PR DESCRIPTION
#1214 removes the `Slit.nshutters` attribute and adds `Slit.shutter_state` which is a string combination of `1` - open shutter, `0` - closed shutter, and `x` - main shutter.

This is a follow up PR which adds a function to compute the number of open shutters in a slitlet, `nshutters`, from `Slit.shutter_state` and uses that number in all steps which reference `nshutters` - `resample`, `pathloss`, `msaflagopen`, `extract1d`.