### PR TITLE
Updates for NIRISS WFSS WCS

### DIFF
--- a/jwst/assign_wcs/util.py
+++ b/jwst/assign_wcs/util.py
@@ -363,7 +363,9 @@ def create_grism_bbox(input_model, reference_files, mmag_extract=99.0):
     for each object. The name of the catalog has been stored in the input models meta
     information under the source_catalog key.
 
-    Consider vectorizing this whole function 
+    It's left to the calling routine to cut the bounding boxes at the extent of the 
+    detector (for example, extract 2d would only extract the on-detector portion of
+    the bounding box)
     """
 
     # get the filter that was used with the observation

--- a/jwst/assign_wcs/util.py
+++ b/jwst/assign_wcs/util.py
@@ -327,6 +327,13 @@ def get_object_info(catalog_name=''):
         print("Problem validating object catalog column {0:s}: {1}"
               .format(catalog_name, e))
 
+    # The columns are named sky_bbox_ll, sky_bbox_ul, sky_bbox_lr, and sky_bbox_ur, each of
+    # which is a SkyCoord (i.e. RA & Dec & frame) at one corner of the minimal bounding box.
+    # There will also be a sky_bbox property as a 4-tuple of SkyCoord, but that is not
+    # serializable (hence, the four separate columns). This is not yet merged in photutils
+    # -- I discovered some bugs with SkyCoord and serialization, some of which have just been
+    # fixed in astropy.
+
     for row in catalog:
         objects.append(SkyObject(sid=row['id'],
                                  xcentroid=row['xcentroid'],
@@ -335,10 +342,10 @@ def get_object_info(catalog_name=''):
                                  dec_icrs_centroid=row['dec_icrs_centroid'],
                                  abmag=row['abmag'],
                                  abmag_error=row['abmag_error'],
-                                 ramin=row['ramin'],
-                                 decmin=row['decmin'],
-                                 ramax=row['ramax'],
-                                 decmax=row['decmax'],
+                                 box_ll=row['sky_bbox_ll'],
+                                 box_lr=row['sky_bbox_lr'],
+                                 box_ul=row['sky_bbox_ul'],
+                                 box_ur=row['sky_bbox_ur'],
                                  )
                        )
     return objects

--- a/jwst/lib/catalog_utils.py
+++ b/jwst/lib/catalog_utils.py
@@ -79,14 +79,14 @@ def replace_suffix_ext(filename, old_suffix_list, new_suffix,
 class SkyObject(namedtuple('SkyObject', ("sid",
                                          "xcentroid",
                                          "ycentroid",
-                                         "ra_icrs_centroid",
-                                         "dec_icrs_centroid",
+                                         "icrs_centroid",
                                          "abmag",
                                          "abmag_error",
-                                         "ramin",
-                                         "decmin",
-                                         "ramax",
-                                         "decmax"), rename=False)):
+                                         "sky_bbox_ll",
+                                         "sky_bbox_lr",
+                                         "sky_bbox_ul",
+                                         "sky_bbox_ur",
+                                         ), rename=False)):
 
     """ Sky Object
 
@@ -97,54 +97,51 @@ class SkyObject(namedtuple('SkyObject', ("sid",
     the minimum information needed by the WFSS modes in nircam and niriss.
     """
 
-    __slots__ = ()  # prevent instance dictionary creation for low mem
+    __slots__ = ()  # prevent instance dictionary creation for lower mem
 
     def __new__(cls, sid=None,
                      xcentroid=None,
                      ycentroid=None,
-                     ra_icrs_centroid=None,
-                     dec_icrs_centroid=None,
+                     icrs_centroid=None,
                      abmag=None,
                      abmag_error=None,
-                     ramin=None,
-                     decmin=None,
-                     ramax=None,
-                     decmax=None):
+                     sky_bbox_ll=None,
+                     sky_bbox_lr=None,
+                     sky_bbox_ul=None,
+                     sky_bbox_ur=None):
 
         return super(SkyObject, cls).__new__(cls,
-                                             sid,
-                                             xcentroid,
-                                             ycentroid,
-                                             ra_icrs_centroid,
-                                             dec_icrs_centroid,
-                                             abmag,
-                                             abmag_error,
-                                             ramin,
-                                             decmin,
-                                             ramax,
-                                             decmax)
+                                             sid=sid,
+                                             xcentroid=xcentroid,
+                                             ycentroid=ycentroid,
+                                             icrs_centroid=icrs_centroid,
+                                             abmag=abmag,
+                                             abmag_error=abmag_error,
+                                             sky_bbox_ll=sky_bbox_ll,
+                                             sky_bbox_lr=sky_bbox_lr,
+                                             sky_bbox_ul=sky_bbox_ul,
+                                             sky_bbox_ur=sky_bbox_ur)
 
     def __str__(self):
         """Return a pretty print for the object information."""
         return ("id: {0}\n"
                 "xcentroid: {1}\n"
                 "ycentroid: {2}\n"
-                "ra_icrs_centroid: {3}\n"
-                "dec_icrs_centroid: {4}\n"
-                "abmag: {5}\n"
-                "abmag_error: {6}\n"
-                "ramin: {7}\n"
-                "decmin: {8}\n"
-                "ramax: {9}\n"
-                "decmax: {10}\n"
+                "icrs_centroid: {3}\n"
+                "abmag: {4}\n"
+                "abmag_error: {5}\n"
+                "sky_bbox_ll: {6}\n"
+                "sky_bbox_lr: {7}\n"
+                "sky_bbox_ul: {8}\n"
+                "sky_bbox_ur: {9}\n"
                 .format(self.sid,
                         self.xcentroid,
                         self.ycentroid,
-                        self.ra_icrs_centroid,
-                        self.dec_icrs_centroid,
+                        str(self.icrs_centroid),
                         self.abmag,
                         self.abmag_error,
-                        self.ramin,
-                        self.decmin,
-                        self.ramax,
-                        self.decmax))
+                        str(self.sky_bbox_ll),
+                        str(self.sky_bbox_lr),
+                        str(self.sky_bbox_ul),
+                        str(self.sky_bbox_ur)))
+        

--- a/jwst/transforms/models.py
+++ b/jwst/transforms/models.py
@@ -63,7 +63,7 @@ class GrismObject(namedtuple('GrismObject', ("sid",
 
     order_bounding is stored as a lookup dictionary per order and contains
     the object x,y bounding location on the grism image
-    GrismObject(order_bounding={"+1":((1,2),(1,2)),"+2":((2,3),(2,3))})
+    GrismObject(order_bounding={"+1":((xmin,xmax),(ymin,ymax)),"+2":((2,3),(2,3))})
 
 
     sky_bbox_?? contains the ra,dec,frame information for the bbox from the catalog
@@ -83,34 +83,34 @@ class GrismObject(namedtuple('GrismObject', ("sid",
                 ycenter=None):
 
         return super(GrismObject, cls).__new__(cls,
-                                               sid,
-                                               order_bounding,
-                                               icrs_centroid,
-                                               sky_bbox_ll,
-                                               sky_bbox_lr,
-                                               sky_bbox_ur,
-                                               sky_bbox_ul,
-                                               xcenter,
-                                               ycenter)
+                                               sid=sid,
+                                               order_bounding=order_bounding,
+                                               icrs_centroid=icrs_centroid,
+                                               sky_bbox_ll=sky_bbox_ll,
+                                               sky_bbox_lr=sky_bbox_lr,
+                                               sky_bbox_ur=sky_bbox_ur,
+                                               sky_bbox_ul=sky_bbox_ul,
+                                               xcenter=xcenter,
+                                               ycenter=ycenter)
 
     def __str__(self):
         """Return a pretty print for the object information."""
         return ("id: {0}\n"
-                "order_bounding {1}\n",
-                "icrs_centroid: {2}\n",
-                "sky_bbox_ll(ra,dec): {3} {4}\n"
-                "sky_bbox_lr(ra,dec): {5} {6}\n"
-                "sky_bbox_ur(ra,dec): {7} {8}\n"
-                "sky_bbox_ul(ra,dec): {9} {10}\n"
-                "xcenter: {11}\n"
-                "ycenter: {12}\n"
+                "order_bounding {1}\n"
+                "icrs_centroid: {2}\n"
+                "sky_bbox_ll: {3}\n"
+                "sky_bbox_lr: {4}\n"
+                "sky_bbox_ur: {5}\n"
+                "sky_bbox_ul:{6}\n"
+                "xcenter: {7}\n"
+                "ycenter: {8}\n"
                 .format(self.sid,
-                        self.order_bounding,
-                        self.icrs_centroid,
-                        self.sky_bbox_ll.ra.value,self.sky_bbox_ll.dec.value,
-                        self.sky_bbox_lr.ra.value,self.sky_bbox_lr.dec.value,
-                        self.sky_bbox_ur.ra.value,self.sky_bbox_ur.dec.value,
-                        self.sky_bbox_ul.ra.value,self.sky_bbox_ul.dec.value,
+                        str(self.order_bounding),
+                        str(self.icrs_centroid),
+                        str(self.sky_bbox_ll),
+                        str(self.sky_bbox_lr),
+                        str(self.sky_bbox_ur),
+                        str(self.sky_bbox_ul),
                         self.xcenter,
                         self.ycenter))
 
@@ -1223,8 +1223,8 @@ class NIRISSBackwardGrismDispersion(Model):
         The list of models for the polynomial model in l
     orders : list
         The list of orders which are available to the model
-    fwcpos_ref : float
-        The reference filter wheel position
+    theta : float
+        The rotation to apply
 
     Notes:
     ------
@@ -1244,24 +1244,24 @@ class NIRISSBackwardGrismDispersion(Model):
     fittable = False
     linear = False
 
-    inputs = ("x", "y", "wavelength", "order", "theta")
+    inputs = ("x", "y", "wavelength", "order")
     outputs = ("x", "y", "x0", "y0", "order")
 
     def __init__(self, orders, lmodels=None, xmodels=None,
-                 ymodels=None, fwcpos_ref=None, name=None, meta=None):
+                 ymodels=None, theta=None, name=None, meta=None):
         self._order_mapping = {int(k): v for v, k in enumerate(orders)}
         self.xmodels = xmodels
         self.ymodels = ymodels
         self.lmodels = lmodels
         self.orders = orders
-        self.fwcpos_ref = fwcpos_ref
+        self.theta = theta
         meta = {"orders": orders}
         if name is None:
             name = 'niriss_backward_grism_dispersion'
         super(NIRISSBackwardGrismDispersion, self).__init__(name=name,
                                                             meta=meta)
 
-    def evaluate(self, x, y, wavelength, order, theta):
+    def evaluate(self, x, y, wavelength, order):
         """Return the valid pixel(s) and wavelengths given center x,y and lam
 
         Parameters:
@@ -1276,8 +1276,6 @@ class NIRISSBackwardGrismDispersion(Model):
             Wavelength to disperse
         order : list
             The order to use
-        theta : float
-            rotation in degrees (from the filter wheel offset fwcpos_ref)
 
 
         Returns:
@@ -1288,7 +1286,9 @@ class NIRISSBackwardGrismDispersion(Model):
         Notes:
         ------
         There's spatial dependence for NIRISS so the forward transform
-        dependes on x,y as well as the filter wheel rotation
+        dependes on x,y as well as the filter wheel rotation. Theta is 
+        usu. taken to be the different between fwcpos_ref in the specwcs
+        reference file and fwcpos from the input image.
 
         """
         if wavelength < 0:
@@ -1303,8 +1303,8 @@ class NIRISSBackwardGrismDispersion(Model):
         dx = self.xmodels[iorder][0](x, y) + t * self.xmodels[iorder][1](x, y)
         dy = self.ymodels[iorder][0](x, y) + t * self.ymodels[iorder][1](x, y)
         # rotate by theta
-        if theta != 0.0:
-            rotate = Rotation2D(self.fwcpos_ref - theta)
+        if self.theta != 0.0:
+            rotate = Rotation2D(self.theta)
             dx, dy = rotate(dx, dy)
 
         return (x+dx, y+dy, x, y, order)
@@ -1343,16 +1343,16 @@ class NIRISSForwardRowGrismDispersion(Model):
     linear = False
 
     # starts with the backwards pixel and calculates the forward pixel
-    inputs = ("x", "y", "x0", "y0", "order", "theta")
+    inputs = ("x", "y", "x0", "y0", "order")
     outputs = ("x", "y", "wavelength", "order")
 
     def __init__(self, orders, lmodels=None, xmodels=None,
-                 ymodels=None, fwcpos_ref=0., name=None, meta=None):
+                 ymodels=None, theta=0., name=None, meta=None):
         self._order_mapping = {int(k): v for v, k in enumerate(orders)}
         self.xmodels = xmodels
         self.ymodels = ymodels
         self.lmodels = lmodels
-        self.fwcpos_ref = fwcpos_ref
+        self.theta = theta
         self.orders = orders
         meta = {"orders": orders}
         if name is None:
@@ -1360,7 +1360,7 @@ class NIRISSForwardRowGrismDispersion(Model):
         super(NIRISSForwardRowGrismDispersion, self).__init__(name=name,
                                                               meta=meta)
 
-    def evaluate(self, x, y, x0, y0, order, theta):
+    def evaluate(self, x, y, x0, y0, order):
         """Return the valid pixel(s) and wavelengths given center x,y and lam
 
         Parameters:
@@ -1380,8 +1380,6 @@ class NIRISSForwardRowGrismDispersion(Model):
         order : int
             Spectral order to use
 
-        theta : float
-            input rotation angle in degrees
 
         Returns:
         --------
@@ -1404,8 +1402,8 @@ class NIRISSForwardRowGrismDispersion(Model):
         t = np.linspace(0, 1, 10)  #sample t
         dx = self.xmodels[iorder][0](x0, y0) + t * self.xmodels[iorder][1](x0, y0)
         dy = self.ymodels[iorder][0](x0, y0) + t * self.ymodels[iorder][1](x0, y0)
-        if theta != 0.0:
-            rotate = Rotation2D(self.fwcpos_ref - theta)
+        if self.theta != 0.0:
+            rotate = Rotation2D(self.theta)
             dx, dy = rotate(dx, dy)
         so = np.argsort(dx)
         tr = np.interp(dxr, dx[so], t[so])
@@ -1446,24 +1444,24 @@ class NIRISSForwardColumnGrismDispersion(Model):
     linear = False
 
     # starts with the backwards pixel and calculates the forward pixel
-    inputs = ("x", "y", "x0", "y0", "order", "theta")
-    outputs = ("x", "y", "wavelength", "order", "theta")
+    inputs = ("x", "y", "x0", "y0", "order")
+    outputs = ("x", "y", "wavelength", "order")
 
     def __init__(self, orders, lmodels=None, xmodels=None,
-                 ymodels=None, fwcpos_ref=None, name=None, meta=None):
+                 ymodels=None, theta=None, name=None, meta=None):
         self._order_mapping = {int(k): v for v, k in enumerate(orders)}
         self.xmodels = xmodels
         self.ymodels = ymodels
         self.lmodels = lmodels
         self.orders = orders
-        self.fwcpos_ref = fwcpos_ref
+        self.theta = theta
         meta = {"orders": orders}
         if name is None:
             name = 'niriss_forward_column_grism_dispersion'
         super(NIRISSForwardColumnGrismDispersion, self).__init__(name=name,
                                                                  meta=meta)
 
-    def evaluate(self, x, y, x0, y0, order, theta):
+    def evaluate(self, x, y, x0, y0, order):
         """Return the valid pixel(s) and wavelengths given center x,y and lam
 
         Parameters:
@@ -1500,8 +1498,8 @@ class NIRISSForwardColumnGrismDispersion(Model):
         t = np.linspace(0, 1, 10)
         dx = self.xmodels[iorder][0](x0, y0) + t * self.xmodels[iorder][1](x0, y0)
         dy = self.ymodels[iorder][0](x0, y0) + t * self.ymodels[iorder][1](x0, y0)
-        if theta != 0.0:
-            rotate = Rotation2D(self.fwcpos_ref - theta)
+        if self.theta != 0.0:
+            rotate = Rotation2D(self.theta)
             dx, dy = rotate(dx, dy)
         so = np.argsort(dy)
         tr = np.interp(dyr, dy[so], t[so])

--- a/jwst/transforms/models.py
+++ b/jwst/transforms/models.py
@@ -38,12 +38,11 @@ Slit.__new__.__defaults__ = ("", 0, 0.0, 0.0, 0.0, 0.0, 0, 0, "", "", "", "",
 
 class GrismObject(namedtuple('GrismObject', ("sid",
                                              "order_bounding",
-                                             "ra_icrs_centroid",
-                                             "dec_icrs_centroid",
-                                             "ramin",
-                                             "decmin",
-                                             "ramax",
-                                             "decmax",
+                                             "icrs_centroid",
+                                             "sky_bbox_ll",
+                                             "sky_bbox_lr",
+                                             "sky_bbox_ur",
+                                             "sky_bbox_ul",
                                              "xcenter",
                                              "ycenter",
                                              ), rename=False)):
@@ -62,8 +61,12 @@ class GrismObject(namedtuple('GrismObject', ("sid",
 
     the segment_[ra/dec][min/max] are also as measured on the direct image
 
-    order_bounding is stored as a lookup dictionary per order:
+    order_bounding is stored as a lookup dictionary per order and contains
+    the object x,y bounding location on the grism image
     GrismObject(order_bounding={"+1":((1,2),(1,2)),"+2":((2,3),(2,3))})
+
+
+    sky_bbox_?? contains the ra,dec,frame information for the bbox from the catalog
 
     """
     __slots__ = ()  # prevent instance dictionary for lower memory
@@ -71,24 +74,22 @@ class GrismObject(namedtuple('GrismObject', ("sid",
     def __new__(cls,
                 sid=None,
                 order_bounding={},
-                ra_icrs_centroid=None,
-                dec_icrs_centroid=None,
-                ramin=None,
-                decmin=None,
-                ramax=None,
-                decmax=None,
+                icrs_centroid=None,
+                sky_bbox_ll=None,
+                sky_bbox_lr=None,
+                sky_bbox_ur=None,
+                sky_bbox_ul=None,
                 xcenter=None,
                 ycenter=None):
 
         return super(GrismObject, cls).__new__(cls,
                                                sid,
                                                order_bounding,
-                                               ra_icrs_centroid,
-                                               dec_icrs_centroid,
-                                               ramin,
-                                               decmin,
-                                               ramax,
-                                               decmax,
+                                               icrs_centroid,
+                                               sky_bbox_ll,
+                                               sky_bbox_lr,
+                                               sky_bbox_ur,
+                                               sky_bbox_ul,
                                                xcenter,
                                                ycenter)
 
@@ -96,20 +97,20 @@ class GrismObject(namedtuple('GrismObject', ("sid",
         """Return a pretty print for the object information."""
         return ("id: {0}\n"
                 "order_bounding {1}\n",
-                "ramin: {2}\n"
-                "decmin: {3}\n"
-                "ramax: {4}\n"
-                "decmax: {5}\n"
-                "xcenter: {6}\n"
-                "ycenter: {7}\n"
+                "icrs_centroid: {2}\n",
+                "sky_bbox_ll(ra,dec): {3} {4}\n"
+                "sky_bbox_lr(ra,dec): {5} {6}\n"
+                "sky_bbox_ur(ra,dec): {7} {8}\n"
+                "sky_bbox_ul(ra,dec): {9} {10}\n"
+                "xcenter: {11}\n"
+                "ycenter: {12}\n"
                 .format(self.sid,
                         self.order_bounding,
-                        self.ra_icrs_centroid,
-                        self.dec_icrs_centroid,
-                        self.ramin,
-                        self.decmin,
-                        self.ramax,
-                        self.decmax,
+                        self.icrs_centroid,
+                        self.sky_bbox_ll.ra.value,self.sky_bbox_ll.dec.value,
+                        self.sky_bbox_lr.ra.value,self.sky_bbox_lr.dec.value,
+                        self.sky_bbox_ur.ra.value,self.sky_bbox_ur.dec.value,
+                        self.sky_bbox_ul.ra.value,self.sky_bbox_ul.dec.value,
                         self.xcenter,
                         self.ycenter))
 
@@ -1408,7 +1409,6 @@ class NIRISSForwardRowGrismDispersion(Model):
             dx, dy = rotate(dx, dy)
         so = np.argsort(dx)
         tr = np.interp(dxr, dx[so], t[so])
-        print(tr, self.lmodels[iorder])
         wavelength = self.lmodels[iorder](tr)
 
         return (x0, y0, wavelength, order)

--- a/jwst/transforms/schemas/niriss_grism_dispersion-0.7.0.yaml
+++ b/jwst/transforms/schemas/niriss_grism_dispersion-0.7.0.yaml
@@ -13,9 +13,9 @@ anyOf:
   - $ref: ../asdf/transform/transform-1.1.0
   - type: object
     properties:
-      fwcpos_ref:
+      theta:
         description: |
-          NIRISS filter wheel reference position in degrees
+          NIRISS filter wheel differential position in degrees
         type: number
       xmodels:
         description: |
@@ -52,4 +52,4 @@ anyOf:
         items:
           minItems: 1
           maxItems: 1
-    required: [lmodels, xmodels, ymodels, fwcpos_ref, orders]
+    required: [lmodels, xmodels, ymodels, theta, orders]

--- a/jwst/transforms/tags/jwst_models.py
+++ b/jwst/transforms/tags/jwst_models.py
@@ -69,7 +69,7 @@ class NIRISSGrismDispersionType(TransformType):
                       list(node['lmodels']),
                       list(node['xmodels']),
                       list(node['ymodels']),
-                      node['fwcpos_ref'],
+                      node['theta'],
                       )
 
     @classmethod
@@ -80,7 +80,7 @@ class NIRISSGrismDispersionType(TransformType):
                 'xmodels': xll,
                 'ymodels': yll,
                 'lmodels': list(model.lmodels),
-                'fwcpos_ref': model.fwcpos_ref,
+                'theta': model.theta,
                 'model_type': type(model).name
                 }
         return yamlutil.custom_tree_to_tagged_tree(node, ctx)
@@ -93,7 +93,7 @@ class NIRISSGrismDispersionType(TransformType):
         assert_array_equal(a.ymodels, b.ymodels)
         assert_array_equal(a.lmodels, b.lmodels)
         assert_array_equal(a.orders, b.orders)
-        assert_array_equal(a.fwcpos_ref, b.fwcpos_ref)
+        assert_array_equal(a.theta, b.theta)
 
 
 class RotationSequenceType(TransformType):


### PR DESCRIPTION
This includes updates to make the NIRISS and NIRCAM calls into the gwcs object align as well as some sundry bug fixes:

* I changed the NIRISS wcs transforms for the grism traversal to init with the rotation angle instead of just the reference position of the filter wheel. The fwcpos in the input exposure is a known constant and users should not have to specify the value. This simplifies the model and creates the same function signature for the calls in both instruments 
* updates to the `GrismObj` and `SkyObj` tuples to use SkyCoords