### PR TITLE
Prevent setup.py from trying to install __pycache__

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 
 import os
+from os.path import basename
 import subprocess
 import sys
 from setuptools import setup, find_packages, Extension, Command
@@ -48,7 +49,7 @@ except ImportError:
 
 
 NAME = 'jwst'
-SCRIPTS = glob('scripts/*')
+SCRIPTS = [s for s in glob('scripts/*') if basename(s) != '__pycache__']
 PACKAGE_DATA = {
     '': [
         '*.fits',


### PR DESCRIPTION
This has bitten me more than once while trying to reinstall the jwst pipeline for testing. This change just makes sure that `setup.py` doesn't attempt to install `scripts/__pycache__` as a script, if it exists.