### PR TITLE
ModelContainer persist=True as default

### DIFF
--- a/jwst/datamodels/container.py
+++ b/jwst/datamodels/container.py
@@ -66,7 +66,7 @@ class ModelContainer(model_base.DataModel):
     # does not describe the data contents of the container.
     schema_url = "container.schema.yaml"
 
-    def __init__(self, init=None, persist=False, **kwargs):
+    def __init__(self, init=None, persist=True, **kwargs):
 
         super(ModelContainer, self).__init__(init=None, **kwargs)
         self._persist = persist


### PR DESCRIPTION
This modifies PR #1027 to have `persist=True` as the default when opening a `ModelContainer` of datamodels from disk, so that the following code works as expected:
```
In [7]: container = datamodels.open('mosaic_long_asn.json')

In [8]: container._models
Out[8]: 
['nrca5_47Tuc_primary_dither2_newpos_cal.fits',
 'nrca5_47Tuc_primary_dither3_newpos_cal.fits']

In [9]: for model in container:
   ...:     model.meta.cal_step.resample = 'COMPLETE'
   ...:     

In [10]: for model in container:
    ...:     print(model.meta.cal_step.resample)
    ...:     
COMPLETE
COMPLETE
```
If `persist=False`, as was previously the default, the above code would not work, i.e. outside the `for ... in ...` block, each model in the container would not have any of its attributes updated.  Since this is very common in almost every pipeline Step that uses `ModelContainer`, it makes sense to have this be the default.

We should figure out specific places in each pipeline step were we would like the `persist=False` behavior, and use the flag as appropriate in those steps if it makes the step run faster.

@bernie-simon 
@stsci-hack 
@hbushouse 
@stscieisenhamer 