### PR TITLE
Resample spec fixes

### DIFF
--- a/jwst/outlier_detection/outlier_detection.py
+++ b/jwst/outlier_detection/outlier_detection.py
@@ -325,25 +325,25 @@ def flag_cr(sci_image, blot_image, gain_image, readnoise_image, **pars):
     # logic copied from jwst.jump step...
     # Get subarray limits from metadata of input model
     xstart = blot_image.meta.subarray.xstart
-    xsize  = blot_image.data.shape[1]
-    xstop  = xstart + xsize - 1
+    xsize = blot_image.data.shape[1]
+    xstop = xstart + xsize - 1
     ystart = blot_image.meta.subarray.ystart
-    ysize  = blot_image.data.shape[0]
-    ystop  = ystart + ysize - 1
-    if (readnoise_image.meta.subarray.xstart==xstart and
-        readnoise_image.meta.subarray.xsize==xsize   and
-        readnoise_image.meta.subarray.ystart==ystart and
-        readnoise_image.meta.subarray.ysize==ysize):
+    ysize = blot_image.data.shape[0]
+    ystop = ystart + ysize - 1
+    if (readnoise_image.meta.subarray.xstart == xstart and
+        readnoise_image.meta.subarray.xsize == xsize and
+        readnoise_image.meta.subarray.ystart == ystart and
+        readnoise_image.meta.subarray.ysize == ysize):
 
         log.debug('Readnoise and gain subarrays match science data')
         rn = readnoise_image.data
         gain = gain_image.data
-        
+
     else:
         log.debug('Extracting readnoise and gain subarrays to match science data')
-        rn = readnoise_image.data[ystart-1:ystop,xstart-1:xstop]
-        gain = gain_image.data[ystart-1:ystop,xstart-1:xstop]
-        
+        rn = readnoise_image.data[ystart - 1:ystop, xstart - 1:xstop]
+        gain = gain_image.data[ystart - 1:ystop, xstart - 1:xstop]
+
     # TODO: for JWST, the actual readnoise at a given pixel depends on the
     # number of reads going into that pixel.  So we need to account for that
     # using the meta.exposure.nints, ngroups and nframes keywords.
@@ -441,14 +441,14 @@ def abs_deriv(array):
     tmp = np.zeros(array.shape, dtype=np.float64)
     out = np.zeros(array.shape, dtype=np.float64)
 
-    tmp[1:,:] = array[:-1,:]
+    tmp[1:, :] = array[:-1, :]
     tmp, out = _absolute_subtract(array, tmp, out)
-    tmp[:-1,:] = array[1:,:]
+    tmp[:-1, :] = array[1:, :]
     tmp, out = _absolute_subtract(array, tmp, out)
 
-    tmp[:,1:] = array[:,:-1]
+    tmp[:, 1:] = array[:, :-1]
     tmp, out = _absolute_subtract(array, tmp, out)
-    tmp[:,:-1] = array[:,1:]
+    tmp[:, :-1] = array[:, 1:]
     tmp, out = _absolute_subtract(array, tmp, out)
 
     return out

--- a/jwst/outlier_detection/outlier_detection_scaled.py
+++ b/jwst/outlier_detection/outlier_detection_scaled.py
@@ -132,10 +132,10 @@ class OutlierDetectionScaled(object):
             radius_inner = 4
             radius_outer = 5
 
-        apertures = CircularAperture((xcenter,ycenter),r=radius)
+        apertures = CircularAperture((xcenter, ycenter), r=radius)
         aperture_mask = apertures.to_mask(method='center')[0]
         # This mask has 1 for mask region, 0 for outside of mask
-        median_mask = aperture_mask.to_image((ny,nx))
+        median_mask = aperture_mask.to_image((ny, nx))
         inv_median_mask = np.abs(median_mask - 1)
         # Perform photometry
         catalog = tso_aperture_photometry(self.input_models, xcenter, ycenter,
@@ -144,7 +144,7 @@ class OutlierDetectionScaled(object):
 
         # Extract net photometry for the source
         # This will be the value used for scaling the median image within
-        # the aperture region 
+        # the aperture region
         phot_values = catalog['net_aperture_sum']
 
         # Convert CubeModel into ModelContainer of 2-D DataModels
@@ -162,7 +162,6 @@ class OutlierDetectionScaled(object):
         base_filename = self.input_models.meta.filename
         median_model.meta.filename = '_'.join(base_filename.split('_')[:2] +
             ['median.fits'])
-        
 
         # Perform median combination on set of drizzled mosaics
         median_model.data = create_median(input_models, **pars)
@@ -170,10 +169,10 @@ class OutlierDetectionScaled(object):
                             r_out=radius_outer)
 
         tbl1 = aperture_photometry(median_model.data, apertures,
-                                   error=median_model.data*0.0 + 1.0)
+                                   error=median_model.data * 0.0 + 1.0)
         tbl2 = aperture_photometry(median_model.data, aper2,
-                                   error=median_model.data*0.0 + 1.0)
-        
+                                   error=median_model.data * 0.0 + 1.0)
+
         aperture_sum = u.Quantity(tbl1['aperture_sum'][0])
         annulus_sum = u.Quantity(tbl2['aperture_sum'][0])
         annulus_mean = annulus_sum / aper2.area()
@@ -189,14 +188,14 @@ class OutlierDetectionScaled(object):
         # Area outside of aperture in median will remain unchanged
         blot_models = datamodels.ModelContainer()
         for i in range(self.input_models.data.shape[0]):
-            scale_factor = float(phot_values[i]/median_phot_value)
+            scale_factor = float(phot_values[i] / median_phot_value)
             scaled_image = datamodels.ImageModel(init=median_model.data.shape)
             scaled_image.meta = median_model.meta
-            scaled_data = median_model.data*(scale_factor*median_mask) + \
-                    (median_model.data*inv_median_mask)
+            scaled_data = median_model.data * (scale_factor * median_mask) + \
+                    (median_model.data * inv_median_mask)
             scaled_image.data = scaled_data
             blot_models.append(scaled_image)
-        
+
         if save_intermediate_results:
             log.info("Writing out Scaled Median images...")
             blot_models.save()
@@ -208,7 +207,6 @@ class OutlierDetectionScaled(object):
 
         for i in range(self.input_models.data.shape[0]):
             self.input_models.dq[i] = input_models[i].dq
-            
+
         # clean-up (just to be explicit about being finished with these results)
         del median_model, blot_models
-

--- a/jwst/outlier_detection/outlier_detection_scaled_step.py
+++ b/jwst/outlier_detection/outlier_detection_scaled_step.py
@@ -50,7 +50,7 @@ class OutlierDetectionScaledStep(Step):
 
             self.input_models = input_models
 
-            reffiles= {}
+            reffiles = {}
             reffiles['gain'] = self._build_reffile_container('gain')
             reffiles['readnoise'] = self._build_reffile_container('readnoise')
 
@@ -73,7 +73,7 @@ class OutlierDetectionScaledStep(Step):
             # Set up outlier detection, then do detection
             step = outlier_detection_scaled.OutlierDetectionScaled(
                         self.input_models,
-                        reffiles=reffiles, 
+                        reffiles=reffiles,
                         **pars)
             step.do_detection()
 
@@ -102,19 +102,19 @@ class OutlierDetectionScaledStep(Step):
         """
 
         reffile_to_model = {'gain': datamodels.GainModel,
-                            'readnoise': datamodels.ReadnoiseModel}          
+                            'readnoise': datamodels.ReadnoiseModel}
         reffile_model = reffile_to_model[reftype]
 
         reffiles = [self.input_models.meta.ref_file.instance[reftype]['name']]
-        
+
         self.log.debug("Using {} reffile(s):".format(reftype.upper()))
         for r in set(reffiles):
             self.log.debug("    {}".format(r))
 
         # Use get_reference_file method to insure latest reference file
         # always gets used...especially since only one name will ever be needed
-        ref_list = [reffile_model(self.get_reference_file(self.input_models, reftype))] 
-        
+        ref_list = [reffile_model(self.get_reference_file(self.input_models, reftype))]
+
         return datamodels.ModelContainer(ref_list)
 
 

--- a/jwst/outlier_detection/outlier_detection_stack_step.py
+++ b/jwst/outlier_detection/outlier_detection_stack_step.py
@@ -7,18 +7,18 @@ from . import outlier_detection
 
 class OutlierDetectionStackStep(Step):
     """
-    Flag outlier bad pixels and cosmic rays in the DQ array of each input image 
-    of a stack of exposures, which in the case of TSO data are from the same 
+    Flag outlier bad pixels and cosmic rays in the DQ array of each input image
+    of a stack of exposures, which in the case of TSO data are from the same
     data cube.
 
     Input images can listed in an input association file or already opened
     with a ModelContainer.
-    
+
     DQ arrays are modified in place.
-    
+
     By default, resampling has been disabled.  The 'resample_data' attribute
     can be reset to 'True' to turn on resampling if desired for the data.
-    
+
 
     Parameters
     -----------
@@ -44,7 +44,7 @@ class OutlierDetectionStackStep(Step):
     """
     reference_file_types = ['gain', 'readnoise']
     prefetch_references = False
-    
+
     def process(self, input):
 
         with datamodels.open(input) as input_models:
@@ -58,7 +58,7 @@ class OutlierDetectionStackStep(Step):
 
             self.log.info("Performing outlier detection on stack of {} inputs".format(len(input_models)))
             self.input_models = input_models
-            reffiles= {}
+            reffiles = {}
             reffiles['gain'] = self._build_reffile_container('gain')
             reffiles['readnoise'] = self._build_reffile_container('readnoise')
 
@@ -122,11 +122,10 @@ class OutlierDetectionStackStep(Step):
             length = len(self.input_models)
             # This call to reference_uri_to_cache_path expects a reference
             # filename as a URI(crds://), not a file path(/path/to/file)
-            ref_list = [reffile_to_model[reftype](self.reference_uri_to_cache_path(reffiles[0]))]*length
+            ref_list = [reffile_to_model[reftype](self.reference_uri_to_cache_path(reffiles[0]))] * length
         else:
-            ref_list = [reffile_to_model[reftype](self.get_reference_file(im, reftype)) for im in self.input_models] 
+            ref_list = [reffile_to_model[reftype](self.get_reference_file(im, reftype)) for im in self.input_models]
         return datamodels.ModelContainer(ref_list)
-
 
 
 if __name__ == '__main__':

--- a/jwst/outlier_detection/outlier_detection_step.py
+++ b/jwst/outlier_detection/outlier_detection_step.py
@@ -49,8 +49,8 @@ class OutlierDetectionStep(Step):
 
             self.log.info("Performing outlier detection on {} inputs".format(len(input_models)))
             self.input_models = input_models
-            
-            reffiles= {}
+
+            reffiles = {}
             reffiles['gain'] = self._build_reffile_container('gain')
             reffiles['readnoise'] = self._build_reffile_container('readnoise')
 
@@ -103,7 +103,7 @@ class OutlierDetectionStep(Step):
         reffile_to_model = {'gain': datamodels.GainModel,
             'readnoise': datamodels.ReadnoiseModel}
 
-        reffiles = [self.get_reference_file(im, reftype) for im in self.input_models] 
+        reffiles = [self.get_reference_file(im, reftype) for im in self.input_models]
         self.log.debug("Using {} reffile(s):".format(reftype.upper()))
         for r in set(reffiles):
             self.log.debug("    {}".format(r))
@@ -115,9 +115,8 @@ class OutlierDetectionStep(Step):
             ref_list = [reffile_to_model.get(reftype)(reffiles[0])] * length
         else:
             ref_list = [reffile_to_model.get(reftype)(ref) for ref in reffiles]
-            
-        return datamodels.ModelContainer(ref_list)
 
+        return datamodels.ModelContainer(ref_list)
 
 
 if __name__ == '__main__':

--- a/jwst/pipeline/resample.cfg
+++ b/jwst/pipeline/resample.cfg
@@ -8,4 +8,4 @@ kernel = 'square'
 fillval = 'INDEF'
 good_bits = 4
 blendheaders = True
-suffix = 'resamp'
+suffix = 'i2d'

--- a/jwst/pipeline/resample.cfg
+++ b/jwst/pipeline/resample.cfg
@@ -8,3 +8,4 @@ kernel = 'square'
 fillval = 'INDEF'
 good_bits = 4
 blendheaders = True
+suffix = 'resamp'

--- a/jwst/resample/blend.py
+++ b/jwst/resample/blend.py
@@ -20,17 +20,17 @@ def blendfitsdata(input_list, output_model):
     from the list of FITS objects generated from the input_list of filenames.
     """
     new_hdrs, new_table = blendheaders.get_blended_headers(input_list)
-    
+
     # Now merge the keyword values from new_hdrs into the metatdata for the
     # output datamodel
-    # 
-    # start by building dict which maps all FITS keywords in schema to their 
+    #
+    # start by building dict which maps all FITS keywords in schema to their
     # attribute in the schema
     fits_dict = schema.build_fits_dict(output_model.schema)
     # Need to insure that output_model does not already have an instance
     # of hdrtab from previous processing, an instance that would be
     # incompatible with the new table generated now...
-    if hasattr(output_model,'hdrtab'):
+    if hasattr(output_model, 'hdrtab'):
         # If found, remove it to be replaced by new instance
         del output_model.hdrtab
     # Now assign values from new_hdrs to output_model.meta using fits_dict map
@@ -44,17 +44,17 @@ def blendfitsdata(input_list, output_model):
 
     output_model.add_schema_entry('hdrtab', new_schema)
     output_model.hdrtab = fits_support.from_fits_hdu(new_table, new_schema)
-        
+
 
 def blendmetadata(input_models, output_model):
     final_rules = build_meta_rules(input_models)
 
     # Apply rules to each set of input headers
     new_headers = []
-    i=0
+    i = 0
     # apply rules to PRIMARY headers separately, since there is only
     # 1 PRIMARY header per image, yet many extension headers
-    newphdr,newtab = final_rules.apply(phdrlist)
+    newphdr, newtab = final_rules.apply(phdrlist)
     final_rules.add_rules_kws(newphdr) # Adds HISTORY comments on rules used
     new_headers.append(newphdr)
     for hdrs in hdrlist[1:]:
@@ -79,7 +79,7 @@ def blendmetadata(input_models, output_model):
     # Need to insure that output_model does not already have an instance
     # of hdrtab from previous processing, an instance that would be
     # incompatible with the new table generated now...
-    if hasattr(output_model,'hdrtab'):
+    if hasattr(output_model, 'hdrtab'):
         # If found, remove it to be replaced by new instance
         del output_model.hdrtab
 
@@ -134,10 +134,10 @@ def build_meta_rules(input_models, rules_file=None):
 def build_tab_schema(new_table):
     """
     Return new schema definition that describes the input table.
-    
+
     """
     hdrtab = OrderedDict()
-    hdrtab['title']='Combined header table'
+    hdrtab['title'] = 'Combined header table'
     hdrtab['fits_hdu'] = 'HDRTAB'
     datatype = []
     for col in new_table.columns:
@@ -147,8 +147,8 @@ def build_tab_schema(new_table):
         c['name'] = cname
         c['datatype'] = ctype
         datatype.append(c)
-    hdrtab['datatype']=datatype
-    
+    hdrtab['datatype'] = datatype
+
     return hdrtab
 
 
@@ -158,7 +158,7 @@ def convert_dtype(value):
     """
     if 'S' in value:
         # working with a string description
-        str_len = int(value[value.find('S')+1:])
+        str_len = int(value[value.find('S') + 1:])
         new_dtype = [u'ascii', str_len] ## CHANGED
     else:
         new_dtype = unicode(str(value))

--- a/jwst/resample/gwcs_blot.py
+++ b/jwst/resample/gwcs_blot.py
@@ -80,7 +80,7 @@ class GWCSBlot(object):
         # Compute the mapping between the input and output pixel coordinates
         pixmap = resample_utils.calc_gwcs_pixmap(blot_wcs, self.source_wcs,
             outsci.shape)
-        log.debug("Pixmap shape: {}".format(pixmap[:,:,0].shape))
+        log.debug("Pixmap shape: {}".format(pixmap[:, :, 0].shape))
         log.debug("Sci shape: {}".format(outsci.shape))
 
         source_pscale = self.source_model.meta.wcsinfo.cdelt1

--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -192,10 +192,10 @@ class ResampleData(object):
                 exposure_times['start'].append(img.meta.exposure.start_time)
                 exposure_times['end'].append(img.meta.exposure.end_time)
 
-                # apply sky subtraction 
+                # apply sky subtraction
                 if 'skybg' in img.meta._instance:
                     img.data -= img.meta.skybg
-                    
+
                 outwcs_pscale = output_model.meta.wcsinfo.cdelt1
                 wcslin_pscale = img.meta.wcsinfo.cdelt1
 

--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -226,7 +226,8 @@ class ResampleData(object):
 
 
 def _buildMask(dqarr, bitvalue):
-    """ Builds a bit-mask from an input DQ array and a bitvalue flag"""
+    """ Build a bit-mask from an input DQ array and a bitvalue flag
+    """
 
     bitvalue = bitmask.interpret_bits_value(bitvalue)
 
@@ -237,8 +238,8 @@ def _buildMask(dqarr, bitvalue):
 
 def build_driz_weight(model, wht_type=None, good_bits=None):
     """ Create input weighting image based on user inputs
-
     """
+    
     if good_bits is not None and good_bits < 0: good_bits = None
     dqmask = _buildMask(model.dq, good_bits)
     exptime = model.meta.exposure.exposure_time

--- a/jwst/resample/resample_spec.py
+++ b/jwst/resample/resample_spec.py
@@ -185,7 +185,7 @@ class ResampleSpecData(object):
                     bounds_error=False, fill_value='extrapolate')
                 xpos.append(f(lam[y_center, x_center]))
         x_arg = np.array(xpos)[~np.isnan(lam[:, x_center])]
-        y_arg = y[~np.isnan(lam[:,x_center]), x_center]
+        y_arg = y[~np.isnan(lam[:, x_center]), x_center]
         # slit_coords, spect0 = refwcs(x_arg, y_arg, output='numericals_plus')
         slit_ra, slit_dec, slit_spec_ref = refwcs(x_arg, y_arg)
         slit_coords = SkyCoord(ra=slit_ra, dec=slit_dec, unit=u.deg)

--- a/jwst/resample/resample_spec_step.py
+++ b/jwst/resample/resample_spec_step.py
@@ -29,15 +29,18 @@ class ResampleSpecStep(Step):
 
     def process(self, input):
 
-        input_models = datamodels.open(input)
+        input = datamodels.open(input)
 
-        # Put single input into a ModelContainer
-        if not isinstance(input_models, datamodels.ModelContainer):
-            s = datamodels.ModelContainer()
-            s.append(input_models)
-            input_models = s
+        # If single input, wrap in a ModelContainer
+        if not isinstance(input, datamodels.ModelContainer):
+            input_models = datamodels.ModelContainer([input])
+            input_models.meta.resample.output = input.meta.filename
+            self.blendheaders = False
+        else:
+            input_models = input
 
-        self.driz_filename = self.get_reference_file(input_models[0], 'drizpars')
+        for reftype in self.reference_file_types:
+            ref_filename = self.get_reference_file(input_models[0], reftype)
 
         # Multislits get converted to a ModelContainer per slit
         if all([isinstance(i, datamodels.MultiSlitModel) for i in input_models]):

--- a/jwst/resample/resample_spec_step.py
+++ b/jwst/resample/resample_spec_step.py
@@ -6,21 +6,15 @@ from .. import datamodels
 from . import resample_spec
 from ..exp_to_source import multislit_to_container
 
-import logging
-log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
-
 
 class ResampleSpecStep(Step):
     """
-    ResampleStep: Uses the drizzle process to resample (geometric correction)
-    a single 2D image or resample and combine a set of 2D images specified as
-    an association.
+    ResampleSpecStep: Resample input data onto a regular grid using the
+    drizzle algorithm.
 
     Parameters
     -----------
-    input : str or model
-        Single filename for either a single image or an association table.
+    input : DataModel, Association
     """
 
     spec = """
@@ -35,54 +29,54 @@ class ResampleSpecStep(Step):
 
     def process(self, input):
 
-        with datamodels.open(input) as self.input_models:
+        input_models = datamodels.open(input)
 
-            # Single input model, single resample output
-            if not isinstance(self.input_models, datamodels.ModelContainer):
-                s = datamodels.ModelContainer()
-                s.append(self.input_models)
-                self.input_models = s
+        # Put single input into a ModelContainer
+        if not isinstance(input_models, datamodels.ModelContainer):
+            s = datamodels.ModelContainer()
+            s.append(input_models)
+            input_models = s
 
-            self.driz_filename = self.get_reference_file(self.input_models[0], 'drizpars')
+        self.driz_filename = self.get_reference_file(input_models[0], 'drizpars')
 
-            # Multislits get converted to a ModelContainer per slit
-            if all([isinstance(i, datamodels.MultiSlitModel) for i in self.input_models]):
-                log.info('Converting MultiSlit to ModelContainer')
-                container_dict = multislit_to_container(self.input_models)
-                output_product = datamodels.MultiProductModel()
-                output_product.update(self.input_models[0])
-                for k, v in container_dict.items():
-                    self.input_models = v
+        # Multislits get converted to a ModelContainer per slit
+        if all([isinstance(i, datamodels.MultiSlitModel) for i in input_models]):
+            self.log.info('Converting MultiSlit to ModelContainer')
+            container_dict = multislit_to_container(input_models)
+            output_product = datamodels.MultiProductModel()
+            output_product.update(input_models[0])
+            for k, v in container_dict.items():
+                input_models = v
 
-                    # Set up the resampling object as part of this step
-                    self.step = resample_spec.ResampleSpecData(self.input_models,
-                        self.driz_filename, single=self.single,
-                        wht_type=self.wht_type, pixfrac=self.pixfrac,
-                        kernel=self.kernel, fillval=self.fillval,
-                        good_bits=self.good_bits)
-                    # Do the resampling
-                    self.step.do_drizzle()
-                    if len(self.step.output_models) == 1:
-                        out_slit = self.step.output_models[0]
-                        output_product.products.append(out_slit)
-                    else:
-                        out_slit = self.step.output_models
-                result = output_product
-            else:
                 # Set up the resampling object as part of this step
-                self.step = resample_spec.ResampleSpecData(self.input_models,
-                    self.driz_filename, single=self.single, wht_type=self.wht_type,
-                    pixfrac=self.pixfrac, kernel=self.kernel,
-                    fillval=self.fillval, good_bits=self.good_bits)
+                self.step = resample_spec.ResampleSpecData(input_models,
+                    self.driz_filename, single=self.single,
+                    wht_type=self.wht_type, pixfrac=self.pixfrac,
+                    kernel=self.kernel, fillval=self.fillval,
+                    good_bits=self.good_bits)
                 # Do the resampling
                 self.step.do_drizzle()
-
-                # Return either the single resampled datamodel, or the container
-                # of datamodels.
                 if len(self.step.output_models) == 1:
-                    result = self.step.output_models[0]
+                    out_slit = self.step.output_models[0]
+                    output_product.products.append(out_slit)
                 else:
-                    result = self.step.output_models
+                    out_slit = self.step.output_models
+            result = output_product
+        else:
+            # Set up the resampling object as part of this step
+            self.step = resample_spec.ResampleSpecData(input_models,
+                self.driz_filename, single=self.single, wht_type=self.wht_type,
+                pixfrac=self.pixfrac, kernel=self.kernel,
+                fillval=self.fillval, good_bits=self.good_bits)
+            # Do the resampling
+            self.step.do_drizzle()
+
+            # Return either the single resampled datamodel, or the container
+            # of datamodels.
+            if len(self.step.output_models) == 1:
+                result = self.step.output_models[0]
+            else:
+                result = self.step.output_models
 
         result.meta.cal_step.resample = 'COMPLETE'
 

--- a/jwst/resample/resample_spec_step.py
+++ b/jwst/resample/resample_spec_step.py
@@ -85,6 +85,7 @@ class ResampleSpecStep(Step):
                     result = self.step.output_models
 
         result.meta.cal_step.resample = 'COMPLETE'
+
         return result
 
 

--- a/jwst/resample/resample_step.py
+++ b/jwst/resample/resample_step.py
@@ -8,13 +8,12 @@ from . import resample
 
 class ResampleStep(Step):
     """
-    ResampleStep: Uses the drizzle process to resample (geometric correction)
-    a single 2D image or resample and combine a set of 2D images specified as
-    an association.
+    ResampleStep: Resample input data onto a regular grid using the
+    drizzle algorithm.
 
     Parameters
     -----------
-    input : str or model
+    input : DataModel or Association
         Single filename for either a single image or an association table.
     """
 
@@ -31,30 +30,21 @@ class ResampleStep(Step):
 
     def process(self, input):
 
-        input_models = datamodels.open(input)
-        # If single input, insert into a ModelContainer
-        if not isinstance(input_models, datamodels.ModelContainer):
-            s = datamodels.ModelContainer()
-            s.append(input_models)
-            s.assign_group_ids()
-            s.meta.resample.output = s.group_names[0].replace('_resamp', '_drz')
-            self.input_models = s
-        else:
-            self.input_models = input_models
+        input = datamodels.open(input)
 
-        # identify what reference file has been associated with these inputs
-        try:
-            ref_filename = self.get_reference_file(self.input_models[0],
-                self.reference_file_types[0])
-            self.log.info('{} reffile is {}'.format(self.reference_file_types[0],
-                ref_filename))
-        except:
-            self.log.error('{} reffile is not found.'.format(
-                self.reference_file_types[0]))
+        # If single input, wrap in a ModelContainer
+        if not isinstance(input, datamodels.ModelContainer):
+            input_models = datamodels.ModelContainer([input])
+            input_models.meta.resample.output = input.meta.filename
+            self.blendheaders = False
+        else:
+            input_models = input
+
+        for reftype in self.reference_file_types:
+            ref_filename = self.get_reference_file(input_models[0], reftype)
 
         # Call the resampling routine
-        resamp = resample.ResampleData(self.input_models,
-            ref_filename=ref_filename,
+        resamp = resample.ResampleData(input_models, ref_filename=ref_filename,
             single=self.single, wht_type=self.wht_type, pixfrac=self.pixfrac,
             kernel=self.kernel, fillval=self.fillval, good_bits=self.good_bits,
             blendheaders=self.blendheaders)

--- a/jwst/resample/resample_step.py
+++ b/jwst/resample/resample_step.py
@@ -62,14 +62,13 @@ class ResampleStep(Step):
         resamp.do_drizzle()
 
         if len(resamp.output_models) == 1:
-            output_model = resamp.output_models[0]
+            result = resamp.output_models[0]
         else:
-            output_model = resamp.output_models
+            result = resamp.output_models
 
+        result.meta.cal_step.resample = "COMPLETE"
 
-        output_model.meta.cal_step.resample = "COMPLETE"
-
-        return output_model
+        return result
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
A grab-bag of fixes, mostly to the `resample` modules:
- PEP8 fixes
- Remove `with()` block at beginning of `ResampleSpecStep.process()`
- Make `input_models` not a class attribute
- Make resample_step result var name consistent with other steps
- Write `meta.cal_step.resample` 'COMPLETE' correctly
- Simplify single input to `ResampleStep`
- Simplify single input to `ResampleSpecStep`
