### PR TITLE
Fix l3 regtests

### DIFF
--- a/jwst/outlier_detection/outlier_detection_scaled_step.py
+++ b/jwst/outlier_detection/outlier_detection_scaled_step.py
@@ -50,7 +50,7 @@ class OutlierDetectionScaledStep(Step):
 
             self.input_models = input_models
 
-            reffiles = {}
+            reffiles= {}
             reffiles['gain'] = self._build_reffile_container('gain')
             reffiles['readnoise'] = self._build_reffile_container('readnoise')
 
@@ -73,12 +73,11 @@ class OutlierDetectionScaledStep(Step):
             # Set up outlier detection, then do detection
             step = outlier_detection_scaled.OutlierDetectionScaled(
                         self.input_models,
-                        reffiles=reffiles,
+                        reffiles=reffiles, 
                         **pars)
             step.do_detection()
 
-            for model in self.input_models:
-                model.meta.cal_step.outlier_detection = 'COMPLETE'
+            self.input_models.meta.cal_step.outlier_detection = 'COMPLETE'
 
             return self.input_models
 
@@ -102,19 +101,19 @@ class OutlierDetectionScaledStep(Step):
         """
 
         reffile_to_model = {'gain': datamodels.GainModel,
-                            'readnoise': datamodels.ReadnoiseModel}
+                            'readnoise': datamodels.ReadnoiseModel}          
         reffile_model = reffile_to_model[reftype]
 
         reffiles = [self.input_models.meta.ref_file.instance[reftype]['name']]
-
+        
         self.log.debug("Using {} reffile(s):".format(reftype.upper()))
         for r in set(reffiles):
             self.log.debug("    {}".format(r))
 
         # Use get_reference_file method to insure latest reference file
         # always gets used...especially since only one name will ever be needed
-        ref_list = [reffile_model(self.get_reference_file(self.input_models, reftype))]
-
+        ref_list = [reffile_model(self.get_reference_file(self.input_models, reftype))] 
+        
         return datamodels.ModelContainer(ref_list)
 
 

--- a/jwst/outlier_detection/outlier_detection_scaled_step.py
+++ b/jwst/outlier_detection/outlier_detection_scaled_step.py
@@ -50,7 +50,7 @@ class OutlierDetectionScaledStep(Step):
 
             self.input_models = input_models
 
-            reffiles= {}
+            reffiles = {}
             reffiles['gain'] = self._build_reffile_container('gain')
             reffiles['readnoise'] = self._build_reffile_container('readnoise')
 
@@ -73,7 +73,7 @@ class OutlierDetectionScaledStep(Step):
             # Set up outlier detection, then do detection
             step = outlier_detection_scaled.OutlierDetectionScaled(
                         self.input_models,
-                        reffiles=reffiles, 
+                        reffiles=reffiles,
                         **pars)
             step.do_detection()
 
@@ -101,11 +101,11 @@ class OutlierDetectionScaledStep(Step):
         """
 
         reffile_to_model = {'gain': datamodels.GainModel,
-                            'readnoise': datamodels.ReadnoiseModel}          
+                            'readnoise': datamodels.ReadnoiseModel}
         reffile_model = reffile_to_model[reftype]
 
         reffiles = [self.input_models.meta.ref_file.instance[reftype]['name']]
-        
+
         self.log.debug("Using {} reffile(s):".format(reftype.upper()))
         for r in set(reffiles):
             self.log.debug("    {}".format(r))
@@ -113,7 +113,7 @@ class OutlierDetectionScaledStep(Step):
         # Use get_reference_file method to insure latest reference file
         # always gets used...especially since only one name will ever be needed
         ref_list = [reffile_model(self.get_reference_file(self.input_models, reftype))] 
-        
+
         return datamodels.ModelContainer(ref_list)
 
 

--- a/jwst/outlier_detection/outlier_detection_scaled_step.py
+++ b/jwst/outlier_detection/outlier_detection_scaled_step.py
@@ -112,7 +112,7 @@ class OutlierDetectionScaledStep(Step):
 
         # Use get_reference_file method to insure latest reference file
         # always gets used...especially since only one name will ever be needed
-        ref_list = [reffile_model(self.get_reference_file(self.input_models, reftype))] 
+        ref_list = [reffile_model(self.get_reference_file(self.input_models, reftype))]
 
         return datamodels.ModelContainer(ref_list)
 

--- a/jwst/pipeline/calwebb_coron3.py
+++ b/jwst/pipeline/calwebb_coron3.py
@@ -143,7 +143,7 @@ class Coron3Pipeline(Pipeline):
                                              wht=resample_input[0].err)
             result.update(resample_input[0])
             # The resample step blends headers already...
-            self.log.debug('Blending metadata for {}'.format(output_file))
+            self.log.debug('Blending metadata for {}'.format(result.meta.filename))
             blend.blendfitsdata(targ_files, result)
 
         result.meta.asn.pool_name = asn['asn_pool']

--- a/jwst/pipeline/calwebb_tso3.py
+++ b/jwst/pipeline/calwebb_tso3.py
@@ -20,7 +20,6 @@ class Tso3Pipeline(Pipeline):
     """
     TSO3Pipeline: Applies level 3 processing to TSO-mode data from
                     any JWST instrument.
-
     Included steps are:
         outlier_detection
         tso_photometry
@@ -47,7 +46,6 @@ class Tso3Pipeline(Pipeline):
     def process(self, input):
         """
         Run the TSO3Pipeline
-
         Parameters
         ----------
         input: Level3 Association, json format
@@ -81,6 +79,7 @@ class Tso3Pipeline(Pipeline):
                 for i in range(cube.data.shape[0]):
                     # Update DQ arrays with those from outlier_detection step
                     cube.dq[i] = input_2dmodels[i].dq
+
                 cube.meta.cal_step.outlier_detection = \
                     input_2dmodels[0].meta.cal_step.outlier_detection
 
@@ -88,6 +87,7 @@ class Tso3Pipeline(Pipeline):
                 self.log.info("Performing scaled outlier detection on input images...")
                 cube = self.outlier_detection_scaled(cube)
 
+        
         if input_models[0].meta.cal_step.outlier_detection == 'COMPLETE':
             self.log.info("Writing Level 2c cubes with updated DQ arrays...")
             for cube in input_models:
@@ -114,7 +114,7 @@ class Tso3Pipeline(Pipeline):
             # define output for x1d (level 3) products
             x1d_result = datamodels.MultiSpecModel()
             # TODO: check to make sure the following line is working
-            x1d_result.update(input_models)
+            x1d_result.update(input_models[0])
 
             # For each exposure in the TSO...
             for cube in input_models:

--- a/jwst/pipeline/calwebb_tso3.py
+++ b/jwst/pipeline/calwebb_tso3.py
@@ -20,6 +20,7 @@ class Tso3Pipeline(Pipeline):
     """
     TSO3Pipeline: Applies level 3 processing to TSO-mode data from
                     any JWST instrument.
+
     Included steps are:
         outlier_detection
         tso_photometry
@@ -46,6 +47,7 @@ class Tso3Pipeline(Pipeline):
     def process(self, input):
         """
         Run the TSO3Pipeline
+
         Parameters
         ----------
         input: Level3 Association, json format
@@ -79,14 +81,12 @@ class Tso3Pipeline(Pipeline):
                 for i in range(cube.data.shape[0]):
                     # Update DQ arrays with those from outlier_detection step
                     cube.dq[i] = input_2dmodels[i].dq
-
                 cube.meta.cal_step.outlier_detection = \
                     input_2dmodels[0].meta.cal_step.outlier_detection
 
             else:
                 self.log.info("Performing scaled outlier detection on input images...")
                 cube = self.outlier_detection_scaled(cube)
-
         
         if input_models[0].meta.cal_step.outlier_detection == 'COMPLETE':
             self.log.info("Writing Level 2c cubes with updated DQ arrays...")

--- a/jwst/pipeline/calwebb_tso3.py
+++ b/jwst/pipeline/calwebb_tso3.py
@@ -87,7 +87,7 @@ class Tso3Pipeline(Pipeline):
             else:
                 self.log.info("Performing scaled outlier detection on input images...")
                 cube = self.outlier_detection_scaled(cube)
-        
+
         if input_models[0].meta.cal_step.outlier_detection == 'COMPLETE':
             self.log.info("Writing Level 2c cubes with updated DQ arrays...")
             for cube in input_models:


### PR DESCRIPTION
These minor changes go along with the changes in PRs #1243 and #1246 to get the CALTSO3 and CALCORON3 regression tests to run successfully again. 

The fixes resolve problems with how the cal_step status was updated for CALTSO3, what variable name actually refers to the real output in a log message in when reporting on blending metadata in CALCORON3, and what gets used to update the output NIRISS MultiSpec model for NIRISS CALTSO3 output. 