### PR TITLE
BOTS in calspec2

### DIFF
--- a/jwst/pipeline/calwebb_spec2.py
+++ b/jwst/pipeline/calwebb_spec2.py
@@ -209,8 +209,7 @@ class Spec2Pipeline(Pipeline):
             input = self.fringe(input)
 
         # Apply pathloss correction to NIRSpec exposures
-        if exp_type in ['NRS_FIXEDSLIT', 'NRS_BRIGHTOBJ', 'NRS_MSASPEC',
-                        'NRS_IFU']:
+        if exp_type in ['NRS_FIXEDSLIT', 'NRS_MSASPEC', 'NRS_IFU']:
             input = self.pathloss(input)
 
         # Apply flux calibration
@@ -229,9 +228,8 @@ class Spec2Pipeline(Pipeline):
         # "regular" spectra or cube_build for IFU data. No resampled
         # product is produced for time-series modes.
         if input.meta.exposure.type in [
-                'NRS_FIXEDSLIT', 'NRS_BRIGHTOBJ',
-                'NRS_MSASPEC', 'NIS_WFSS', 'NRC_GRISM'
-        ]:
+            'NRS_FIXEDSLIT', 'NRS_MSASPEC', 'NIS_WFSS', 'NRC_GRISM'
+            ]:
 
             # Call the resample_spec step
             self.resample_spec.suffix = 's2d'


### PR DESCRIPTION
NIRSpec TSO observations, `BRIGHTOBJ`, should not go through `resample` and `pathloss`.