### PR TITLE
Initial grism mode extract2d implementation

### DIFF
--- a/jwst/assign_wcs/util.py
+++ b/jwst/assign_wcs/util.py
@@ -369,8 +369,14 @@ def create_grism_bbox(input_model, reference_files, mmag_extract=99.0):
     """
 
     # get the filter that was used with the observation
-    filter_name = input_model.meta.instrument.filter
-
+    instr_name = input_model.meta.instrument.name
+    if instr_name == 'NIRCAM':
+        filter_name = input_model.meta.instrument.filter
+    elif instr_name == 'NIRISS':
+        filter_name = input_model.meta.instrument.pupil
+    else:
+        raise ValueError("Unsupported instrument specified in input_model")
+        
     # extract the catalog objects
     skyobject_list = get_object_info(input_model.meta.source_catalog.filename)
 

--- a/jwst/extract_2d/extract_2d.py
+++ b/jwst/extract_2d/extract_2d.py
@@ -26,13 +26,13 @@ def extract2d(input_model, which_subarray=None, apply_wavecorr=False, reffile=""
     elif exp_type in grism_modes:
         output_model = extract_grism_objects(input_model, grism_objects=[], reffile="")
 
-    elif exp_type not in supported_modes:
+    else:
         log.info("'EXP_TYPE {} not supported for extract 2D".format(exp_type))
         input_model.meta.cal_step.extract_2d = 'SKIPPED'
         return input_model
 
-    else:
-        # Set the step status to COMPLETE
-        output_model.meta.cal_step.extract_2d = 'COMPLETE'
-        del input_model
-        return output_model
+    
+    # Set the step status to COMPLETE
+    output_model.meta.cal_step.extract_2d = 'COMPLETE'
+    del input_model
+    return output_model

--- a/jwst/extract_2d/extract_2d.py
+++ b/jwst/extract_2d/extract_2d.py
@@ -4,18 +4,35 @@
 from __future__ import (absolute_import, unicode_literals, division,
                         print_function)
 
+import logging
+
 from .nirspec import nrs_extract2d
 from .grisms import extract_grism_objects
+
+log = logging.getLogger(__name__)
+log.setLevel(logging.DEBUG)
 
 
 def extract2d(input_model, which_subarray=None, apply_wavecorr=False, reffile=""):
     nrs_modes = ['NRS_FIXEDSLIT', 'NRS_MSASPEC', 'NRS_BRIGHTOBJ', 'NRS_LAMP']
     grism_modes = ['NIS_WFSS', 'NRC_GRISM']
     exp_type = input_model.meta.exposure.type.upper()
-
+    log.info('EXP_TYPE is {0}'.format(exp_type))
+    
     if exp_type in nrs_modes:
-        return nrs_extract2d(input_model, which_subarray=None,
+        output_model = nrs_extract2d(input_model, which_subarray=None,
                               apply_wavecorr=False, reffile="")
 
-    if exp_type in grism_modes:
-        return extract_grism_objects(input_model, grism_objects=[], reffile="")
+    elif exp_type in grism_modes:
+        output_model = extract_grism_objects(input_model, grism_objects=[], reffile="")
+
+    elif exp_type not in supported_modes:
+        log.info("'EXP_TYPE {} not supported for extract 2D".format(exp_type))
+        input_model.meta.cal_step.extract_2d = 'SKIPPED'
+        return input_model
+
+    else:
+        # Set the step status to COMPLETE
+        output_model.meta.cal_step.extract_2d = 'COMPLETE'
+        del input_model
+        return output_model

--- a/jwst/extract_2d/extract_2d.py
+++ b/jwst/extract_2d/extract_2d.py
@@ -5,12 +5,17 @@ from __future__ import (absolute_import, unicode_literals, division,
                         print_function)
 
 from .nirspec import nrs_extract2d
+from .grisms import extract_grism_objects
 
 
 def extract2d(input_model, which_subarray=None, apply_wavecorr=False, reffile=""):
     nrs_modes = ['NRS_FIXEDSLIT', 'NRS_MSASPEC', 'NRS_BRIGHTOBJ', 'NRS_LAMP']
+    grism_modes = ['NIS_WFSS', 'NRC_GRISM']
     exp_type = input_model.meta.exposure.type.upper()
 
     if exp_type in nrs_modes:
         return nrs_extract2d(input_model, which_subarray=None,
                               apply_wavecorr=False, reffile="")
+
+    if exp_type in grism_modes:
+        return extract_grism_objects(input_model, grism_objects=[], reffile="")

--- a/jwst/extract_2d/grisms.py
+++ b/jwst/extract_2d/grisms.py
@@ -38,6 +38,8 @@ def extract_grism_objects(input_model, grism_objects=[], reffile=""):
 
     Notes
     -----
+    This method supports NRC_GRISM and NIS_WFSS only
+
     GrismObject is a named tuple which contains distilled
     information about each catalog object. It can be created
     by calling jwst.assign_wcs.util.create_grism_bbox() which
@@ -45,8 +47,6 @@ def extract_grism_objects(input_model, grism_objects=[], reffile=""):
     boxes needed for extraction.
 
     """
-
-    supported_modes = ['NIS_WFSS', 'NRC_GRISM']
     if not grism_objects:
         # get the wavelengthrange reference file from the input_model
         if not reffile:
@@ -54,18 +54,9 @@ def extract_grism_objects(input_model, grism_objects=[], reffile=""):
         else:
             grism_objects = util.create_grism_bbox(input_model, {"wavelengthrange": reffile})
 
-    exp_type = input_model.meta.exposure.type.upper()
-    log.info('EXP_TYPE is {0}'.format(exp_type))
 
-
-    # Setup the output file
-    if exp_type not in supported_modes:
-        input_model.meta.cal_step.extract_2d = 'SKIPPED'
-        log.info('EXP_TYPE {0} is not supported for this method'.format(exp_type))
-        return input_model
-    else:
-        output_model = datamodels.MultiSlitModel()
-        output_model.update(input_model)
+    output_model = datamodels.MultiSlitModel()
+    output_model.update(input_model)
 
     # One WCS model can be used to govern all the extractions
     # and in fact the model transforms rely on the full frame
@@ -130,9 +121,6 @@ def extract_grism_objects(input_model, grism_objects=[], reffile=""):
     
     # memory reduction for pipeline chain        
     del subwcs
-    del input_model
-    # Set the step status to COMPLETE
-    output_model.meta.cal_step.extract_2d = 'COMPLETE'
     return output_model
 
 

--- a/jwst/extract_2d/grisms.py
+++ b/jwst/extract_2d/grisms.py
@@ -1,0 +1,165 @@
+#
+#  Module for 2d extraction of grism spectra
+#
+from __future__ import (absolute_import, unicode_literals, division,
+                        print_function)
+import logging
+import copy
+import numpy as np
+from astropy.modeling.models import Shift, Const1D, Mapping, Identity
+
+from .. import datamodels
+from ..assign_wcs import util
+
+
+log = logging.getLogger(__name__)
+log.setLevel(logging.DEBUG)
+
+
+def extract_grism_objects(input_model, grism_objects=[], reffile=""):
+    """
+    Extract 2d boxes around each objects spectra per order.
+
+    Parameters
+    ----------
+    input_model : jwst.datamodels.ImageModel
+
+    grism_objects : list[GrismObject]
+        A list of GrismObjects
+
+    reffile : str
+        The name of the wavelengthrange reference file
+
+
+    Returns
+    -------
+    output_model : jwst.datamodels.MultiSlitModel()
+
+
+    Notes
+    -----
+    GrismObject is a named tuple which contains distilled
+    information about each catalog object. It can be created
+    by calling jwst.assign_wcs.util.create_grism_bbox() which
+    will return a list of GrismObjects that countain the bounding
+    boxes needed for extraction.
+
+    """
+
+    supported_modes = ['NIS_WFSS', 'NRC_GRISM']
+    if not grism_objects:
+        # get the wavelengthrange reference file from the input_model
+        if not reffile:
+            raise ValueError("Expected name of wavelengthrange reference file")
+        else:
+            grism_objects = util.create_grism_bbox(input_model, {"wavelengthrange": reffile})
+
+    exp_type = input_model.meta.exposure.type.upper()
+    log.info('EXP_TYPE is {0}'.format(exp_type))
+
+
+    # Setup the output file
+    if exp_type not in supported_modes:
+        input_model.meta.cal_step.extract_2d = 'SKIPPED'
+        log.info('EXP_TYPE {0} is not supported for this method'.format(exp_type))
+        return input_model
+    else:
+        output_model = datamodels.MultiSlitModel()
+        output_model.update(input_model)
+
+    # One WCS model can be used to govern all the extractions
+    # and in fact the model transforms rely on the full frame
+    # coordinates of the input pixel location. So the WCS
+    # attached to the extraction is just a copy of the 
+    # input_model WCS with a shift transform to the corner
+    # of the subarray. They also depend on the source object
+    # center, this information will be saved to the meta of
+    # the output model as source_[x/y]pos
+    inwcs = input_model.meta.wcs 
+    subwcs = copy.deepcopy(inwcs)
+
+    # For easy reference here, GrismObjects has:
+    #
+    # xcenter,ycenter: in direct image pixels
+    # order_bounding in grism_detector pixels
+    # icrs_centroid: SkyCoord of object center
+    # sky_bbox_ :lower and upper bounding box in SkyCoord
+    # sid: catalog ID of the object
+
+    for obj in grism_objects:
+        for order in obj.order_bounding.keys():
+
+            # Add the shift to the lower corner to each subarray WCS object
+            # The shift should just be the lower bounding box corner
+            # also replace the object center location inputs to the GrismDispersion
+            # model with the known object center information (in pixels of direct image)
+            # This is changes the user input to the model from (x,y,x0,y0,order) -> (x,y,order)
+            #
+            # The bounding boxes here are also limited to the size of the detector
+            bb = obj.order_bounding[order]
+            xmin, xmax = int(round(max(bb[0][0], 0))), int(round(min(bb[0][1], input_model.meta.subarray.xsize)))  # limit the boxes to the detector
+            ymin, ymax = int(round(max(bb[1][0], 0))), int(round(min(bb[1][1], input_model.meta.subarray.ysize))) # limit the boxes to the detector
+
+            tr = inwcs.get_transform('grism_detector', 'detector')
+            tr = Identity(3) | (Mapping((0, 1, 0, 1, 2)) | Shift(xmin) & Shift(ymin) &
+                                                           Const1D(obj.xcenter) & Const1D(obj.ycenter) &
+                                                           Identity(1)) | tr
+            subwcs.set_transform('grism_detector', 'detector', tr)
+
+            log.info("Subarray extracted for obj: {} order: {}:".format(obj.sid, order))
+            log.info("Subarray extents are: ({}, {}), ({}, {})".format(xmin,ymin,xmax,ymax))
+
+            ext_data = input_model.data[ymin : ymax + 1, xmin : xmax+ 1].copy()
+            ext_err = input_model.err[ymin : ymax + 1, xmin : xmax + 1].copy()
+            ext_dq = input_model.dq[ymin : ymax + 1, xmin : xmax + 1].copy()
+
+            
+            new_model = datamodels.ImageModel(data=ext_data, err=ext_err, dq=ext_dq)
+            new_model.meta.wcs = subwcs
+            output_model.slits.append(new_model)
+
+            # set x/ystart values relative to the image (screen) frame.
+            # The overall subarray offset is recorded in model.meta.subarray.
+            # nslit = obj.sid - 1  # catalog id starts at zero
+            output_model.slits[-1].name = str(obj.sid)
+            output_model.slits[-1].xstart = xmin + 1
+            output_model.slits[-1].xsize = (xmax - xmin) + 1
+            output_model.slits[-1].ystart = ymin + 1
+            output_model.slits[-1].ysize = (ymax - ymin) + 1
+        
+    
+    # memory reduction for pipeline chain        
+    del subwcs
+    del input_model
+    # Set the step status to COMPLETE
+    output_model.meta.cal_step.extract_2d = 'COMPLETE'
+    return output_model
+
+
+# move to extract 2d for grism exposures
+# add the wavelength range using the far left and far right orders?
+# fselect1 = wrange_selector[0].index(input_model.meta.instrument.filter)
+# fselect2 = wrange_selector[-1].index(input_model.meta.instrument.filter)
+# lower_lam = wrange[0][fselect1][0]
+# upper_lam = wrange[-1][fselect2][1]
+# input_model.meta.wcsinfo.waverange_start = lower_lam
+# input_model.meta.wcsinfo.waverange_end = upper_lam
+
+def compute_dispersion(wcs):
+    """
+    Compute the pixel dispersion.
+    Make a model for the pixel dispersion from the grismconf specs
+
+    Parameters
+    ----------
+    wcs : `~gwcs.wcs.WCS`
+        The WCS object for this slit.
+
+    Returns
+    -------
+    dispersion : ndarray-like
+        The pixel dispersion [in m].
+
+    """
+    raise NotImplementedError
+


### PR DESCRIPTION
This implements extract 2D for the NIRCAM and NIRIS grism modes, excluding NRC_TSGRISM since that data does not need to be processed through extract2d.

*note that the process takes too long to test an entire catalog, but specifying just 1 object for which all orders are extracted, the output model writes and validates with expected data.