### PR TITLE
fix logic error for grism bounding box locations

### DIFF
--- a/jwst/assign_wcs/util.py
+++ b/jwst/assign_wcs/util.py
@@ -377,6 +377,10 @@ def create_grism_bbox(input_model, reference_files, mmag_extract=99.0):
     else:
         raise ValueError("Unsupported instrument specified in input_model")
         
+    # get the array extent to exclude boxes not contained on the detector
+    xsize = input_model.meta.subarray.xsize
+    ysize = input_model.meta.subarray.ysize
+
     # extract the catalog objects
     skyobject_list = get_object_info(input_model.meta.source_catalog.filename)
 
@@ -422,15 +426,33 @@ def create_grism_bbox(input_model, reference_files, mmag_extract=99.0):
             # add lmin and lmax used for the orders here?
             # input_model.meta.wcsinfo.waverange_start keys covers the
             # full range of all the orders
-            grism_objects.append(GrismObject(sid=obj.sid,
-                                             order_bounding=order_bounding,
-                                             icrs_centroid=obj.icrs_centroid,
-                                             xcenter=xcenter,
-                                             ycenter=ycenter,
-                                             sky_bbox_ll=obj.sky_bbox_ll,
-                                             sky_bbox_lr=obj.sky_bbox_lr,
-                                             sky_bbox_ul=obj.sky_bbox_ul,
-                                             sky_bbox_ur=obj.sky_bbox_ur))
+
+            # don't add objects which are entirely off the detector
+            # this could also live in extrac2d
+            # possible improvement is to add a member to GrismObject which
+            # marks off-detector objects which are near enough to cause
+            # spectra to be observed for later contamination removal, the
+            # rest of the objects can then be removed from the list which are
+            # much futher away
+            exclude = False
+            if (0 >= (ymin and ymax) <= ysize):
+                exclude = True
+            if (0 >= (xmin and xmax) <= xsize):
+                exclude = True
+            
+
+            if not exclude:
+                grism_objects.append(GrismObject(sid=obj.sid,
+                                                 order_bounding=order_bounding,
+                                                 icrs_centroid=obj.icrs_centroid,
+                                                 xcenter=xcenter,
+                                                 ycenter=ycenter,
+                                                 sky_bbox_ll=obj.sky_bbox_ll,
+                                                 sky_bbox_lr=obj.sky_bbox_lr,
+                                                 sky_bbox_ul=obj.sky_bbox_ul,
+                                                 sky_bbox_ur=obj.sky_bbox_ur))
+            else:
+                log.info("Excluding off-image object: {}".format(obj.sid))
 
     return grism_objects
 

--- a/jwst/extract_2d/extract_2d.py
+++ b/jwst/extract_2d/extract_2d.py
@@ -13,7 +13,7 @@ log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
 
-def extract2d(input_model, which_subarray=None, apply_wavecorr=False, reffile=""):
+def extract2d(input_model, which_subarray=None, apply_wavecorr=False, reffile="", grism_objects=[]):
     nrs_modes = ['NRS_FIXEDSLIT', 'NRS_MSASPEC', 'NRS_BRIGHTOBJ', 'NRS_LAMP']
     grism_modes = ['NIS_WFSS', 'NRC_GRISM']
     exp_type = input_model.meta.exposure.type.upper()
@@ -24,7 +24,7 @@ def extract2d(input_model, which_subarray=None, apply_wavecorr=False, reffile=""
                               apply_wavecorr=False, reffile="")
 
     elif exp_type in grism_modes:
-        output_model = extract_grism_objects(input_model, grism_objects=[], reffile="")
+        output_model = extract_grism_objects(input_model, grism_objects=grism_objects, reffile=reffile)
 
     else:
         log.info("'EXP_TYPE {} not supported for extract 2D".format(exp_type))

--- a/jwst/extract_2d/grisms.py
+++ b/jwst/extract_2d/grisms.py
@@ -87,9 +87,11 @@ def extract_grism_objects(input_model, grism_objects=[], reffile=""):
             # This is changes the user input to the model from (x,y,x0,y0,order) -> (x,y,order)
             #
             # The bounding boxes here are also limited to the size of the detector
+            # The check for boxes entirely off the detector is done in create_grism_bbox right now
             bb = obj.order_bounding[order]
             xmin, xmax = int(round(max(bb[0][0], 0))), int(round(min(bb[0][1], input_model.meta.subarray.xsize)))  # limit the boxes to the detector
             ymin, ymax = int(round(max(bb[1][0], 0))), int(round(min(bb[1][1], input_model.meta.subarray.ysize))) # limit the boxes to the detector
+            
 
             tr = inwcs.get_transform('grism_detector', 'detector')
             tr = Identity(3) | (Mapping((0, 1, 0, 1, 2)) | Shift(xmin) & Shift(ymin) &


### PR DESCRIPTION
This fixes a logic error which was extracting boxes calculated from the catalog which were entire off the detector.  I added logic to  `assign_wcs.util.create_grism_bbox` to exlude objects from the returned list which did not fall at least in part on the detector.  This could be updated in the future to  instead add a marker in the `GrismObject` for off detector sources which are still close enough to cast a spectrum onto the detector; this would aid in later contamination removal. For now I'm just excluding them. 

This also fixes an omitted signature parameter from the higher extract_2d call for the grisms.