### PR TITLE
allow additional properties in subarray

### DIFF
--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -648,7 +648,6 @@ properties:
             title: Number of pixels in detector y-axis direction
             type: integer
             fits_keyword: DETYSIZ
-        additionalProperties: false
       dither:
         title: Dither information
         type: object

--- a/jwst/datamodels/schemas/subarray.schema.yaml
+++ b/jwst/datamodels/schemas/subarray.schema.yaml
@@ -52,4 +52,3 @@ properties:
             title: Slow readout axis direction
             type: integer
             fits_keyword: SLOWAXIS
-        additionalProperties: false


### PR DESCRIPTION
This allows `p_subarray` to be included in the `subarray` schema from the `core` schema, so that `datamodels.open(distortinon_file)` works.

@hbushouse We haven't updated the `core` schema to reference the individual schemas. So both the short schemas and their predecessors in the `core` schema exist. Should we update the `core` schema to use the smaller schemas in one of the 7.1 updates or in 7.2 ?