### PR TITLE
updated extract2d to use reference file dictionary in step

### DIFF
--- a/jwst/extract_2d/extract_2d.py
+++ b/jwst/extract_2d/extract_2d.py
@@ -13,18 +13,24 @@ log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
 
-def extract2d(input_model, which_subarray=None, apply_wavecorr=False, reffile="", grism_objects=[]):
+def extract2d(input_model, which_subarray=None, apply_wavecorr=False, reference_files={}, grism_objects=[]):
+
+    if not any(reference_files.values()):
+        log.critical("extract2d needs reference files to make extractions, none were passed")
+        raise ValueError("extract2d needs reference files to make extractions, none were passed")
+
     nrs_modes = ['NRS_FIXEDSLIT', 'NRS_MSASPEC', 'NRS_BRIGHTOBJ', 'NRS_LAMP']
     grism_modes = ['NIS_WFSS', 'NRC_GRISM']
+    
     exp_type = input_model.meta.exposure.type.upper()
     log.info('EXP_TYPE is {0}'.format(exp_type))
     
     if exp_type in nrs_modes:
-        output_model = nrs_extract2d(input_model, which_subarray=None,
-                              apply_wavecorr=False, reffile="")
+        output_model = nrs_extract2d(input_model, which_subarray=which_subarray,
+                              apply_wavecorr=apply_wavecorr, reference_files=reference_files)
 
     elif exp_type in grism_modes:
-        output_model = extract_grism_objects(input_model, grism_objects=grism_objects, reffile=reffile)
+        output_model = extract_grism_objects(input_model, grism_objects=grism_objects, reference_files=reference_files)
 
     else:
         log.info("'EXP_TYPE {} not supported for extract 2D".format(exp_type))

--- a/jwst/extract_2d/extract_2d.py
+++ b/jwst/extract_2d/extract_2d.py
@@ -15,10 +15,6 @@ log.setLevel(logging.DEBUG)
 
 def extract2d(input_model, which_subarray=None, apply_wavecorr=False, reference_files={}, grism_objects=[]):
 
-    if not any(reference_files.values()):
-        log.critical("extract2d needs reference files to make extractions, none were passed")
-        raise ValueError("extract2d needs reference files to make extractions, none were passed")
-
     nrs_modes = ['NRS_FIXEDSLIT', 'NRS_MSASPEC', 'NRS_BRIGHTOBJ', 'NRS_LAMP']
     grism_modes = ['NIS_WFSS', 'NRC_GRISM']
     

--- a/jwst/extract_2d/extract_2d_step.py
+++ b/jwst/extract_2d/extract_2d_step.py
@@ -15,14 +15,17 @@ class Extract2dStep(Step):
         apply_wavecorr = boolean(default=True)
     """
 
-    reference_file_types = ['wavecorr']
-
+    reference_file_types = ['wavecorr', 'wavelengthrange']
 
     def process(self, input_model, *args, **kwargs):
-        reffile = self.get_reference_file(input_model, "wavecorr")
+        reference_file_names = {}
+        for reftype in self.reference_file_types:
+            reffile = self.get_reference_file(input_model, reftype)
+            reference_file_names[reftype] = reffile if reffile else ""
+
         with datamodels.open(input_model) as dm:
-            output_model = extract_2d.extract2d(dm, self.which_subarray,
-                                                self.apply_wavecorr, reffile=reffile)
+            output_model = extract_2d.extract2d(dm, self.which_subarray, self.apply_wavecorr,
+                                                reference_files=reference_file_names)
 
         return output_model
 

--- a/jwst/extract_2d/grisms.py
+++ b/jwst/extract_2d/grisms.py
@@ -16,7 +16,7 @@ log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
 
-def extract_grism_objects(input_model, grism_objects=[], reffile=""):
+def extract_grism_objects(input_model, grism_objects=[], reference_files={}):
     """
     Extract 2d boxes around each objects spectra per order.
 
@@ -49,10 +49,10 @@ def extract_grism_objects(input_model, grism_objects=[], reffile=""):
     """
     if not grism_objects:
         # get the wavelengthrange reference file from the input_model
-        if not reffile:
+        if (not reference_files['wavelengthrange'] or reference_files['wavelengthrange'] == 'N/A'):
             raise ValueError("Expected name of wavelengthrange reference file")
         else:
-            grism_objects = util.create_grism_bbox(input_model, {"wavelengthrange": reffile})
+            grism_objects = util.create_grism_bbox(input_model, reference_files)
 
 
     output_model = datamodels.MultiSlitModel()

--- a/jwst/extract_2d/nirspec.py
+++ b/jwst/extract_2d/nirspec.py
@@ -19,12 +19,13 @@ log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
 
-def nrs_extract2d(input_model, which_subarray=None, apply_wavecorr=False, reffile=""):
+def nrs_extract2d(input_model, which_subarray=None, apply_wavecorr=False, reference_files={}):
     exp_type = input_model.meta.exposure.type.upper()
     
     wavecorr_supported_modes = ['NRS_FIXEDSLIT', 'NRS_MSASPEC', 'NRS_BRIGHTOBJ']
     
     if exp_type in wavecorr_supported_modes:
+        reffile = reference_files['wavecorr']
         if reffile and reffile.strip().upper() == 'N/A':
             apply_wavecorr = False
             warnings.warn("WAVECORR reference file missing - skipping correction")


### PR DESCRIPTION
This updates the extrac2d step to pass a dictionary of reference file names to the lower calls. 
The update passes for grisms, @nden should check I did the correct thing for nirspec