### PR TITLE
calspec2 should always create a single IFU cube

### DIFF
--- a/jwst/pipeline/calwebb_spec2.py
+++ b/jwst/pipeline/calwebb_spec2.py
@@ -241,7 +241,10 @@ class Spec2Pipeline(Pipeline):
 
         elif exp_type in ['MIR_MRS', 'NRS_IFU']:
 
-            # Call the cube_build step for IFU data
+            # Call the cube_build step for IFU data;
+            # always create a single cube containing multiple
+            # wavelength bands
+            self.cube_build.output_type = 'multi'
             self.cube_build.suffix = 's3d'
             cube = self.cube_build(input)
 


### PR DESCRIPTION
Updated the calspec2 pipeline to set the cube_build output_type argument to "multi", so that it always produces a single IFU cube. Fixes #1265.