### PR TITLE
Update extract_1d to handle ModelContainer as input

### DIFF
--- a/jwst/extract_1d/extract_1d_step.py
+++ b/jwst/extract_1d/extract_1d_step.py
@@ -33,6 +33,8 @@ class Extract1dStep(Step):
         elif isinstance(input_model, datamodels.ImageModel):
             # It's a single 2-D image
             self.log.debug('Input is an ImageModel')
+        elif isinstance(input_model, datamodels.ModelContainer):
+            self.log.debug('Input is a ModelContainer')
         elif isinstance(input_model, datamodels.MultiSlitModel):
             self.log.debug('Input is a MultiSlitModel')
         elif isinstance(input_model, datamodels.MultiProductModel):
@@ -43,19 +45,53 @@ class Extract1dStep(Step):
             # Resampled 2-D data
             self.log.debug('Input is a DrizProductModel')
         else:
-            self.log.warning('Input is a %s,', str(type(input_model)))
-            self.log.warning('which was not expected for extract_1d.')
-
-        # Get the reference file name
-        self.ref_file = self.get_reference_file(input_model, 'extract1d')
-        self.log.info('Using EXTRACT1D reference file %s', self.ref_file)
+            self.log.error('Input is a %s,', str(type(input_model)))
+            self.log.error('which was not expected for extract_1d.')
+            self.log.error('extract_1d will be skipped.')
+            input_model.meta.cal_step.extract_1d = 'SKIPPED'
+            return input_model
 
         # Do the extraction
-        result = extract.do_extract1d(input_model, self.ref_file,
-                                      self.smoothing_length, self.bkg_order)
-
-        # Set the step flag to complete
-        result.meta.cal_step.extract_1d = 'COMPLETE'
+        if isinstance(input_model, datamodels.ModelContainer):
+            if len(input_model) > 1:
+                self.log.debug("Input contains %d items", len(input_model))
+                result = datamodels.ModelContainer()
+                for model in input_model:
+                    # Get the reference file name for each model in the input
+                    self.ref_file = self.get_reference_file(model, 'extract1d')
+                    self.log.info('Using EXTRACT1D reference file %s',
+                                  self.ref_file)
+                    temp = extract.do_extract1d(model, self.ref_file,
+                                                self.smoothing_length,
+                                                self.bkg_order)
+                    # Set the step flag to complete in each MultiSpecModel
+                    temp.meta.cal_step.extract_1d = 'COMPLETE'
+                    result.append(temp)
+                    del temp
+            elif len(input_model) == 1:
+                # Get the reference file name for the one model in the input
+                self.ref_file = self.get_reference_file(input_model[0],
+                                                        'extract1d')
+                self.log.info('Using EXTRACT1D reference file %s',
+                              self.ref_file)
+                result = extract.do_extract1d(input_model[0], self.ref_file,
+                                              self.smoothing_length,
+                                              self.bkg_order)
+                # Set the step flag to complete
+                result.meta.cal_step.extract_1d = 'COMPLETE'
+            else:
+                self.log.error('Input model is empty;')
+                self.log.error('extract_1d will be skipped.')
+                return input_model
+        else:
+            # Get the reference file name
+            self.ref_file = self.get_reference_file(input_model, 'extract1d')
+            self.log.info('Using EXTRACT1D reference file %s', self.ref_file)
+            result = extract.do_extract1d(input_model, self.ref_file,
+                                          self.smoothing_length,
+                                          self.bkg_order)
+            # Set the step flag to complete
+            result.meta.cal_step.extract_1d = 'COMPLETE'
 
         return result
 


### PR DESCRIPTION
If the input to the extract_1d step is a ModelContainer, extract_1d_step.py
now loops over the objects in the container and creates one MultiSpecModel
for each input.  If there is only one object in the input, the output will
be a MultiSpecModel; however, if the input contains more than one object,
the output will be a ModelContainer with one MultiSpecModel for each input
object.

If the input to the extract_1d step is not a ModelContainer, the step
will write a single MultiSpecModel as it did prior to these changes.
See issue #1264.