### PR TITLE
Fix calspec2 cube (s3d) file name

### DIFF
--- a/jwst/pipeline/calwebb_spec2.py
+++ b/jwst/pipeline/calwebb_spec2.py
@@ -252,7 +252,9 @@ class Spec2Pipeline(Pipeline):
             # wavelength bands
             self.cube_build.output_type = 'multi'
             self.cube_build.suffix = 's3d'
+            self.cube_build.save_results = False
             cube = self.cube_build(input)
+            self.save_model(cube[0], 's3d')
 
             # Pass the cube along for input to 1D extraction
             x1d_input = cube.copy()


### PR DESCRIPTION
Quick-n-dirty hack to calwebb_spec2 to force the pipeline to construct the proper exposure-based file name for the s3d files produced by the cube_build step. Right now cube_build is constructing output file names internally by taking the input file name and appending additional fields like channel/band numbers/names (for MIRI) or filter/grating names (for NIRSpec). This is not appropriate for use in the calwebb_spec2 pipeline, where the root names of all products must be the same simple exposure-based root name.

For example, in the case of a MIRI IFUSHORT (channels 1+2) rate image, the output file name created by cube_build is `jw80500018001_02101_00002_MIRIFUSHORT_rate_ch1-2-medium_s3d.fits`. This type of name is only appropriate for level-3 processing. For level-2b, the name should simply be `jw80500018001_02101_00002_MIRIFUSHORT_s3d.fits`.

This update turns off the automatic saving of products by the cube_build step and instead calls the .save_model method to save the cube_build result with the proper file name, just so that things are working properly for the B7.1 delivery.

At some point in the future cube_build will need to be updated to construct the file names properly (if possible).