### PR TITLE
Convert reference data from float to complex.

### DIFF
--- a/jwst/datamodels/irs2.py
+++ b/jwst/datamodels/irs2.py
@@ -16,8 +16,10 @@ class IRS2Model(model_base.DataModel):
         Any of the initializers supported by `~jwst.datamodels.DataModel`.
 
     irs2_table : numpy array
-        A table with 8 columns and 1458176 (2048 * 712) rows; all values
-        are complex.  There are four columns for ALPHA and four for BETA.
+        A table with 8 columns and 2916352 (2048 * 712 * 2) rows.  All
+        values are float, but these are interpreted as alternating real
+        and imaginary parts (real, imag, real, imag, ...) of complex
+        values.  There are four columns for ALPHA and four for BETA.
     """
     schema_url = "irs2.schema.yaml"
 

--- a/jwst/datamodels/schemas/irs2.schema.yaml
+++ b/jwst/datamodels/schemas/irs2.schema.yaml
@@ -8,19 +8,19 @@ allOf:
       fits_hdu: IRS2
       datatype:
       - name: alpha_0
-        datatype: complex64
+        datatype: float32
       - name: alpha_1
-        datatype: complex64
+        datatype: float32
       - name: alpha_2
-        datatype: complex64
+        datatype: float32
       - name: alpha_3
-        datatype: complex64
+        datatype: float32
       - name: beta_0
-        datatype: complex64
+        datatype: float32
       - name: beta_1
-        datatype: complex64
+        datatype: float32
       - name: beta_2
-        datatype: complex64
+        datatype: float32
       - name: beta_3
-        datatype: complex64
+        datatype: float32
 $schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/refpix/irs2_subtract_reference.py
+++ b/jwst/refpix/irs2_subtract_reference.py
@@ -110,17 +110,14 @@ def correct_model(input_model, irs2_model,
     if beta is None:
         log.info("Using reference pixels only.")
 
-    try:
-        scipix_n = input_model.meta.exposure.nrs_normal
-    except AttributeError as errmsg:
-        log.warning(errmsg)
+    scipix_n = input_model.meta.exposure.nrs_normal
+    if scipix_n is None:
         log.warning("Keyword NRS_NORM not found; using default value %d" %
                     scipix_n_default)
         scipix_n = scipix_n_default
-    try:
-        refpix_r = input_model.meta.exposure.nrs_reference
-    except AttributeError as errmsg:
-        log.warning(errmsg)
+
+    refpix_r = input_model.meta.exposure.nrs_reference
+    if refpix_r is None:
         log.warning("Keyword NRS_REF not found; using default value %d" %
                     refpix_r_default)
         refpix_r = refpix_r_default

--- a/jwst/refpix/irs2_subtract_reference.py
+++ b/jwst/refpix/irs2_subtract_reference.py
@@ -72,22 +72,40 @@ def correct_model(input_model, irs2_model,
     """
 
     output_model = input_model.copy()
+    output_model.meta.cal_step.refpix = 'not specified yet'
 
     # Get reference data.
+    # The reference data are complex, but they're stored as float, with
+    # alternating real and imaginary parts.  We therefore check for twice
+    # as many rows as we actually want, and we'll divide that number by two
+    # when allocating the arrays alpha and beta.
     nrows = len(irs2_model.irs2_table.field("alpha_0"))
-    if nrows != 712 * 2048:
-        log.warning("Number of rows in reference file = %d,"
-                    " but it should be 1458176." % nrows)
-    alpha = np.ones((4, nrows), dtype=np.complex64)
-    beta = np.zeros((4, nrows), dtype=np.complex64)
-    alpha[0, :] = irs2_model.irs2_table.field("alpha_0")
-    alpha[1, :] = irs2_model.irs2_table.field("alpha_1")
-    alpha[2, :] = irs2_model.irs2_table.field("alpha_2")
-    alpha[3, :] = irs2_model.irs2_table.field("alpha_3")
-    beta[0, :] = irs2_model.irs2_table.field("beta_0")
-    beta[1, :] = irs2_model.irs2_table.field("beta_1")
-    beta[2, :] = irs2_model.irs2_table.field("beta_2")
-    beta[3, :] = irs2_model.irs2_table.field("beta_3")
+    expected_nrows = 2 * 712 * 2048
+    if nrows != expected_nrows:
+        log.error("Number of rows in reference file = {},"
+                  " but it should be {}.".format(nrows, expected_nrows))
+        output_model.meta.cal_step.refpix = 'SKIPPED'
+        return output_model
+    alpha = np.ones((4, nrows // 2), dtype=np.complex64)
+    beta = np.zeros((4, nrows // 2), dtype=np.complex64)
+
+    alpha[0, :] = float_to_complex(
+                        irs2_model.irs2_table.field("alpha_0"))
+    alpha[1, :] = float_to_complex(
+                        irs2_model.irs2_table.field("alpha_1"))
+    alpha[2, :] = float_to_complex(
+                        irs2_model.irs2_table.field("alpha_2"))
+    alpha[3, :] = float_to_complex(
+                        irs2_model.irs2_table.field("alpha_3"))
+
+    beta[0, :] = float_to_complex(
+                    irs2_model.irs2_table.field("beta_0"))
+    beta[1, :] = float_to_complex(
+                    irs2_model.irs2_table.field("beta_1"))
+    beta[2, :] = float_to_complex(
+                    irs2_model.irs2_table.field("beta_2"))
+    beta[3, :] = float_to_complex(
+                    irs2_model.irs2_table.field("beta_3"))
 
     if beta is None:
         log.info("Using reference pixels only.")
@@ -149,6 +167,14 @@ def correct_model(input_model, irs2_model,
     exclude_ref(output_model, irs2_mask)
 
     return output_model
+
+
+def float_to_complex(data):
+    """Convert real and imaginary parts to complex"""
+
+    nelem = len(data)
+
+    return data[0:-1:2] + 1j * data[1:nelem:2]
 
 def make_irs2_mask(output_model, scipix_n, refpix_r):
 

--- a/jwst/refpix/refpix_step.py
+++ b/jwst/refpix/refpix_step.py
@@ -43,7 +43,8 @@ class RefPixStep(Step):
                 irs2_model = datamodels.IRS2Model(self.irs2_name)
                 result = irs2_subtract_reference.correct_model(input_model,
                                                                irs2_model)
-                result.meta.cal_step.refpix = 'COMPLETE'
+                if result.meta.cal_step.refpix != 'SKIPPED':
+                    result.meta.cal_step.refpix = 'COMPLETE'
                 irs2_model.close()
             else:
                 self.log.info('use_side_ref_pixels = %s' %

--- a/jwst/refpix/refpix_step.py
+++ b/jwst/refpix/refpix_step.py
@@ -46,6 +46,7 @@ class RefPixStep(Step):
                 if result.meta.cal_step.refpix != 'SKIPPED':
                     result.meta.cal_step.refpix = 'COMPLETE'
                 irs2_model.close()
+                return result
             else:
                 self.log.info('use_side_ref_pixels = %s' %
                               (self.use_side_ref_pixels,))


### PR DESCRIPTION
The schema for the IRS2 reference file was changed to specify that the
columns are float32 rather than complex64.  irs2_subtract_reference.py
was modified to convert these values to complex.
See GitHub issue #1277 and JIRA ticket JP-181.