### PR TITLE
Pipeline precache skip override

### DIFF
--- a/jwst/stpipe/pipeline.py
+++ b/jwst/stpipe/pipeline.py
@@ -104,7 +104,7 @@ class Pipeline(Step):
 
         """
         for step in self._unskipped_steps:
-            override = step._get_ref_override(reference_file_type):
+            override = step._get_ref_override(reference_file_type)
             if override is not None:
                 return override
         return None

--- a/jwst/stpipe/pipeline.py
+++ b/jwst/stpipe/pipeline.py
@@ -79,11 +79,36 @@ class Pipeline(Step):
 
             setattr(self, key, new_step)
 
-        self.reference_file_types = []
-        for name in self.step_defs.keys():
-            step = getattr(self, name)
-            self.reference_file_types += step.reference_file_types
+        self.reference_file_types = self._collect_active_reftypes()
 
+    def _collect_active_reftypes(self):
+        """Collect the list of non-overridden reftypes for all child
+        Steps that are not skipped.
+        """
+        return [reftype for step in self._unskipped_steps
+                for reftype in step.reference_file_types]
+
+    @property 
+    def _unskipped_steps(self):
+        """Return a list of the unskipped Step objects launched by `self`."""
+        return [getattr(self, name) for name in self.step_defs.keys()
+                if not getattr(self, name).skip]
+
+    def _get_ref_override(self, reference_file_type):
+        """Return any override for `reference_file_type` for any of the steps in
+        Pipeline `self`.  OVERRIDES Step.
+        
+        Returns
+        -------
+        override_filepath or None.
+
+        """
+        for step in self._unskipped_steps:
+            override = step._get_ref_override(reference_file_type):
+            if override is not None:
+                return override
+        return None
+            
     @classmethod
     def merge_config(cls, config, config_file):
         steps = config.get('steps', {})


### PR DESCRIPTION
This fix addresses an issue with the test_coron3_1.py unit test where the PSF reference file is being overridden...  but CRDS still attempts to assign and precache a reference at the pipeline level which cannot be found.

It adds support for "skip" and "override" to the recent Pipeline level pre-caching change needed to consolidate multiple reference file calls into a single CRDS call per pipeline to improve error reporting.    reference_file_types at the pipeline level is limited to those Steps that are not skipped and those references within Steps that are not overridden.
