### PR TITLE
Add sky bounding box properties to source catalog

### DIFF
--- a/jwst/source_catalog/source_catalog.py
+++ b/jwst/source_catalog/source_catalog.py
@@ -132,7 +132,8 @@ def make_source_catalog(model, kernel_fwhm, kernel_xsize, kernel_ysize,
     columns = ['id', 'xcentroid', 'ycentroid', 'ra_icrs_centroid',
                'dec_icrs_centroid', 'area', 'source_sum',
                'source_sum_err', 'semimajor_axis_sigma',
-               'semiminor_axis_sigma', 'orientation']
+               'semiminor_axis_sigma', 'orientation',
+               'sky_bbox_ll', 'sky_bbox_ul', 'sky_bbox_lr', 'sky_bbox_ur']
     catalog = photutils.properties_table(source_props, columns=columns)
 
     # convert orientation to degrees

--- a/jwst/source_catalog/source_catalog.py
+++ b/jwst/source_catalog/source_catalog.py
@@ -137,7 +137,6 @@ def make_source_catalog(model, kernel_fwhm, kernel_xsize, kernel_ysize,
     catalog = photutils.properties_table(source_props, columns=columns)
 
     # convert orientation to degrees
-    catalog = QTable(catalog)
     orient_deg = catalog['orientation'].to(u.deg)
     catalog.replace_column('orientation', orient_deg)
 

--- a/jwst/source_catalog/source_catalog.py
+++ b/jwst/source_catalog/source_catalog.py
@@ -129,9 +129,8 @@ def make_source_catalog(model, kernel_fwhm, kernel_xsize, kernel_ysize,
     source_props = photutils.source_properties(
         model.data, segm, error=total_error, filter_kernel=kernel, wcs=wcs)
 
-    columns = ['id', 'xcentroid', 'ycentroid', 'ra_icrs_centroid',
-               'dec_icrs_centroid', 'area', 'source_sum',
-               'source_sum_err', 'semimajor_axis_sigma',
+    columns = ['id', 'xcentroid', 'ycentroid', 'sky_centroid', 'area',
+               'source_sum', 'source_sum_err', 'semimajor_axis_sigma',
                'semiminor_axis_sigma', 'orientation',
                'sky_bbox_ll', 'sky_bbox_ul', 'sky_bbox_lr', 'sky_bbox_ur']
     catalog = photutils.properties_table(source_props, columns=columns)


### PR DESCRIPTION
These properties will be used by the wide-field slitless spectroscopy pipeline.

CC: @sosey, @hbushouse