### PR TITLE
Fix typo in calwebb_spec3.py

### DIFF
--- a/jwst/pipeline/calwebb_spec3.py
+++ b/jwst/pipeline/calwebb_spec3.py
@@ -130,7 +130,7 @@ class Spec3Pipeline(Pipeline):
             if exptype in IFU_EXPTYPES:
                 result = self.cube_build(result)
                 try:
-                    resample_complete = result.meta.cal_step.cube_build
+                    resample_complete = result[0].meta.cal_step.cube_build
                 except AttributeError:
                     pass
             else:


### PR DESCRIPTION
"result" was changed to "result[0]" to fix part of issue #1288.  This change does not close this issue, but doing it first simplifies making further changes and testing.