### PR TITLE
Remove extra_fits when readung and writing model file from disk

### DIFF
--- a/jwst/datamodels/fits_support.py
+++ b/jwst/datamodels/fits_support.py
@@ -370,6 +370,10 @@ def _save_extra_fits(hdulist, tree):
                     continue
                 hdu.header.append((key, val, comment), end=True)
 
+    # Remove extra_fits so it is not written to the asdf extension
+    if 'extra_fits' in tree:
+        del tree['extra_fits']
+
 
 def _save_history(hdulist, tree):
     history = tree.get('history', [])
@@ -536,7 +540,11 @@ def _load_from_schema(hdulist, schema, tree, pass_invalid_values):
 
 
 def _load_extra_fits(hdulist, known_keywords, known_datas, tree):
-    # Handle _extra_fits
+    # Remove any extra_fits from tree
+    if 'extra_fits' in tree:
+        del tree['extra_fits']
+
+    # Add header keywords and data not in schema to extra_fits
     for hdu in hdulist:
         known = known_keywords.get(hdu, set())
 
@@ -551,9 +559,10 @@ def _load_extra_fits(hdulist, known_keywords, known_datas, tree):
                 ['extra_fits', hdu.name, 'header'], cards, tree)
 
         if hdu not in known_datas:
-            if hdu.data is not None:
-                properties.put_value(
-                    ['extra_fits', hdu.name, 'data'], hdu.data, tree)
+            if hdu.name.lower() != 'asdf':
+                if hdu.data is not None:
+                    properties.put_value(
+                        ['extra_fits', hdu.name, 'data'], hdu.data, tree)
 
 
 def _load_history(hdulist, tree):


### PR DESCRIPTION
The extra_fits area in a datamodel is intended to hold the information from a file that is not contained in the model schema. It is temporary and should not be persisted to disk in the asdf extension
when saving a model file. This change removes the extra_fits section of a tree after loading the asdf extension from a file and before writing the asdf extension to a file. In addition, it checks to make
sure that the asdf extension is not saved in the extra_fits area.