### PR TITLE
Update NIRSpec IRS2 keyword attribute names

### DIFF
--- a/jwst/ipc/x_irs2.py
+++ b/jwst/ipc/x_irs2.py
@@ -62,16 +62,20 @@ def _get_irs2_parameters(input_model, n=None, r=None):
     """
 
     try:
-        # I simply made up these names, so I expect this to fail.
-        n_norm = input_model.meta.exposure.irs2_norm
-        n_ref = input_model.meta.exposure.irs2_ref
+        # Try to get keyword values
+        n_norm = input_model.meta.exposure.nrs_normal
+        n_ref = input_model.meta.exposure.nrs_reference
     except AttributeError:
+        # If keywords are missing, set default values
         n_norm = 16
         n_ref = 4
+
+    # Check for user-supplied values
     if n is not None:
         n_norm = n
     if r is not None:
         n_ref = r
+
     param = ReadoutParam(refout=(512 + 512 // n_norm * n_ref),
                          n=n_norm, r=n_ref)
 

--- a/jwst/persistence/persistence.py
+++ b/jwst/persistence/persistence.py
@@ -643,9 +643,9 @@ class DataSet():
         self.groupgap = self.output_obj.meta.exposure.groupgap
         try:
             if integ == 0:
-                self.nresets = self.output_obj.meta.exposure.nrststrt
+                self.nresets = self.output_obj.meta.exposure.nresets_at_start
             else:
-                self.nresets = self.output_obj.meta.exposure.nresets
+                self.nresets = self.output_obj.meta.exposure.nresets_between_ints
         except AttributeError:
             if self.output_obj.meta.instrument.detector == "MIRI":
                 self.nresets = 0

--- a/jwst/refpix/irs2_subtract_reference.py
+++ b/jwst/refpix/irs2_subtract_reference.py
@@ -93,14 +93,14 @@ def correct_model(input_model, irs2_model,
         log.info("Using reference pixels only.")
 
     try:
-        scipix_n = input_model.meta.exposure.nrs_norm
+        scipix_n = input_model.meta.exposure.nrs_normal
     except AttributeError as errmsg:
         log.warning(errmsg)
         log.warning("Keyword NRS_NORM not found; using default value %d" %
                     scipix_n_default)
         scipix_n = scipix_n_default
     try:
-        refpix_r = input_model.meta.exposure.nrs_ref
+        refpix_r = input_model.meta.exposure.nrs_reference
     except AttributeError as errmsg:
         log.warning(errmsg)
         log.warning("Keyword NRS_REF not found; using default value %d" %

--- a/jwst/saturation/x_irs2.py
+++ b/jwst/saturation/x_irs2.py
@@ -62,16 +62,20 @@ def _get_irs2_parameters(input_model, n=None, r=None):
     """
 
     try:
-        # I simply made up these names, so I expect this to fail.
-        n_norm = input_model.meta.exposure.irs2_norm
-        n_ref = input_model.meta.exposure.irs2_ref
+        # Try to get keyword values
+        n_norm = input_model.meta.exposure.nrs_normal
+        n_ref = input_model.meta.exposure.nrs_reference
     except AttributeError:
+        # If keywords are missing, use default values
         n_norm = 16
         n_ref = 4
+
+    # Check for user-supplied values
     if n is not None:
         n_norm = n
     if r is not None:
         n_ref = r
+
     param = ReadoutParam(refout=(512 + 512 // n_norm * n_ref),
                          n=n_norm, r=n_ref)
 


### PR DESCRIPTION
Updated 3 modules in the ipc, refpix, and saturation steps to use new meta attribute names for the NIRSpec IRS2 readout keywords NRS_NORM and NRS_REF, in keeping with recent changes/additions to the core schema for these keywords.