### PR TITLE
Fix WCS crpix values in cube_build

### DIFF
--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -709,9 +709,9 @@ class IFUCubeData(object):
         IFUCube.meta.wcsinfo.crval1 = self.Crval1
         IFUCube.meta.wcsinfo.crval2 = self.Crval2
         IFUCube.meta.wcsinfo.crval3 = self.Crval3
-        IFUCube.meta.wcsinfo.crpix1 = self.Crpix1
-        IFUCube.meta.wcsinfo.crpix2 = self.Crpix2
-        IFUCube.meta.wcsinfo.crpix3 = self.Crpix3
+        IFUCube.meta.wcsinfo.crpix1 = self.Crpix1+1
+        IFUCube.meta.wcsinfo.crpix2 = self.Crpix2+1
+        IFUCube.meta.wcsinfo.crpix3 = self.Crpix3+1
         IFUCube.meta.wcsinfo.cdelt1 = self.Cdelt1/3600.0
         IFUCube.meta.wcsinfo.cdelt2 = self.Cdelt2/3600.0
         IFUCube.meta.wcsinfo.cdelt3 = self.Cdelt3


### PR DESCRIPTION
IFU cube WCS is saving 0-indexed crpix locations instead of 1-indexed FITS standard, so cube WCS is off by 1 pixel from correct values.  I've added this back into the metadata values, and verified performance against an idealized input array.