### PR TITLE
Fix for jump detection when there are saturated groups

### DIFF
--- a/jwst/jump/tests/test_twopoint_difference.py
+++ b/jwst/jump/tests/test_twopoint_difference.py
@@ -1,7 +1,9 @@
-from ..twopoint_difference import find_CRs
+
+from twopoint_difference import find_CRs
 import numpy as np
 import pytest
-from ...datamodels import dqflags
+import dqflags
+from astropy.io import fits
 
 #@pytest.mark.skip(reason="testing skipping")
 def test_noCRs_NoFlux():
@@ -57,7 +59,7 @@ def test_3grps_cr2_NoFlux():
     assert(np.array_equal([0, 4, 0], gdq[0, :, 100, 100]))
 
 
-#@pytest.mark.skip("testing skipping")
+#@pytest.mark.xfail("testing skipping")
 def test_4grps_cr2_NoFlux():
     ngroups=4
     data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups)
@@ -83,7 +85,7 @@ def test_5grps_cr2_nframe2():
     assert(4 == np.max(gdq)) #a CR was found
     assert(np.array_equal([0,4,4,0,0], gdq[0, :, 100, 100]) )
 
-@pytest.mark.xfail(run=False)
+@pytest.mark.xfail
 def test_4grps_twocrs_2nd_4th():
     ngroups=4
     data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups)
@@ -153,16 +155,16 @@ def test_10grps_twocrs_10percenthit():
     ngroups=10
     data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups)
     nframes=2
-    data[0, 0, 100, 100] = 10.0
-    data[0, 1, 100, 100] = 60
-    data[0, 2, 100, 100] = 60
-    data[0, 3, 100, 100] = 60
-    data[0, 4, 100, 100] = 60
-    data[0, 5, 100, 100] = 60
-    data[0, 6, 100, 100] = 60
-    data[0, 7, 100, 100] = 2115
-    data[0, 8, 100, 100] = 2115
-    data[0, 9, 100, 100] = 2115
+    data[0:200, 0, 100, 100] = 10.0
+    data[0:200, 1, 100, 100] = 60
+    data[0:200, 2, 100, 100] = 60
+    data[0:200, 3, 100, 100] = 60
+    data[0:200, 4, 100, 100] = 60
+    data[0:200, 5, 100, 100] = 60
+    data[0:200, 6, 100, 100] = 60
+    data[0:200, 7, 100, 100] = 2115
+    data[0:200, 8, 100, 100] = 2115
+    data[0:200, 9, 100, 100] = 2115
     medianDiff = find_CRs(data, gdq, read_noise, rej_threshold, nframes)
     print("calculated median diff of pixel is ", medianDiff[0, 100, 100])
     assert(4 == np.max(gdq)) #a CR was found
@@ -226,18 +228,18 @@ def test_6grps_twocrs_twopixels_nframes2():
     data[0, 3, 100, 100] = 60
     data[0, 4, 100, 100] = 115
     data[0, 5, 100, 100] = 115
-    data[0, 0, 120, 100] = 10.0
-    data[0, 1, 120, 100] = 10.0
-    data[0, 2, 120, 100] = 60
-    data[0, 3, 120, 100] = 60
-    data[0, 4, 120, 100] = 115
-    data[0, 5, 120, 100] = 115
+    data[0, 0, 200, 100] = 10.0
+    data[0, 1, 200, 100] = 10.0
+    data[0, 2, 200, 100] = 60
+    data[0, 3, 200, 100] = 60
+    data[0, 4, 200, 100] = 115
+    data[0, 5, 200, 100] = 115
     medianDiff = find_CRs(data, gdq, read_noise, rej_threshold, nframes)
     assert(4 == np.max(gdq)) #a CR was found
     print("100 100 dq",repr(gdq[0,:,100,100]))
-    print("120 100 dq",repr(gdq[0,:,120,100]))
+    print("200 100 dq",repr(gdq[0,:,200,100]))
     assert(np.array_equal([0,4,0,0,4,0] , gdq[0, :, 100, 100]) )
-    assert(np.array_equal([0, 0, 4, 0, 4, 0] , gdq[0, :, 120, 100]))
+    assert(np.array_equal([0, 0, 4, 0, 4, 0] , gdq[0, :, 200, 100]))
 
 #@pytest.mark.skip("testing skipping")
 def test_5grps_cr2_negslope():
@@ -253,7 +255,7 @@ def test_5grps_cr2_negslope():
     print("calculated median diff of pixel is ", medianDiff[0, 100, 100])
     assert(4 == np.max(gdq))  # a CR was found
     assert(np.array_equal([0, 0, 4, 0, 0] , gdq[0, :, 100, 100]))
-
+#@pytest.mark.skip
 def test_6grps_1CR():
     ngroups = 6
     data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups,readnoise=10)
@@ -267,7 +269,7 @@ def test_6grps_1CR():
     medianDiff = find_CRs(data, gdq, read_noise, rej_threshold, nframes)
     print("calculated median diff of pixel is ", medianDiff[0, 100, 100])
     assert(11 == medianDiff[0, 100, 100])
-
+#@pytest.mark.skip
 def test_7grps_1CR():
     ngroups = 7
     data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups,readnoise=10)
@@ -282,7 +284,7 @@ def test_7grps_1CR():
     medianDiff = find_CRs(data, gdq, read_noise, rej_threshold, nframes)
     print("calculated median diff of pixel is ", medianDiff[0, 100, 100])
     assert(11.5 == medianDiff[0, 100, 100])
-
+#@pytest.mark.skip
 def test_5grps_noCR():
     ngroups = 6
     data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups,readnoise=10)
@@ -295,7 +297,7 @@ def test_5grps_noCR():
     medianDiff = find_CRs(data, gdq, read_noise, rej_threshold, nframes)
     print("calculated median diff of pixel is ", medianDiff[0, 100, 100])
     assert(11 == medianDiff[0, 100, 100])
-
+#@pytest.mark.skip
 def test_6grps_noCR():
     ngroups = 6
     data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups,readnoise=10)
@@ -367,11 +369,11 @@ def test_10grps_noCR_2pixels_sigma0():
     nframes=1
     data[0, 0, 100, 100] = crmag
     data[0, 1:11, 100, 100] = crmag
-    read_noise[50, 50] = 0.0
-    read_noise[60, 60] = 0.0
+    read_noise[500, 500] = 0.0
+    read_noise[600, 600] = 0.0
     medianDiff = find_CRs(data, gdq, read_noise, rej_threshold, nframes)
     assert(0 == np.max(gdq))  # no CR was found
-
+#@pytest.mark.skip
 def test_5grps_Satat4_CRat3():
     ngroups = 5
     crmag = 1000
@@ -388,7 +390,57 @@ def test_5grps_Satat4_CRat3():
    # assert(4 == np.max(gdq))  # no CR was found
     assert (np.array_equal([0, 0, dqflags.group['JUMP_DET'],dqflags.group['SATURATED'], dqflags.group['SATURATED']], gdq[0, :, 100, 100]))
 
+#@pytest.mark.skip
+def test_6grps_Satat6_CRat1():
+    ngroups = 6
+    crmag = 1000
+    data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups, readnoise=5 * np.sqrt(2))
+    nframes=1
+    data[0, 0, 100, 100] = 10000
+    data[0, 1, 100, 100] = 35000 #CR
+    data[0, 2, 100, 100] = 40005
+    data[0, 3, 100, 100] = 45029
+    data[0, 4, 100, 100] = 50014
+    data[0, 5, 100, 101] = 61000
+    data[0, 0, 100, 101] = 10000
+    data[0, 1, 100, 101] = 15001
+    data[0, 2, 100, 101] = 20003
+    data[0, 3, 100, 101] = 25006
+    data[0, 4, 100, 101] = 30010
+    data[0, 5, 100, 101] = 35015
+    gdq[0, 5, 100, 100] = dqflags.group['SATURATED']
+    medianDiff = find_CRs(data, gdq, read_noise, rej_threshold, nframes)
+   # assert(4 == np.max(gdq))  # no CR was found
+    assert (np.array_equal([0, dqflags.group['JUMP_DET'], 0,0,0, dqflags.group['SATURATED']], gdq[0, :, 100, 100]))
 
+
+@pytest.mark.xfail
+def test_6grps_Satat6_CRat1_flagadjpixels():
+    ngroups = 6
+    crmag = 1000
+    data, gdq, nframes, read_noise, rej_threshold = setup_cube(ngroups, readnoise=5 * np.sqrt(2))
+    nframes=1
+    data[0, 0, 100, 100] = 10000
+    data[0, 1, 100, 100] = 35000 #CR
+    data[0, 2, 100, 100] = 40005
+    data[0, 3, 100, 100] = 45029
+    data[0, 4, 100, 100] = 50014
+    data[0, 5, 100, 101] = 61000
+    data[0, 0, 100, 101] = 10000
+    data[0, 1, 100, 101] = 15001
+    data[0, 2, 100, 101] = 20003
+    data[0, 3, 100, 101] = 25006
+    data[0, 4, 100, 101] = 30010
+    data[0, 5, 100, 101] = 35015
+    gdq[0, 5, 100, 100] = dqflags.group['SATURATED']
+    medianDiff = find_CRs(data, gdq, read_noise, rej_threshold, nframes)
+   # assert(4 == np.max(gdq))  # no CR was found
+    assert (np.array_equal([0, dqflags.group['JUMP_DET'], 0,0,0, dqflags.group['SATURATED']], gdq[0, :, 100, 100]))
+    assert (np.array_equal([0, dqflags.group['JUMP_DET'], 0, 0, 0, dqflags.group['SATURATED']], gdq[0, :, 99, 100]))
+    assert (np.array_equal([0, dqflags.group['JUMP_DET'], 0, 0, 0, dqflags.group['SATURATED']], gdq[0, :, 101, 100]))
+    assert (np.array_equal([0, dqflags.group['JUMP_DET'], 0, 0, 0, dqflags.group['SATURATED']], gdq[0, :, 100, 99]))
+    assert (np.array_equal([0, dqflags.group['JUMP_DET'], 0, 0, 0, dqflags.group['SATURATED']], gdq[0, :, 100, 101]))
+    
 #@pytest.mark.skip
 def test_10grps_Satat8_CRsat3and6():
     ngroups = 10
@@ -412,8 +464,8 @@ def test_10grps_Satat8_CRsat3and6():
 
 def setup_cube(ngroups,readnoise=10):
     nints = 1
-    nrows = 200
-    ncols = 200
+    nrows = 2048
+    ncols = 2048
     rej_threshold = 3
     nframes = 1
     data = np.zeros(shape=(nints, ngroups, nrows, ncols), dtype=np.float32)
@@ -424,6 +476,6 @@ def setup_cube(ngroups,readnoise=10):
     return data, gdq, nframes, read_noise, rej_threshold
 
 
-#if __name__ == '__main__':
-#    pytest.main(['-x', 'test_find_CRs_mwr.py'])
-#   # pytest.main(['test_find_CRs_mwr.py'])
+if __name__ == '__main__':
+    pytest.main(['-x', 'test_find_CRs_mwr.py'])
+   # pytest.main(['test_find_CRs_mwr.py'])

--- a/jwst/jump/twopoint_difference.py
+++ b/jwst/jump/twopoint_difference.py
@@ -1,13 +1,11 @@
 """
 Two-Point Difference method for finding outliers in a 3-d ramp data cube.
-
 The scheme used in this variation of the method uses numpy array methods
 to compute first-differences and find the max outlier in each pixel while
 still working in the full 3-d data array. This makes detection of the first
 outlier very fast. We then iterate pixel-by-pixel over only those pixels
 that are already known to contain an outlier, to look for any additional
 outliers and set the appropriate DQ mask for all outliers in the pixel.
-
 This is MUCH faster than doing all the work on a pixel-by-pixel basis.
 """
 
@@ -26,7 +24,6 @@ def find_CRs(data, gdq, read_noise, rej_threshold, nframes):
 
     """
     Find CRs/Jumps in each integration within the input data array.
-
     The input data array is assumed to be in units of electrons, i.e. already
     multiplied by the gain. We also assume that the read noise is in units of
     electrons.
@@ -96,15 +93,21 @@ def find_CRs(data, gdq, read_noise, rej_threshold, nframes):
         # negative outliers
         ratio = np.abs(first_diffs - med_diffs[:, :, np.newaxis]) / sigma[:, :, np.newaxis]
 
-        # Find the group index of the max outlier in each pixel
-        # (the RHS is identical to the previous versions:
-        #  max_index = np.nanargmax (ratio, axis=2)
-        max_index1 = sort_index[:, :, ngroups - 2]
+        
+        # get the rows and columns of pixels of all pixels
+        row, col = np.where(number_sat_groups >= 0)
+        # Get the group index for each pixel of the largest non-saturated group, assuming the indicies are sorted.
+        # This is a 2-D array.
+        max_value_index = ngroups - 2 - number_sat_groups
 
-        # Get indices of highest values (may be outliers) that are above the
-        # rejection threshold
+        # Extract from the sorted group index the index of the largest non-saturated group
+        max_index1d = sort_index[row, col, max_value_index[row, col]]
+        # Reshape the list of max indicies to be a 2-day array
+        max_index1 = np.reshape(max_index1d, (nrows,ncols))
+
         r, c = np.indices(max_index1.shape)
-        row1, col1 = np.where(ratio[r, c, max_index1 - number_sat_groups] > rej_threshold)
+        # Get the row and column indices of pixels whose largest non-saturated ratio is above the threshold
+        row1, col1 = np.where(ratio[r, c, max_index1] > rej_threshold)
         log.debug('From highest outlier Twopt found %d pixels with at least one CR' % (len(row1)))
         number_pixels_with_cr = len(row1)
         for j in range(number_pixels_with_cr):
@@ -162,23 +165,30 @@ def return_clipped_median(num_differences, diffs_to_ignore, differences, sorted_
     """
 
     # ignore largest value and number of CRs found when finding new median
-
+    # Check to see if this is a 2-D array or 1-D
     if sorted_index.ndim > 1:
 
         # always exclude the highest value
         pixel_med_index = sorted_index[:, :, int((num_differences - 1) / 2)] # always exclude the highest value
         row, col = np.indices(pixel_med_index.shape)
 
-        # in addition decrease the index by 1 for every two diffs_to_ignore, these will be saturated values in this case
+        # In addition, decrease the index by 1 for every two diffs_to_ignore, these will be saturated values in this case
         pixel_med_diff = differences[row, col, pixel_med_index - ((diffs_to_ignore) / 2).astype(int)]
-        if (num_differences - 1) % 2 == 0:  # even
-            pixel_med_index2 = sorted_index[:, :, int((num_differences - 1) / 2) - 1]
-            pixel_med_diff = (pixel_med_diff + differences[row, col, pixel_med_index2 - ((diffs_to_ignore) / 2).astype(int)]) / 2.0
-
+        # For pixels with an even number of groups the median is the mean of the two central values
+        even_group_rows,even_group_cols = np.where((num_differences - diffs_to_ignore - 1)% 2 == 0)
+        pixel_med_index2 = np.zeros_like(pixel_med_index)
+        pixel_med_index2[even_group_rows,even_group_cols]=sorted_index[even_group_rows, even_group_cols, int((num_differences - 1) / 2 ) - 1]
+        # Average together the two central values
+        pixel_med_diff[even_group_rows,even_group_cols] = (pixel_med_diff[even_group_rows, even_group_cols] +
+                                                           differences[even_group_rows, even_group_cols,
+                                                                       pixel_med_index2[even_group_rows, even_group_cols]
+                                                                       - ((diffs_to_ignore[even_group_rows, even_group_cols])
+                                                                          / 2).astype(int)]) / 2.0
+    # The 1-D array case is a lot simplier.    
     else:
         pixel_med_index = sorted_index[int(((num_differences - 1 - diffs_to_ignore) / 2))]
         pixel_med_diff = differences[pixel_med_index]
-        if (num_differences - diffs_to_ignore - 1) % 2 == 0:  # even
+        if (num_differences - diffs_to_ignore - 1) % 2 == 0:  # even number of groups
             pixel_med_index2 = sorted_index[int((num_differences - 1 - diffs_to_ignore) / 2) - 1]
             pixel_med_diff = (pixel_med_diff + differences[pixel_med_index2]) / 2.0
 


### PR DESCRIPTION
The program was using a wrong index to find the largest non-saturated difference. I added test to recreate the original problem that now work with the fix.
Also, the calculation of the median was not correct since it assumed all pixels in the integration had the same number of non-saturated groups.
An expected to fail test was added for a future feature to flag pixels adjacent to detected jumps.