### PR TITLE
disable osx tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: c
 
 os:
     - linux
-    - osx
 
 sudo: false
 


### PR DESCRIPTION
Travis has continuous problems with OSX testing. Here's a [blog post](https://blog.travis-ci.com/2017-09-22-macos-update) about this.
Since the code is mostly python, I suggest we disable the testing on osx for now. Any objections?

Should we disable python 27 as well and include python 3.6? (Python 3.6 is probably used in the nightly tests.)