### PR TITLE
Create a MultiSlitModel when one slit is extracted.

### DIFF
--- a/jwst/extract_2d/nirspec.py
+++ b/jwst/extract_2d/nirspec.py
@@ -21,9 +21,9 @@ log.setLevel(logging.DEBUG)
 
 def nrs_extract2d(input_model, which_subarray=None, apply_wavecorr=False, reference_files={}):
     exp_type = input_model.meta.exposure.type.upper()
-    
+
     wavecorr_supported_modes = ['NRS_FIXEDSLIT', 'NRS_MSASPEC', 'NRS_BRIGHTOBJ']
-    
+
     if exp_type in wavecorr_supported_modes:
         reffile = reference_files['wavecorr']
         if reffile and reffile.strip().upper() == 'N/A':
@@ -33,7 +33,7 @@ def nrs_extract2d(input_model, which_subarray=None, apply_wavecorr=False, refere
         apply_wavecorr = False
         log.info("Skipping wavecorr correction for EXP_TYPE {0}".format(exp_type))
 
-    
+
     slit2msa = input_model.meta.wcs.get_transform('slit_frame', 'msa_frame')
     # This is a cludge but will work for now.
     # This model keeps open_slits as an attribute.
@@ -41,8 +41,8 @@ def nrs_extract2d(input_model, which_subarray=None, apply_wavecorr=False, refere
     if which_subarray is not None:
         open_slits = [sub for sub in open_slits if sub.name==which_subarray]
     log.debug('open slits {0}'.format(open_slits))
-    if len(open_slits) == 1:
-        # the output model is the same as the input - ImageModel or CubeModel
+    if exp_type == 'NRS_BRIGHTOBJ':
+        # the output model is CubeModel
         output_model, xlo, xhi, ylo, yhi = process_slit(input_model, open_slits[0],
                                                         exp_type, apply_wavecorr, reffile)
     else:


### PR DESCRIPTION
Create a `MultiSlitModel` product with a single slit as long as exp_type is not `NRS_BRIGHTOBJ`.
`NRS_BRIGHTOBJ` creates a `CubeModel` as output. Still need to run some tests before merging.