### PR TITLE
Add docs for the NIRCAM Grism and NIRISS WFSS wcs and extrac2d steps

### DIFF
--- a/docs/jwst/assign_wcs/exp_types.rst
+++ b/docs/jwst/assign_wcs/exp_types.rst
@@ -32,11 +32,21 @@ WCS reference file information per EXP_TYPE
   | WCS pipeline coordinate frames: detector, v2v3, world
   | Implements: Distortion file created from TEL team data.
 
+:NRC_GRISM, NRC_TSGRISM:
+  | reftypes: *specwcs*, *distortion* *wavelengthrange*
+  | WCS pipeline coordinate frames: grism_detector, detector, v2v3, world
+  | Implements: reference files provided by NIRCAM team
+
 :NIS_IMAGE, NIS_TACQ, NIS_TACONFIRM, NIS_FOCUS:
 
   | reftypes: *distortion*
   | WCS pipeline coordinate frames: detector, v2v3, world
   | Implements: reference file provided by NIRISS team
+
+:NIS_WFSS:
+  | reftypes: *specwcs*, *distortion*
+  | WCS pipeline coordinate frames: grism_detector, detector, v2v3, world
+  | Implements: reference files provided by NIRISS team
 
 :NIS_SOSS:
 
@@ -62,4 +72,5 @@ WCS reference file information per EXP_TYPE
   | reftypes: *fpa*, *camera*, *disperser*, *collimator*, *msa*, *wavelengthrange*, *fore*, *ote*
   | WCS pipeline coordinate frames: detector, sca, bgwa, slit_frame, msa_frame, ote, v2v3, world
   | Implements: CDP 2 delivery
+
 

--- a/docs/jwst/assign_wcs/main.rst
+++ b/docs/jwst/assign_wcs/main.rst
@@ -2,7 +2,7 @@
 Description
 ===========
 
-jwst.assign_wcs is one of the first steps in the level 2B JWST pipeline.
+``jwst.assign_wcs`` is one of the first steps in the level 2B JWST pipeline.
 It associates a WCS object with each science exposure. The WCS transforms
 positions on the detector to a world coordinate frame - ICRS and wavelength.
 In general there may be intermediate coordinate frames depending on the instrument.
@@ -46,10 +46,26 @@ Calling it as a function with detector positions as inputs returns the
 corresponding world coordinates. Using MIRI LRS fixed slit as an example:
 
 >>> from jwst.datamodels import ImageModel
->>> exp = ImagModel(miri_fixed_assign_wcs.fits')
+>>> exp = ImageModel('miri_fixed_assign_wcs.fits')
 >>> ra, dec, lam = exp.meta.wcs(x, y)
 >>> print(ra, dec, lam)
     (329.97260532549336, 372.0242999250267, 5.4176100046836675)
+
+The GRISM modes for NIRCAM and NIRISS have a slightly difference calling structure,
+in addition to the (x, y) coordinate, they need to know other information about the
+spectrum or source object. In the JWST backward direction (going from the sky to
+the detector) the WCS model also looks for the wavelength and order and returns
+the (x,y) location of that wavelength+order on the dispersed image and the original
+source pixel location, as entered, along with the order that was specified:
+
+>>> form jwst.datamodels import ImageModel
+>>> exp = ImageModel('nircam_grism_assign_wcs.fits')
+>>> x, y, x0, y0, order = exp.meta.wcs(x0, y0, wavelength, order)
+>>> print(x0, y0, wavelength, order)
+    (365.523884327, 11.6539963919, 2.557881113, 2.0)
+>>> print(x, y, x0, y0, order)
+    (1539.5898464615102, 11.6539963919, 365.523884327, 11.6539963919, 
+
 
 The WCS provides access to intermediate coordinate frames
 and transforms between any two frames in the WCS pipeline in forward or
@@ -73,7 +89,7 @@ multiple-integration datasets the step will accept either of these data products
 the slope results for each integration in the exposure, or the single slope image
 that is the result of averaging over all integrations.
 
-jwst.assign_wcsis based on gwcs and uses the modeling, units and coordinates subpackages in astropy.
+``jwst.assign_wcs`` is based on gwcs and uses the modeling, units and coordinates subpackages in astropy.
 
 Software dependencies:
 

--- a/docs/jwst/assign_wcs/main.rst
+++ b/docs/jwst/assign_wcs/main.rst
@@ -62,9 +62,9 @@ source pixel location, as entered, along with the order that was specified:
 >>> exp = ImageModel('nircam_grism_assign_wcs.fits')
 >>> x, y, x0, y0, order = exp.meta.wcs(x0, y0, wavelength, order)
 >>> print(x0, y0, wavelength, order)
-    (365.523884327, 11.6539963919, 2.557881113, 2.0)
+    (365.523884327, 11.6539963919, 2.557881113, 2)
 >>> print(x, y, x0, y0, order)
-    (1539.5898464615102, 11.6539963919, 365.523884327, 11.6539963919, 
+    (1539.5898464615102, 11.6539963919, 365.523884327, 11.6539963919, 2)
 
 
 The WCS provides access to intermediate coordinate frames

--- a/docs/jwst/assign_wcs/reference_files.rst
+++ b/docs/jwst/assign_wcs/reference_files.rst
@@ -30,7 +30,7 @@ reftype                                     description                         
 **specwcs**            Wavelength calibration models                                 MIRI, NIRCAM, NIRISS
 **regions**            Stores location of the regions on the detector                MIRI
 **v2v3**               Transform from MIRI instrument focal plane to V2V3 plane      MIRI
-**wavelengthrange**    Typical wavelength ranges                                     MIRI, NIRSPEC
+**wavelengthrange**    Typical wavelength ranges                                     MIRI, NIRSPEC, NIRCAM, NIRISS
 ===================    ==========================================================   ============================
 
 
@@ -111,10 +111,10 @@ DISTORTION
 CRDS Selection Criteria
 :::::::::::::::::::::::
 
-:MIRI: DETECTOR, EXP_TYPE. CHANNEL, BAND
+:MIRI: DETECTOR, EXP_TYPE, CHANNEL, BAND
 :FGS: DETECTOR, EXP_TYPE
-:NIRCAM: DETECTOR, EXP_TYPE. CHANNEL.
-:NIRISS: EXP_TYPE
+:NIRCAM: DETECTOR, EXP_TYPE,  CHANNEL, FILTER
+:NIRISS: EXP_TYPE, PUPIL
 
 Reference File Formats
 ::::::::::::::::::::::
@@ -311,6 +311,8 @@ CRDS Selection Criteria
 
 :MIRI: DETECTOR, CHANNEL, BAND, SUBARRAY, EXP_TYPE
 :NIRISS: EXP_TYPE, SUBARRAY
+:NIRCAM: EXP_TYPE, MODULE, PUPIL
+:NIRISS: EXP_TYPE, FILTER, PUPIL
 
 Reference File Formats
 ::::::::::::::::::::::
@@ -333,6 +335,27 @@ For the MIRI MRS the file is in ASDF format with the following structure.
 For NIRISS SOSS mode the file is in ASDF format with the following structure.
 
 :model: A tabular model with the wavelength solution.
+
+For NIRCAM GRISM and TSGRIM modes the file is in ASDF format with the following structure:
+
+:displ: The wavelength transform models
+:dispx: The x-dispersion models
+:dispy: The y-dispersion models
+:invdispx: The inverse x-dispersion models
+:invdispy: The inverse y-dispersion models
+:invdispl: The inverse wavelength transform models
+:orders: a list of order numbers that the models relate to, in the same order as the models
+
+For NIRISS WFSS mode the file is in ASDF format with the following structure:
+
+:displ: The wavelength transform models
+:dispx: The x-dispersion models
+:dispy: The y-dispersion models
+:invdispx: The inverse x-dispersion models
+:invdispl: The inverse wavelength transform models
+:fwcpos_ref: The reference filter wheel position in degrees
+:orders: a list of order numbers that the models relate to, in the same order as the models
+
 
 Regions
 -------
@@ -376,6 +399,9 @@ CRDS Selection Criteria
 
 :NIRSPEC: Match EXP_TYPE
 :MIRI: Match EXP_TYPE
+:NIRCAM: Match EXP_TYPE
+:NIRISS: Match EXP_TYPE
+
 
 Reference File Formats
 ::::::::::::::::::::::
@@ -390,3 +416,14 @@ For NIRSPEC the file is a dictionary storing information about default wavelengt
 :filter_grating:
                  :order: Default spectral order
                  :range: Default wavelength range
+
+For NIRCAM GRISM and TSGRIM modes and NIRISS WFSS mode the wavelengthrange file contains the wavelength limits to use when caluclating the minimum and maximum dispersion extents on the detector. The selection of the
+correct minimum and maximum wavelength range is done with the following logic, where the index of
+the desired filter is used as the reference into wrange_selector, and the same for the index of the order:
+
+wave_min, wave_max = wrange[order][wrange_selector[filter name]]
+
+:order: a list of orders
+:wrange: a 2D list of wavelength ranges, ordered in the same way as the orders
+:wrange_selector: The list of FILTER names, these are used to select the correct wavelength range
+

--- a/docs/jwst/extract_2d/main.rst
+++ b/docs/jwst/extract_2d/main.rst
@@ -16,9 +16,21 @@ This step uses the ``bounding_box`` attribute of the WCS stored in the data mode
 which is populated by the ``assign_wcs`` step. Hence the ``assign_wcs`` step
 must be applied to the science exposure before running this step.
 
+For GRISM/WFSS modes in NIRCAM and NIRSS, no ``bounding_box`` has been attached
+to the datamodel. This is to keep the WCS flexible enough to be used with any
+source catalog that may be associated with the dispersed image. Instead, there
+is a helper method that is used to calculate the bounding boxes that contain
+the dispersed spectra for each object. One box is made for each order. ``extract2d``
+uses the source catalog referenced in the input models meta information to create
+the list of objects and their corresponding bounding box, this list is used to make
+the 2D cutouts from the dispersed image.
+
 Algorithm
 ---------
-The step is currently applied only to NIRSpec Fixed Slit and NIRSPEC MSA observations.
+The step is currently applied only to NIRSpec Fixed Slit, NIRSPEC MSA,
+NIRCAM GRISM and NIRISS WFSS observations.
+
+For NIRSPEC:
 
 If the step parameter ``which_subarray`` is left unspecified, the default behavior is
 to extract all slits which fall within a detector. Only one slit may be extracted by
@@ -42,9 +54,23 @@ slit region populated with the name and region characteristic for the slits,
 corresponding to the FITS keywords ``SLTNAME``, ``SLTSTRT1``, ``SLTSIZE1``,
 ``SLTSTRT2``, and ``SLTSIZE2``.
 
+
+For NIRCAM GRISM and NIRISS WFSS :
+
+If the step parameter ``grism_objects`` is left unspecified, the default behavior
+is to use the source catalog that is specified in the input model's meta information, 
+``input_model.meta.source_catalog.filename``. Otherwise, a user can submit of list of
+``GrismObjects`` that contains information about the objects that should be extracted.
+The ``GrismObject`` list can be created automatically by using the method in
+``jwst.assign_wcs.utils.create_grism_bbox``. This method also uses the name of the source
+catalog saved in the input model's meta information. If it's better to construct a list
+of ``GrismObjects`` outside of these, the ``GrismObject`` itself can be imported from
+``jwst.transforms.models``. 
+
+
 Step Arguments
 ==============
-The extract_2d step has one optional argument:
+The extract_2d step has two optional arguments for NIRSPEC observations: 
 
 * ``--which_subarray``: name (string value) of a specific slit region to
   extract. The default value of None will cause all known slits for the
@@ -54,6 +80,12 @@ The extract_2d step has one optional argument:
 * ``--apply_wavecorr``: bool (default is True). Flag indicating whether to apply the
    Nirspec wavelength zero-point correction.
 
+
+For NIRCAM and NIRISS, the extract_2d step has only one optional argument:
+
+* ``--grism_objects``: list (default is empty). A list of ``jwst.transforms.models.GrismObject``.
+
+
 Reference Files
 ===============
 To apply the Nirspec wavelength zero-point correction, this step uses the
@@ -61,3 +93,10 @@ WAVECORR reference file. The zero-point correction is applied to observations
 with EXP_TYPE of "NRS_FIXEDSLT", "NRS_BRIGHTOBJ" or "NRS_MSASPEC". This is an optional
 correction (on by default). It can be turned off by specifying ``apply_wavecorr=False``
 when running the step.
+
+NIRCAM GRISM and NIRISS WFSS observations use the wavelengthrange reference file in order
+to construct the bounding boxes around each objects orders. If a list of ``GrismObject``
+is supplied, then no reference file is neccessary. 
+
+
+


### PR DESCRIPTION
Initial documentation for the NIRCAM GRISM, TSGRISM, and NIRISS WFSS modes for assign_wcs and extract_2d