### PR TITLE
Grism mode updates for extraction

### DIFF
--- a/jwst/assign_wcs/assign_wcs.py
+++ b/jwst/assign_wcs/assign_wcs.py
@@ -43,6 +43,7 @@ def load_wcs(input_model, reference_files={}):
         exclude_types = ['NRS_FIXEDSLIT', 'NRS_BRIGHTOBJ', 'NRS_IFU',
                          'NRS_MSASPEC', 'NRS_LAMP', 'MIR_MRS', 'NIS_SOSS',
                          'NRC_GRISM', 'NRC_TSGRISM', 'NIS_WFSS']
+
         if output_model.meta.exposure.type not in exclude_types:
             orig_s_region = output_model.meta.wcsinfo.s_region.strip()
             update_s_region(output_model)

--- a/jwst/assign_wcs/niriss.py
+++ b/jwst/assign_wcs/niriss.py
@@ -218,12 +218,6 @@ def wfss(input_model, reference_files):
     catalog in units of RA,DEC so they can be translated to pixels by
     the dispersed image's imaging wcs.
 
-    For each spectral order, the configuration file contains a
-    magnitude-cutoff value. Sources with magnitudes fainter than the
-    extraction cutoff (MMAG_EXTRACT)  will not be extracted, but are
-    accounted for when computing the spectral contamination and background
-    estimates. The default extraction value is 99 right now.
-
     The sensitivity information from the original aXe style configuration
     file needs to be modified by the passband of the filter used for
     the direct image to get the min and max wavelengths
@@ -231,22 +225,6 @@ def wfss(input_model, reference_files):
     and the min and max wavelengths to use to calculate t are stored in the
     grism reference file as wrange, which can be selected by wrange_selector
     which contains the filter names.
-
-
-    Step 1: Convert the source catalog from the reference frame of the
-            uberimage to that of the dispersed image.  For the Vanilla
-            Pipeline we assume that the pointing information in the file
-            headers is sufficient.  This will be strictly true if all images
-            were obtained in a single visit (same guide stars).
-    Step 2: Record source information for each object in the catalog: position
-            (RA and Dec), shape (A_IMAGE, B_IMAGE, THETA_IMAGE), and all
-            available magnitudes.
-    Step 3: Compute the trace and wavelength solutions for each object in the
-            catalog and for each spectral order.  Record this information.
-    Step 4: Compute the WIDTH of each spectral subwindow, which may be fixed or
-            variable (see discussion of optimal extraction, below).  Record
-            this information.
-    Step 4: Record the MMAG_EXTRACT for each object and spectral order.
 
     Source catalog use moved to extract_2d
     """

--- a/jwst/extract_2d/extract_2d_step.py
+++ b/jwst/extract_2d/extract_2d_step.py
@@ -13,6 +13,7 @@ class Extract2dStep(Step):
     spec = """
         which_subarray = string(default = None)
         apply_wavecorr = boolean(default=True)
+        grism_objects = list(default=list())
     """
 
     reference_file_types = ['wavecorr', 'wavelengthrange']

--- a/jwst/transforms/models.py
+++ b/jwst/transforms/models.py
@@ -39,6 +39,8 @@ Slit.__new__.__defaults__ = ("", 0, 0.0, 0.0, 0.0, 0.0, 0, 0, "", "", "", "",
 class GrismObject(namedtuple('GrismObject', ("sid",
                                              "order_bounding",
                                              "icrs_centroid",
+                                             "partial_order",
+                                             "waverange",
                                              "sky_bbox_ll",
                                              "sky_bbox_lr",
                                              "sky_bbox_ur",
@@ -75,6 +77,8 @@ class GrismObject(namedtuple('GrismObject', ("sid",
                 sid=None,
                 order_bounding={},
                 icrs_centroid=None,
+                partial_order=False,
+                waverange=None,
                 sky_bbox_ll=None,
                 sky_bbox_lr=None,
                 sky_bbox_ur=None,
@@ -86,6 +90,8 @@ class GrismObject(namedtuple('GrismObject', ("sid",
                                                sid=sid,
                                                order_bounding=order_bounding,
                                                icrs_centroid=icrs_centroid,
+                                               partial_order=partial_order,
+                                               waverange=waverange,
                                                sky_bbox_ll=sky_bbox_ll,
                                                sky_bbox_lr=sky_bbox_lr,
                                                sky_bbox_ur=sky_bbox_ur,
@@ -104,6 +110,8 @@ class GrismObject(namedtuple('GrismObject', ("sid",
                 "sky_bbox_ul:{6}\n"
                 "xcenter: {7}\n"
                 "ycenter: {8}\n"
+                "partial_order: {9}\n"
+                "waverange: {10}\n"
                 .format(self.sid,
                         str(self.order_bounding),
                         str(self.icrs_centroid),
@@ -112,7 +120,9 @@ class GrismObject(namedtuple('GrismObject', ("sid",
                         str(self.sky_bbox_ur),
                         str(self.sky_bbox_ul),
                         self.xcenter,
-                        self.ycenter))
+                        self.ycenter,
+                        str(self.partial_order),
+                        str(self.waverange)))
 
 
 class MIRI_AB2Slice(Model):


### PR DESCRIPTION
Still testing this out but wanted to run it through travis. The updates generally include:
- some added logging information that's useful
- logic to correct the dispersion directions, though I haven't decided if this is correct yet, still testing
- rejection of completely off-detector orders and marking of partial orders
- rounding for the order bounding boxes to int
- addition of the grism_objects parameter optional parameter to the extract_2d step