### PR TITLE
Outputnames

### DIFF
--- a/jwst/cube_build/cube_build_step.py
+++ b/jwst/cube_build/cube_build_step.py
@@ -304,7 +304,8 @@ class CubeBuildStep (Step):
                 save_IFU = True
             
         if save_IFU == True:
-            Final_IFUCube.save(None)
+#            Final_IFUCube.save(None)
+            self.save_model(Final_IFUCube,self.suffix)
 #            print('at the end',Final_IFUCube[0].meta.ref_file.crds.sw_version)
         return Final_IFUCube
 

--- a/jwst/cube_build/cube_build_step.py
+++ b/jwst/cube_build/cube_build_step.py
@@ -43,6 +43,7 @@ class CubeBuildStep (Step):
          zdebug = integer(default=None)
          single = boolean(default=false)
          output_type = option('band','channel','grating','multi',default='band')
+#         output_use_model = boolean(default=true)
        """
     reference_file_types = ['cubepar','resol']
 
@@ -285,28 +286,30 @@ class CubeBuildStep (Step):
             else:
                 result =  thiscube.build_ifucube()
 #                print('returning',result.meta.filename)
-#                print('********',result.meta.ref_file.crds.sw_version)
                 Final_IFUCube.append(result)
-
             if(self.debug_pixel ==1):
                 self.spaxel_debug.close()
 
-
-        save_IFU = False
-#        print('cube_build_step',self.save_results)
-
-        if self.pipeline == 3:
-            if self.save_results == True or self.output_file !=None:
-                self.save_results = False # turn off the Step class functions
+#        save_IFU = False
+#        if self.pipeline == 31:
+#            if self.save_results == True or self.output_file !=None:
+#                self.save_results = False # turn off the Step class functions
                                       # cause new output_file names
                                       # to be determined. Cube_build handles all this
-                self.output_file = None
-                save_IFU = True
-            
-        if save_IFU == True:
+#                self.output_file = None
+#                save_IFU = True
+#        if save_IFU == True:
 #            Final_IFUCube.save(None)
-            self.save_model(Final_IFUCube,self.suffix)
-#            print('at the end',Final_IFUCube[0].meta.ref_file.crds.sw_version)
+
+
+#        print('save results',self.save_results,self.suffix)
+        if self.save_results == True:
+            self.suffix = 's3d'
+#            print(Final_IFUCube[0].meta.filename)
+            self.save_results = False
+            #self.save_model(Final_IFUCube,self.suffix)
+            self.output_file = None
+            Final_IFUCube.save(None)
         return Final_IFUCube
 
 #********************************************************************************

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -686,16 +686,9 @@ class IFUCubeData(object):
         IFUCube.update(self.input_models[j])
 
         IFUCube.meta.filename = self.output_name
-#        with datamodels.open(self.input_models[j]) as input:
-#            print('********',j)
-#            print('********',input.meta.ref_file.crds.sw_version)
-#            print('********',input.meta.ref_file.cubepar)
 
-#        print('********',IFUCube.meta.ref_file.crds.sw_version)
-#        print('********',IFUCube.meta.ref_file.cubepar)        
         if self.output_type == 'single':
             with datamodels.open(self.input_models[j]) as input:
-
 
                 # define the cubename for each single 
                 filename = self.input_filenames[j]


### PR DESCRIPTION
Cube build forms the filenames. Now they are not overwritten by the step function when there are more than one IFUCube produced. 
However, when cube build is run from strun the files were not being saved and the end. So the fix is if
self.save_results =true   then cube_build will save the IFUCube to disk. In the various testing I have done I believe this is only the default case if run from strun - not the calspec2 or calspec3 pipelines. So for build 7.1 I hope this is acceptable. 