### PR TITLE
Use consistent variance array names

### DIFF
--- a/jwst/datamodels/cube.py
+++ b/jwst/datamodels/cube.py
@@ -23,12 +23,30 @@ class CubeModel(model_base.DataModel):
 
     err : numpy array
         The error array.  3-D
+
+    zeroframe: numpy array
+        The zero-frame array.  3-D
+
+    relsens: numpy array
+        The relative sensitivity array.
+
+    area: numpy array
+        The pixel area array.  2-D
+
+    wavelength: numpy array
+        The wavelength array.  2-D
+
+    var_poisson: numpy array
+        The variance due to Poisson noise array.  3-D
+
+    var_rnoise: numpy array
+        The variance due to read noise array.  3-D
     """
     schema_url = "cube.schema.yaml"
 
     def __init__(self, init=None, data=None, dq=None, err=None, zeroframe=None,
-                 relsens=None, area=None, wavelength=None, var_p_int=None, 
-                 var_r_int=None, **kwargs):
+                 relsens=None, area=None, wavelength=None, var_poisson=None, 
+                 var_rnoise=None, **kwargs):
       
         super(CubeModel, self).__init__(init=init, **kwargs)
 
@@ -50,15 +68,15 @@ class CubeModel(model_base.DataModel):
         if area is not None:
             self.area = area
 
-        if var_p_int is not None:
-            self.var_p_int = var_p_int
-
-        if var_r_int is not None:
-            self.var_r_int = var_r_int
-   
         if wavelength is not None:
             self.wavelength = wavelength
 
+        if var_poisson is not None:
+            self.var_poisson = var_poisson
+
+        if var_rnoise is not None:
+            self.var_rnoise = var_rnoise
+   
         # Implicitly create arrays
         self.dq = self.dq
         self.err = self.err

--- a/jwst/datamodels/image.py
+++ b/jwst/datamodels/image.py
@@ -29,12 +29,27 @@ class ImageModel(model_base.DataModel):
 
     relsens2d: numpy array
         The relative sensitivty 2D array.
+
+    zeroframe: numpy array
+        The zero-frame array.
+
+    area: numpy array
+        The pixel area array.
+
+    wavelength: numpy array
+        The wavelength array.
+
+    var_poisson: numpy array
+        The variance due to Poisson noise array.
+
+    var_rnoise: numpy array
+        The variance due to read noise array.
     """
     schema_url = "image.schema.yaml"
 
     def __init__(self, init=None, data=None, dq=None, err=None, relsens=None,
                  relsens2d=None, zeroframe=None, area=None, wavelength=None, 
-                 var_p2d=None, var_r2d=None, **kwargs):
+                 var_poisson=None, var_rnoise=None, **kwargs):
         super(ImageModel, self).__init__(init=init, **kwargs)
 
         if data is not None:
@@ -61,11 +76,11 @@ class ImageModel(model_base.DataModel):
         if wavelength is not None:
             self.wavelength = wavelength
 
-        if var_p2d is not None:
-            self.var_p2d = var_p2d
+        if var_poisson is not None:
+            self.var_poisson = var_poisson
 
-        if var_r2d is not None:
-            self.var_r2d = var_r2d
+        if var_rnoise is not None:
+            self.var_rnoise = var_rnoise
 
         # Implicitly create arrays
         self.dq = self.dq

--- a/jwst/datamodels/schemas/cube.schema.yaml
+++ b/jwst/datamodels/schemas/cube.schema.yaml
@@ -31,18 +31,6 @@ allOf:
       default: 0.0
       ndim: 2
       datatype: float32
-    var_p_int:
-      title: Integration-specific variances of slope due to Poisson noise
-      fits_hdu: VAR_POISSON
-      default: 0.0
-      ndim: 3
-      datatype: float32
-    var_r_int:
-      title: Integration-specific variances of slope due to read noise
-      fits_hdu: VAR_RNOISE
-      default: 0.0
-      ndim: 3
-      datatype: float32
     relsens:
       $ref: relsens.schema.yaml
     wavelength:
@@ -50,5 +38,17 @@ allOf:
       fits_hdu: WAVELENGTH
       ndim: 2
       default: 0.0
+      datatype: float32
+    var_poisson:
+      title: Integration-specific variances of slope due to Poisson noise
+      fits_hdu: VAR_POISSON
+      default: 0.0
+      ndim: 3
+      datatype: float32
+    var_rnoise:
+      title: Integration-specific variances of slope due to read noise
+      fits_hdu: VAR_RNOISE
+      default: 0.0
+      ndim: 3
       datatype: float32
 $schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/ramp_fitting/ramp_fit.py
+++ b/jwst/ramp_fitting/ramp_fit.py
@@ -376,8 +376,8 @@ def ols_ramp_fit(model, buffsize, save_opt, readnoise_model, gain_model,
     # Create new model...
     new_model = datamodels.ImageModel(data=c_rates.astype(np.float32),
             dq=final_pixeldq.astype(np.uint32), 
-            var_p2d=var_p_2d_all.astype(np.float32),
-            var_r2d=var_r_2d_all.astype(np.float32), err=err_2d_all.copy())
+            var_poisson=var_p_2d_all.astype(np.float32),
+            var_rnoise=var_r_2d_all.astype(np.float32), err=err_2d_all.copy())
 
     new_model.update(model)  # ... and add all keys from input
 

--- a/jwst/ramp_fitting/utils.py
+++ b/jwst/ramp_fitting/utils.py
@@ -623,8 +623,8 @@ def output_integ(model, slope_int, dq_int, effintim, var_p_int, var_r_int):
     cubemod.data = slope_int / effintim
     cubemod.err = np.sqrt(var_p_int + var_r_int)
     cubemod.dq = dq_int
-    cubemod.var_p_int = var_p_int
-    cubemod.var_r_int = var_r_int
+    cubemod.var_poisson = var_p_int
+    cubemod.var_rnoise = var_r_int
 
     cubemod.update(model) # keys from input needed for photom step
 


### PR DESCRIPTION
Updated ImageModel and CubeModel definitions to use consistent array and extension names for poisson and read noise variance arrays. Also updated ramp_fit to use the new argument names when creating its output rate and rateints models. The current version of the models had an inconsistency in the names that was preventing the appearance of the variance arrays in the rate product.

In support of #596.