### PR TITLE
fix output_dir problem

### DIFF
--- a/jwst/cube_build/__init__.py
+++ b/jwst/cube_build/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import absolute_import
 from .cube_build_step import CubeBuildStep
 
-__version__ = '0.7.8'
+__version__ = '0.7.9'

--- a/jwst/cube_build/cube_build_step.py
+++ b/jwst/cube_build/cube_build_step.py
@@ -145,7 +145,9 @@ class CubeBuildStep (Step):
 # the cube_build software will attached the needed information on channel, sub-channel
 # grating or filter. 
 #________________________________________________________________________________
-        input_table = data_types.DataTypes(input,self.single,self.output_file)
+        input_table = data_types.DataTypes(input,self.single,
+                                           self.output_file,
+                                           self.output_dir)
         
         self.cube_type = input_table.input_type
         self.input_models = input_table.input_models

--- a/jwst/cube_build/data_types.py
+++ b/jwst/cube_build/data_types.py
@@ -41,7 +41,7 @@ class DataTypes(object):
                 ]
               }
 
-    def __init__(self, input,single,output_file):
+    def __init__(self, input,single,output_file,output_dir):
 
         self.input_models = []
         self.filenames = []
@@ -116,6 +116,9 @@ class DataTypes(object):
 #            default = root.find('cube_build') # the user has not provided a name
             self.output_name = basename
         
+
+        if output_dir !=None :
+            self.output_name= output_dir + '/' + self.output_name
 
     def build_product_name(self, filename):
         indx = filename.rfind('.fits')


### PR DESCRIPTION
If output_dir is provided cube_build now adds that to the output name.
Eventually (build 7.2) we will probably want this to be done in the re-work Jonathan is working on

This address issue #1307 (which got lost in all the file naming updates)
