### PR TITLE
Allow negative spectral order

### DIFF
--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -1246,7 +1246,7 @@ def get_spectral_order(slit):
 
     if hasattr(slit.meta, 'wcsinfo'):
         sp_order = slit.meta.wcsinfo.spectral_order
-        if sp_order is None or sp_order < 1:
+        if sp_order is None or sp_order == 0:
             log.warning("spectral_order is {}; using 1"
                         .format(sp_order))
             sp_order = 1


### PR DESCRIPTION
There was a test on spectral order, requiring it to be not None and
greater than zero.  However, there are some modes that can have a
negative spectral order, so the test has been changed to allow that.
See issue #1297.