### PR TITLE
Allow the spectral order to be zero

### DIFF
--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -1246,9 +1246,8 @@ def get_spectral_order(slit):
 
     if hasattr(slit.meta, 'wcsinfo'):
         sp_order = slit.meta.wcsinfo.spectral_order
-        if sp_order is None or sp_order == 0:
-            log.warning("spectral_order is {}; using 1"
-                        .format(sp_order))
+        if sp_order is None:
+            log.warning("spectral_order is None; using 1")
             sp_order = 1
     else:
         log.warning("slit.meta doesn't have attribute wcsinfo; "


### PR DESCRIPTION
Removed the test that required the spectral order to be non-zero, since
the order will be zero for prism data.  See issue #1297.