### PR TITLE
Update FITS WCS keywords in Level 3 resampled image

### DIFF
--- a/jwst/pipeline/calwebb_image3.py
+++ b/jwst/pipeline/calwebb_image3.py
@@ -58,7 +58,11 @@ class Image3Pipeline(Pipeline):
 
         # Check if input is single or multiple exposures
         is_container = isinstance(input_models, datamodels.ModelContainer)
-        if is_container and len(input_models.group_names) > 1:
+        try:
+            has_groups = len(input_models.group_names) > 1
+        except:
+            has_groups = False
+        if is_container and has_groups:
 
             self.log.info("Generating source catalogs for alignment...")
             input_models = self.tweakreg_catalog(input_models)
@@ -97,8 +101,7 @@ class Image3Pipeline(Pipeline):
         except:
             pass
 
-        product = input_models.meta.asn_table.products[0].name
-        result.meta.filename = product
+        result.meta.filename = input_models.meta.asn_table.products[0].name
         self.save_model(result, suffix=self.suffix)
 
         self.log.info("Creating source catalog...")

--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -222,6 +222,8 @@ class ResampleData(object):
             output_model.meta.resample.weight_type = self.drizpars['wht_type']
             output_model.meta.resample.pointings = pointings
 
+            build_fits_wcs(output_model)
+
             self.output_models.append(output_model)
 
 
@@ -255,3 +257,17 @@ def build_driz_weight(model, wht_type=None, good_bits=None):
         # Create an identity input weight map
         inwht = np.ones(model.data.shape, dtype=model.data.dtype)
     return inwht
+
+def build_fits_wcs(model):
+    """Update FITS WCS keywords of the resampled image based on the gwcs"""
+    transform = model.meta.wcs.forward_transform
+    model.meta.wcsinfo.crpix1 = -transform[0].offset.value + 1
+    model.meta.wcsinfo.crpix2 = -transform[1].offset.value + 1
+    model.meta.wcsinfo.cdelt1 = transform[3].factor.value
+    model.meta.wcsinfo.cdelt2 = transform[4].factor.value
+    model.meta.wcsinfo.crval1 = model.meta.wcsinfo.ra_ref = transform[6].lon.value
+    model.meta.wcsinfo.crval2 = model.meta.wcsinfo.dec_ref = transform[6].lat.value
+    model.meta.wcsinfo.pc1_1 = transform[2].matrix.value[0][0]
+    model.meta.wcsinfo.pc1_2 = transform[2].matrix.value[0][1]
+    model.meta.wcsinfo.pc2_1 = transform[2].matrix.value[1][0]
+    model.meta.wcsinfo.pc2_2 = transform[2].matrix.value[1][1]


### PR DESCRIPTION
Syncs the `meta.wcsinfo` block with the `gwcs` object in the output of `Image3Pipeline`.  The FITS WCS keywords now perfectly describe the actual WCS contained in the `gwcs` object.

@larrybradley `source_catalog` step should now produce sources with correct RA and DEC by just reading the FITS WCS keywords.

Resolves #1292 for Level 3 image modes.