### PR TITLE
S_REGION log message

### DIFF
--- a/jwst/assign_wcs/assign_wcs.py
+++ b/jwst/assign_wcs/assign_wcs.py
@@ -44,8 +44,10 @@ def load_wcs(input_model, reference_files={}):
                          'NRS_MSASPEC', 'NRS_LAMP', 'MIR_MRS', 'NIS_SOSS',
                          'NRC_GRISM', 'NRC_TSGRISM', 'NIS_WFSS']
         if output_model.meta.exposure.type not in exclude_types:
+            orig_s_region = output_model.meta.wcsinfo.s_region.strip()
             update_s_region(output_model)
-            log.info("assign_wcs updated S_REGION to {0}".format(output_model.meta.wcsinfo.s_region))
+            if orig_s_region != output_model.meta.wcsinfo.s_region.strip():
+                log.info("assign_wcs updated S_REGION to {0}".format(output_model.meta.wcsinfo.s_region))
         else:
             log.info("assign_wcs did not update S_REGION for type {0}".format(output_model.meta.exposure.type))
         log.info("COMPLETED assign_wcs")

--- a/jwst/extract_2d/nirspec.py
+++ b/jwst/extract_2d/nirspec.py
@@ -53,8 +53,10 @@ def nrs_extract2d(input_model, which_subarray=None, apply_wavecorr=False, refere
                                                          exp_type, apply_wavecorr, reffile)
 
             output_model.slits.append(new_model)
+            orig_s_region = new_model.meta.wcsinfo.s_region.strip()
             util.update_s_region(new_model)
-            log.info('extract_2d updated S_REGION to {0}'.format(new_model.meta.wcsinfo.s_region))
+            if orig_s_region != new_model.meta.wcsinfo.s_region.strip():
+                log.info('extract_2d updated S_REGION to {0}'.format(new_model.meta.wcsinfo.s_region))
             # set x/ystart values relative to the image (screen) frame.
             # The overall subarray offset is recorded in model.meta.subarray.
             nslit = len(output_model.slits) - 1


### PR DESCRIPTION
Only print S_REGION update value if it was actually updated.

Fixes #1355 .
Though how S_Region is updated for spectral data should be revisited for 7.2.