### PR TITLE
Fix set_fits_wcs() so we can roundtrip from meta.wcsinfo to astropy.wcs object

### DIFF
--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -839,13 +839,15 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
             HDU, pass ``'PRIMARY'``.
         """
         header = wcs.to_header()
+        extensions = self._asdf._extensions
         if hdu_name == 'PRIMARY':
             hdu = fits.PrimaryHDU(header=header)
         else:
             hdu = fits.ImageHDU(name=hdu_name, header=header)
         hdulist = fits.HDUList([hdu])
 
-        ff = fits_support.from_fits(hdulist, self._schema, validate=False)
+        ff = fits_support.from_fits(hdulist, self._schema, extensions=extensions,
+            pass_invalid_values=self._pass_invalid_values)
 
         self._instance = properties.merge_tree(self._instance, ff.tree)
 

--- a/jwst/datamodels/tests/test_wcs.py
+++ b/jwst/datamodels/tests/test_wcs.py
@@ -1,6 +1,3 @@
-# Licensed under a 3-clause BSD style license - see LICENSE.rst
-# -*- coding: utf-8 -*-
-
 from __future__ import absolute_import, division, unicode_literals, print_function
 
 import os
@@ -34,7 +31,7 @@ def teardown():
 def _header_to_dict(x):
     return dict((a, b) for (a, b, c) in x)
 
-'''
+
 def test_wcs():
     with ImageModel(FITS_FILE) as dm:
         wcs1 = dm.get_fits_wcs()
@@ -49,9 +46,8 @@ def test_wcs():
 
     wcs1.wcs.crpix[0] = 42.0
 
-    dm2.set_fits_wcs(wcs1, hdu_name="PRIMARY")
-    header = _header_to_dict(dm2.extra_fits.PRIMARY.header)
-    assert header['CRPIX1'] == 42.0
+    dm2.set_fits_wcs(wcs1)
+    assert dm2.meta.wcsinfo.crpix1 == 42.0
 
     wcs2 = dm2.get_fits_wcs()
     assert wcs2.wcs.crpix[0] == 42.0
@@ -75,4 +71,3 @@ def test_wcs():
         wcs5 = dm5.get_fits_wcs()
 
     assert wcs5.wcs.crpix[0] == 42.0
-'''


### PR DESCRIPTION
The calling API for `fits_support.from_fits()` changed in #772.  This catches up with that change, and uncomments and fixes a test for it.

Resolves #1365 .