### PR TITLE
save extra_fits first

### DIFF
--- a/jwst/datamodels/fits_support.py
+++ b/jwst/datamodels/fits_support.py
@@ -391,8 +391,8 @@ def to_fits(tree, schema, extensions=None):
     hdulist = fits.HDUList()
     hdulist.append(fits.PrimaryHDU())
 
-    _save_from_schema(hdulist, tree, schema)
     _save_extra_fits(hdulist, tree)
+    _save_from_schema(hdulist, tree, schema)
     _save_history(hdulist, tree)
 
     asdf = fits_embed.AsdfInFits(hdulist, tree, extensions=extensions)

--- a/jwst/lib/set_telescope_pointing.py
+++ b/jwst/lib/set_telescope_pointing.py
@@ -194,7 +194,7 @@ def update_wcs(model, default_pa_v3=0., siaf_path=None, **kwargs):
     model.meta.pointing.pa_v3 = vinfo.pa
 
     # Update Aperture pointing
-    model.meta.aperture.pa_aper = wcsinfo.pa
+    model.meta.aperture.position_angle = wcsinfo.pa
     model.meta.wcsinfo.crval1 = wcsinfo.ra
     model.meta.wcsinfo.crval2 = wcsinfo.dec
     model.meta.wcsinfo.pc1_1 = -np.cos(wcsinfo.pa * D2R)


### PR DESCRIPTION
When a DataModel is loaded it has only the core schema, which happens to be
by a lucky coincidence) containing only Primary header keywords. When the schema
is extended with wcsinfo (or any other schema that points to an extension header), 
it now adds values which should be written to a SCI extension.

`fits_support.to_fits()` first calls `save_from_schema` and passes a "skeleton" HDUlist which 
has only a primary header. So a SCI extension is created in order to populate the wcs keywords.
Then `fits_support.to_fits` calls `_save_extra_fits`  and adds the real SCI extension.
I think this is in general a wrong approach and we were just "lucky" or "unlucky" that we didn't see
the problem so far. I think it would be better to create the complete FITS HDUList
and then run `save_from_schema`.

One caveat is that when the schema has data arrays and there are data arrays in _extra_fits, they may be ordered differently than before. This is not an error in itself because FITS does not guarantee the order of extensions. It's just ugly.

This came up originally as a bug in DMS testing. The `set_telescope_pointing` script opens the file as a DataModel and extends its schema to include `wcsinfo.schema.yaml`. Then a call to `to_fits` produces a file with two SCI extensions.