### PR TITLE
Optimize reference fetch

### DIFF
--- a/jwst/stpipe/crds_client.py
+++ b/jwst/stpipe/crds_client.py
@@ -69,18 +69,21 @@ def get_multiple_reference_paths(dataset_model, reference_file_types):
     key = (filename, tuple(reference_file_types))
     
     try:
-        refpaths = _BESTREFS_CACHE[key]
+
+        refpaths = { reftype:_BESTREFS_CACHE[(filename, reftype)]
+                     for reftype in reference_file_types }
         log.verbose("Using cached bestrefs for", repr(filename), "with types", repr(reference_file_types))
+        
     except KeyError:
 
         data_dict = _get_data_dict(filename, dataset_model)
 
         # Cache prefetch-like results
-        _BESTREFS_CACHE[key] = refpaths = _get_refpaths(data_dict, tuple(reference_file_types))
+        refpaths = _get_refpaths(data_dict, tuple(reference_file_types))
 
         # Cache results for each individual reftype, as-in get_reference_file().
         for reftype, path in refpaths.items():
-            _BESTREFS_CACHE[(filename, (reftype,))] = { reftype : path }
+            _BESTREFS_CACHE[(filename, reftype)] = path
 
     return refpaths
 

--- a/jwst/stpipe/crds_client.py
+++ b/jwst/stpipe/crds_client.py
@@ -241,12 +241,13 @@ def init_multiprocessing(common_dataset_filepaths=()):
     parameters used by more than one process.  It can be empty.
     """
     # Determine the context to be used based on CRDS cache, CRDS server, and CRDS_CONTEXT.
+    # This can optimize away JSONRPC calls to the server for each subprocess when configured
+    # to interact with the server.
     with log.warn_on_exception("Failed determining context name"):
         final_context = get_context_used()
 
-    # Perform the load of `final_context`, in this case for all instruments, questionable
-    # since a header-based load will only mappings for load the required instrument.
-    # Should be around 2-12 seconds depending on file system performance.
+    # Load `final_context` from the file system.  Every subprocess should inherit the
+    # cached context rather than reloading it.
     with log.warn_on_exception("Failed loading context:", repr(final_context)):
         mapping = crds.get_symbolic_mapping(final_context)
         mapping.force_load()

--- a/jwst/stpipe/pipeline.py
+++ b/jwst/stpipe/pipeline.py
@@ -155,25 +155,6 @@ class Pipeline(Step):
 
         return spec
 
-    def _precache_reference_files(self, input_file):
-        """
-        Precache all of the expected reference files in this Pipeline
-        and all of its constituent Steps process method is called.
-
-        input_file:  a filename string, model, or model container.
-
-        """
-        from .. import datamodels
-        gc.collect()
-        try:
-            with datamodels.open(input_file) as model:
-                super(Pipeline, self)._precache_reference_files_opened(model)
-        except (ValueError, TypeError, IOError):
-            self.log.info(
-                'First argument {0} does not appear to be a '
-                'model'.format(input_file))
-        gc.collect()
-
     def set_input_filename(self, path):
         self._input_filename = path
         for key, val in self.step_defs.items():

--- a/jwst/stpipe/tests/test_crds.py
+++ b/jwst/stpipe/tests/test_crds.py
@@ -136,16 +136,3 @@ def test_crds_failed_getreferences_reftype():
 #     assert_raises(crds.getreferences, header, reftypes=["foo"], context="jwst_9942.pmap")
 
 
-def test_crds_flatten():
-    from jwst.stpipe import crds_client
-
-    json = {
-        'meta': {
-            'instrument': {
-                'name': 'MIRI'
-                }
-            }
-        }
-    flat = crds_client._flatten_dict(json)
-    print(flat)
-    assert flat['meta.instrument.name'] == 'MIRI'


### PR DESCRIPTION
This is a response to Jeb's performance issues when attempting to multi-process 5 or so MIRI associations concurrently.   I believe any remaining CRDS performance issues are in data model i/o or garbage collection.  This addresses that.   This changes only the crds_client glue code.

**The primary optimization is to cache the header parameters CRDS extracts from incoming data models and uses for bestrefs matching.**   Since the cache is keyed by filenames,  this scheme can be defeated by similar files with different names (pipeline progression?) or by datasets that change in ways that affect bestrefs matching (only original header counts...)   Nevertheless,  potentially it can reduce CRDS data models related file i/o by 3:1,  maybe 4:1.   This does not reduce Step file i/o.   This does not eliminate redundant but fast calls to CRDS bestrefs.  It just caches parameters.

**A secondary optimization was to remove two calls to gc.collect() for every bestrefs call.**  memory_profiler.profile() showed zero growth,  I've seen gc be surprisingly expensive,  seconds.

**Removes handling for older versions of CRDS that don't have crds_cache_locking module.**

**Additional caching to avoid repeat equivalent calls to crds.getreferences(),  strategically good even though those are currently cheap for most CRDS configurations.**



