### PR TITLE
More fixes to get set_telescope_pointing to work

### DIFF
--- a/jwst/datamodels/level1b.py
+++ b/jwst/datamodels/level1b.py
@@ -56,8 +56,8 @@ class Level1bModel(model_base.DataModel):
         #
         # TODO: Hacky. Need solution which involves schema
         # specification and embedded in DataModel.
-        if 'zeroframe' not in self.instance and \
-           'data' in self.instance and \
-           len(self.data.shape) == 4:
-            nints, ngroups, ny, nx = self.data.shape
-            self.zeroframe = np.zeros((nints, ny, nx))
+        #if 'zeroframe' not in self.instance and \
+        #   'data' in self.instance and \
+        #   len(self.data.shape) == 4:
+        #    nints, ngroups, ny, nx = self.data.shape
+        #    self.zeroframe = np.zeros((nints, ny, nx))

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -284,7 +284,8 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         current_date = Time(datetime.datetime.now())
         current_date.format = 'isot'
         self.meta.date = current_date.value
-        self.meta.model_type = self.__class__.__name__
+        if self.meta.model_type is not None:
+            self.meta.model_type = self.__class__.__name__
 
     def save(self, path, *args, **kwargs):
         """

--- a/jwst/lib/set_telescope_pointing.py
+++ b/jwst/lib/set_telescope_pointing.py
@@ -10,7 +10,7 @@ from numpy import (cos, sin)
 from namedlist import namedlist
 from asdf import schema as asdf_schema
 
-from ..datamodels import DataModel
+from ..datamodels import Level1bModel
 from ..lib.engdb_tools import (
     ENGDB_BASE_URL,
     ENGDB_Service,
@@ -109,14 +109,14 @@ def add_wcs(filename, default_pa_v3=0., siaf_path=None, **kwargs):
         Keyword arguments used by matrix calculation routines
     """
     logger.info('Updating WCS info for file {}'.format(filename))
-    model = DataModel(filename)
-    model = _extend_schema(model, 'wcsinfo.schema.yaml')
+    model = Level1bModel(filename)
     update_wcs(
         model,
         default_pa_v3=default_pa_v3,
         siaf_path=siaf_path,
         **kwargs
     )
+    model.meta.model_type = None
     model.save(filename)
     model.close()
     logger.info('...update completed')

--- a/scripts/set_velocity_aberration.py
+++ b/scripts/set_velocity_aberration.py
@@ -169,7 +169,7 @@ def add_dva(filename):
     '''
     hdulist = fits.open(filename, 'update')
     pheader = hdulist[0].header
-    sheader = hdulist[1].header
+    sheader = hdulist['SCI'].header
     jwst_dx = float(pheader['JWST_DX'])
     jwst_dy = float(pheader['JWST_DY'])
     jwst_dz = float(pheader['JWST_DZ'])


### PR DESCRIPTION
The changes in #1370 resolved the issue of having two SCI extensions appear in files updated by set_telescope_pointing, but it still resulted in an output file that had the DATAMODL keyword set to 'DataModel'. This causes failures in the `calwebb_detector1` pipeline (and steps), because they all use the generic `datamodels.open()` function to load their inputs. It was loading them into a DataModel, which doesn't work. They need to load into a RampModel.

These changes have the effect of removing the DATAMODL keyword from the files produced by set_telescope_pointing, so that the subsequent calls to `datamodels.open()` rely on file structure info to correctly determine that they should use RampModel.

This also allowed for a change to set_telescope_pointing to have it use the appropriate `Level1bModel` for input, instead of `DataModel`. `Level1bModel` already has the wcsinfo.schema included and hence there's no need to extend the schema to include the WCS keywords.

A change was also made to the Level1bModel itself, such that it no longer automatically creates a ZEROFRAME array/extension if there isn't one in the input. This is not needed or desired. If there's no ZEROFRAME in the input, don't create one (just like for REFOUT).

Finally, because of the change to fits_support in #1370, there's no longer a guarantee that the SCI extension will always be the first extension HDU in a FITS file, so the set_velocity_abberation script has been updated to explicitly use the SCI extension (rather than extension 1).

I have tested these changes on several level-1b files provided by Mike Swam and the updated _uncal.fits files come out correctly and they in turn process through calwebb_detector1 correctly.