### PR TITLE
force WAVELENGTH array to show in fits.info()

### DIFF
--- a/jwst/datamodels/schemas/multislit.schema.yaml
+++ b/jwst/datamodels/schemas/multislit.schema.yaml
@@ -134,4 +134,10 @@ allOf:
               ndim: 2
               default: 1.0
               datatype: float32
+            wavelength:
+              title: wavelength array
+              fits_hdu: WAVELENGTH
+              ndim: 2
+              default: 0.0
+              datatype: float32
 $schema: http://stsci.edu/schemas/fits-schema/fits-schema


### PR DESCRIPTION
Using `astropy.fits.info(filename)` with `extract_2d` output file does not show the WAVELENGTH extension in the file, although it is present and accessible within the model. This is forces it to show as a FITS extension.