### PR TITLE
Add new REFERENCE_PIXEL dq flag definition

### DIFF
--- a/jwst/datamodels/dqflags.py
+++ b/jwst/datamodels/dqflags.py
@@ -29,7 +29,8 @@ pixel = {'GOOD': 0,
          'ADJ_OPEN': 134217728,
          'UNRELIABLE_RESET': 268435456,
          'MSA_FAILED_OPEN': 536870912,
-         'OTHER_BAD_PIXEL': 1073741824
+         'OTHER_BAD_PIXEL': 1073741824,
+         'REFERENCE_PIXEL': 2147483648
 }
 
 group = {'GOOD': 0,


### PR DESCRIPTION
Added a definition for REFERENCE_PIXEL to the list of pixel dq flag definitions, which will be used in MASK reference files to identify reference pixels, so that they can be excluded from downstream operations like resampling.

Note that I think this is the last new definition we can add without having to again bump up the dq datatype from uint32.

In partial fulfillment of #841.