### PR TITLE
Keyword schema updates

### DIFF
--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -258,11 +258,11 @@ properties:
             type: string
             fits_keyword: MU_EPOCH
           proposer_ra:
-            title: Proposer target RA
+            title: Proposer's target RA
             type: number
             fits_keyword: PROP_RA
           proposer_dec:
-            title: Propose target Dec
+            title: Proposer's target Dec
             type: number
             fits_keyword: PROP_DEC
           source_type:

--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -7,7 +7,7 @@ properties:
         anyOf:
           - $ref: http://stsci.edu/schemas/asdf/time/time-1.0.0
           - type: string
-        title: Date this file was created (UTC)
+        title: Date this file was created [UTC]
         fits_keyword: DATE
       origin:
         title: Organization responsible for creating file
@@ -21,6 +21,10 @@ properties:
         title: Name of the file
         type: string
         fits_keyword: FILENAME
+      filetype:
+        title: Type of data in the file
+        type: string
+        fits_keyword: FILETYPE
       data_processing_software_version:
         title: Data processing software version number
         type: string
@@ -45,11 +49,18 @@ properties:
         title: Telescope used to acquire the data
         type: string
         fits_keyword: TELESCOP
-      engineering_quality:
-        title: Engineering data quality indicator from EngDB
+      hga_move:
+        title: High Gain Antenna moved during data collection
+        type: boolean
+        fits_keyword: HGA_MOVE
+      hga_start_time:
+        title: Start time of HGA motion
         type: string
-        enum: [OK, SUSPECT]
-        fits_keyword: ENG_QUAL
+        fits_keyword: HGA_STRT
+      hga_stop_time:
+        title: Stop time of HGA motion
+        type: string
+        fits_keyword: HGA_STOP
       asn:
         title: Association information
         type: object
@@ -62,28 +73,8 @@ properties:
             title: Name of the ASN table
             type: string
             fits_keyword: ASNTABLE
-      basic:
-        title: Basic information
-        type: object
-        properties:
-          filetype:
-            title: Type of data in the file
-            type: string
-            fits_keyword: FILETYPE
-          hga_move:
-            title: High Gain Antenna moved during data collection
-            type: boolean
-            fits_keyword: HGA_MOVE
-          hga_start_time:
-            title: Start time of HGA motion
-            type: string
-            fits_keyword: HGA_STRT
-          hga_stop_time:
-            title: Stop time of HGA motion
-            type: string
-            fits_keyword: HGA_STOP
       program:
-        title: Programmatic information
+        title: Program information
         type: object
         properties:
           title:
@@ -173,7 +164,7 @@ properties:
             type: boolean
             fits_keyword: BKGDTARG
           template:
-            title: Proposal instruction template used
+            title: Observation template used
             type: string
             fits_keyword: TEMPLATE
           observation_label:
@@ -184,6 +175,11 @@ properties:
         title: Visit information
         type: object
         properties:
+          engineering_quality:
+            title: Engineering data quality indicator from EngDB
+            type: string
+            enum: [OK, SUSPECT]
+            fits_keyword: ENG_QUAL
           type:
             title: Visit type
             type: string
@@ -197,10 +193,6 @@ properties:
             title: UTC visit start time
             type: string
             fits_keyword: VSTSTART
-          wfs_visit_indicator:
-            title: Wavefront sensing and control visit indicator
-            type: string
-            fits_keyword: WFSVISIT
           status:
             title: Status of a visit
             type: string
@@ -256,15 +248,23 @@ properties:
           proper_motion_ra:
             title: Target proper motion in RA
             type: number
-            fits_keyword: PROP_RA
+            fits_keyword: MU_RA
           proper_motion_dec:
             title: Target proper motion in Dec
             type: number
-            fits_keyword: PROP_DEC
+            fits_keyword: MU_DEC
           proper_motion_epoch:
             title: Target proper motion epoch
+            type: string
+            fits_keyword: MU_EPOCH
+          proposer_ra:
+            title: Proposer target RA
             type: number
-            fits_keyword: PROPEPOC
+            fits_keyword: PROP_RA
+          proposer_dec:
+            title: Propose target Dec
+            type: number
+            fits_keyword: PROP_DEC
           source_type:
             title: Advised source type (point/extended)
             type: string
@@ -422,6 +422,11 @@ properties:
             title: Running count of exposures in visit
             type: integer
             fits_keyword: EXPCOUNT
+          prime_parallel:
+            title: Prime or parallel exposure
+            type: string
+            enum: [PRIME, PARALLEL_COORDINATED, PARALLEL_PURE]
+            fits_keyword: EXPRIPAR
           type:
             title: Type of data in the exposure
             type: string
@@ -438,11 +443,6 @@ properties:
               NRS_IFU, NRS_IMAGE, NRS_LAMP, NRS_MIMF, NRS_MSASPEC, NRS_TACONFIRM,
               NRS_TACQ, NRS_TASLIT]
             fits_keyword: EXP_TYPE
-          prime_parallel:
-            title: Prime or parallel exposure
-            type: string
-            enum: [PRIME, PARALLEL_COORDINATED, PARALLEL_PURE]
-            fits_keyword: EXPRIPAR
           start_time:
             allOf:
               - type: number
@@ -787,6 +787,10 @@ properties:
             title: PRD science aperture used
             type: string
             fits_keyword: APERNAME
+          pps_name:
+            title: original AperName supplied by PPS
+            type: string
+            fits_keyword: PPS_APER
       velocity_aberration:
         title: Velocity aberration correction information
         type: object

--- a/jwst/datamodels/schemas/wcsinfo.schema.yaml
+++ b/jwst/datamodels/schemas/wcsinfo.schema.yaml
@@ -79,19 +79,19 @@ properties:
             fits_keyword: CRPIX3
             fits_hdu: SCI
           crval1:
-            title: RA at the reference pixel (deg)
+            title: first axis value at the reference pixel
             type: number
             default: 0.0
             fits_keyword: CRVAL1
             fits_hdu: SCI
           crval2:
-            title: Dec at the reference pixel (deg)
+            title: second axis value at the reference pixel
             type: number
             default: 0.0
             fits_keyword: CRVAL2
             fits_hdu: SCI
           crval3:
-            title: Wavelength at the reference pixel (microns)
+            title: third axis value at the reference pixel
             type: number
             default: 0.0
             fits_keyword: CRVAL3
@@ -127,19 +127,19 @@ properties:
             fits_keyword: CUNIT3
             fits_hdu: SCI
           cdelt1:
-            title: first axis increment per pixel (deg)
+            title: first axis increment per pixel
             type: number
             default: 1.0
             fits_keyword: CDELT1
             fits_hdu: SCI
           cdelt2:
-            title: second axis increment per pixel (deg)
+            title: second axis increment per pixel
             type: number
             default: 1.0
             fits_keyword: CDELT2
             fits_hdu: SCI
           cdelt3:
-            title: third axis increment per pixel (microns)
+            title: third axis increment per pixel
             type: number
             default: 1.0
             fits_keyword: CDELT3


### PR DESCRIPTION
More updates to keyword definitions in core and wcsinfo schemas, to keep up with the JWST keyword dictionary. A few new keywords added, some removed, along with some changes to comments and a little reordering. So this is going to cause all regression tests to fail, just because of header changes.

On the up side, the dreaded PROPEPOC keyword is now gone (it's been replaced by MU_EPOCH, but none of our current test files have that keyword).