### PR TITLE
Update CAL_SVN keyword [skip ci]

### DIFF
--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -38,9 +38,9 @@ properties:
         type: string
         fits_keyword: CAL_VER
       calibration_software_revision:
-        title: Calibration software revision number
+        title: Calibration software version control sys number
         type: string
-        fits_keyword: CAL_SVN
+        fits_keyword: CAL_VCS
       model_type:
         title: Type of data model
         type: string


### PR DESCRIPTION
One more header change to lump in with all the others today. Rename the CAL_SVN keyword to CAL_VCS and update the comment. Fixes #57.