### PR TITLE
Update calwebb_detector1 and steps to use RampModel input

### DIFF
--- a/jwst/dark_current/dark_current_step.py
+++ b/jwst/dark_current/dark_current_step.py
@@ -18,7 +18,7 @@ class DarkCurrentStep(Step):
     def process(self, input):
 
         # Open the input data model
-        with datamodels.open(input) as input_model:
+        with datamodels.RampModel(input) as input_model:
 
             # Get the name of the dark reference file to use
             self.dark_name = self.get_reference_file(input_model, 'dark')

--- a/jwst/dq_init/dq_init_step.py
+++ b/jwst/dq_init/dq_init_step.py
@@ -17,7 +17,7 @@ class DQInitStep(Step):
 
     def process(self, input):
         # Determine Model type from EXP_TYPE of RampModel
-        input_model = datamodels.open(input)
+        input_model = datamodels.RampModel(input)
 
         # Set flag for guider mode operations
         if input_model.meta.exposure.type in dq_initialization.guider_list: # Reopen as GuiderRawModel

--- a/jwst/group_scale/group_scale_step.py
+++ b/jwst/group_scale/group_scale_step.py
@@ -13,7 +13,7 @@ class GroupScaleStep(Step):
     def process(self, input):
 
         # Open the input data model
-        with datamodels.open(input) as input_model:
+        with datamodels.RampModel(input) as input_model:
 
             # Try to get values of NFRAMES and FRMDIVSR to see
             # if we need to do any rescaling

--- a/jwst/ipc/ipc_step.py
+++ b/jwst/ipc/ipc_step.py
@@ -14,7 +14,7 @@ class IPCStep(Step):
     def process(self, input):
 
         # Open the input data model
-        with datamodels.open(input) as input_model:
+        with datamodels.RampModel(input) as input_model:
 
             # Get the name of the ipc reference file to use
             self.ipc_name = self.get_reference_file(input_model, 'ipc')

--- a/jwst/jump/jump_step.py
+++ b/jwst/jump/jump_step.py
@@ -27,7 +27,7 @@ class JumpStep(Step):
 
     def process(self, input):
 
-        with datamodels.open(input) as input_model:
+        with datamodels.RampModel(input) as input_model:
 
             # Check for consistency between keyword values and data shape
             ngroups = input_model.data.shape[1]
@@ -76,6 +76,3 @@ class JumpStep(Step):
 
         return result
 
-
-if __name__ == '__main__':
-    cmdline.step_script(JumpStep)

--- a/jwst/lastframe/lastframe_step.py
+++ b/jwst/lastframe/lastframe_step.py
@@ -13,7 +13,7 @@ class LastFrameStep(Step):
     def process(self, input):
 
         # Open the input data model
-        with datamodels.open(input) as input_model:
+        with datamodels.RampModel(input) as input_model:
 
             # check the data is MIRI data
             detector = input_model.meta.instrument.detector

--- a/jwst/linearity/linearity_step.py
+++ b/jwst/linearity/linearity_step.py
@@ -14,7 +14,7 @@ class LinearityStep(Step):
     def process(self, input):
 
         # Open the input data model
-        with datamodels.open(input) as input_model:
+        with datamodels.RampModel(input) as input_model:
 
             # Get the name of the linearity reference file to use
             self.lin_name = self.get_reference_file(input_model, 'linearity')

--- a/jwst/persistence/persistence_step.py
+++ b/jwst/persistence/persistence_step.py
@@ -32,7 +32,7 @@ class PersistenceStep(Step):
                 len(self.input_trapsfilled) == 0):
                 self.input_trapsfilled = None
 
-        output_obj = datamodels.open(input).copy()
+        output_obj = datamodels.RampModel(input).copy()
 
         self.trap_density_filename = self.get_reference_file(output_obj,
                                                              "trapdensity")
@@ -103,6 +103,3 @@ class PersistenceStep(Step):
 
         return output_obj
 
-
-if __name__ == '__main__':
-    cmdline.step_script(persistence_step)

--- a/jwst/pipeline/calwebb_detector1.py
+++ b/jwst/pipeline/calwebb_detector1.py
@@ -65,8 +65,8 @@ class Detector1Pipeline(Pipeline):
 
         log.info('Starting calwebb_detector1 ...')
 
-        # open the input
-        input = datamodels.open(input)
+        # open the input as a RampModel
+        input = datamodels.RampModel(input)
 
         # propagate output_dir to steps that might need it
         self.dark_current.output_dir = self.output_dir

--- a/jwst/ramp_fitting/ramp_fit.py
+++ b/jwst/ramp_fitting/ramp_fit.py
@@ -98,6 +98,13 @@ def ramp_fit(model, buffsize, save_opt, readnoise_model, gain_model,
                gain_model, weighting)
         gls_opt_model = None
 
+    # Update data units in output models
+    new_model.meta.bunit_data = 'DN/s'
+    new_model.meta.bunit_err = 'DN/s'
+    if int_model is not None:
+        int_model.meta.bunit_data = 'DN/s'
+        int_model.meta.bunit_err = 'DN/s'
+
     return new_model, int_model, opt_model, gls_opt_model
 
 

--- a/jwst/ramp_fitting/ramp_fit_step.py
+++ b/jwst/ramp_fitting/ramp_fit_step.py
@@ -38,7 +38,7 @@ class RampFitStep (Step):
 
     def process(self, input):
 
-        with datamodels.open(input) as input_model:
+        with datamodels.RampModel(input) as input_model:
 
             readnoise_filename = self.get_reference_file(input_model,
                                                           'readnoise')
@@ -93,5 +93,3 @@ class RampFitStep (Step):
 
         return out_model, int_model
 
-if __name__ == '__main__':
-    cmdline.step_script(ramp_fit_step)

--- a/jwst/refpix/refpix_step.py
+++ b/jwst/refpix/refpix_step.py
@@ -24,7 +24,7 @@ class RefPixStep(Step):
 
     def process(self, input):
 
-        with datamodels.open(input) as input_model:
+        with datamodels.RampModel(input) as input_model:
             if input_model.meta.exposure.readpatt is not None and \
                input_model.meta.exposure.readpatt.find("IRS2") >= 0:
                 self.irs2_name = self.get_reference_file(input_model, 'refpix')

--- a/jwst/rscd/rscd_step.py
+++ b/jwst/rscd/rscd_step.py
@@ -14,7 +14,7 @@ class RSCD_Step(Step):
     def process(self, input):
 
         # Open the input data model
-        with datamodels.open(input) as input_model:
+        with datamodels.RampModel(input) as input_model:
 
             # check the data is MIRI data
             detector = input_model.meta.instrument.detector

--- a/jwst/saturation/saturation_step.py
+++ b/jwst/saturation/saturation_step.py
@@ -14,7 +14,7 @@ class SaturationStep(Step):
     def process(self, input):
 
         # Open the input data model
-        with datamodels.open(input) as input_model:
+        with datamodels.RampModel(input) as input_model:
 
             # Get the name of the saturation reference file
             self.ref_name = self.get_reference_file(input_model, 'saturation')

--- a/jwst/superbias/superbias_step.py
+++ b/jwst/superbias/superbias_step.py
@@ -18,7 +18,7 @@ class SuperBiasStep(Step):
     def process(self, input):
 
         # Open the input data model
-        with datamodels.open(input) as input_model:
+        with datamodels.RampModel(input) as input_model:
 
             # Get the name of the superbias reference file to use
             self.bias_name = self.get_reference_file(input_model, 'superbias')


### PR DESCRIPTION
These changes update the `calwebb_detector1` pipeline and (nearly) all of its steps to explicitly open the input data as a `RampModel`, rather than using the generic `datamodels.open()` function. All steps are setup to work only on a `RampModel` in that they either need to use data spread across multiple groups or integrations, or rely on data arrays like `groupdq` and `pixeldq`, all of which are only present in a `RampModel`. There is no way, therefore, that any of these steps could ever be applied to any kind of simpler model, like `ImageModel` or `CubeModel`, hence there's no reason to allow for any kind of input other than `RampModel`.

The only step in the `calwebb_detector1` pipeline that does not work on 4-D `RampModel` data is the final step `gain_scale`, which is applied after the `ramp_fit` step, and hence works on an `ImageModel` or `CubeModel`. So it still uses the generic `datamodels.open()` function on its input.

Note that while we have an explicit `MIRIRampModel` defined in datamodels, the only difference between it and the generic `RampModel` is the presence of the extra data array `REFOUT` (contains values from the MIRI detector reference output). Currently the `REFOUT` extension is not used in any calibration pipeline steps and is not passed along to any of the `calwebb_detector1` output products, so there's no harm in not loading it from the input file to this pipeline. We could, if desired, update the `RampModel` definition to include the `REFOUT` extension, but in a way that it would be optional, in which case it would get loaded only when it's actually present in the input FITS file. At that point the dedicated `MIRIRampModel` would no longer be needed.

These changes address the fundamental issue encountered in #1372, in which the DATAMODL keyword in level-1b files created by the `set_telescope_pointing` pointing script are set to `Level1bModel`, which when opened with the generic `datamodels.open()` function was causing the data to be loaded into a `Level1bModel`, which doesn't work with the `calwebb_detector1` pipeline (must be a `RampModel`). Now that the pipeline and steps have been fixed to explicitly load the data into the proper type of model, the tricks employed in `set_telescope_pointing` and `datamodels.model_base` to remove the DATAMODL keyword could be backed out to allow the level-1b files to have `DATAMODL="Level1bModel"` in their headers.

One other minor updated included here is to set the value of the BUNIT keyword in the `ramp_fit` output products to be `DN/s`, which partially fulfills #63.