### PR TITLE
Add Python 3.5 back but as allowed failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,8 +40,9 @@ matrix:
 
     include:
 
-        - os: linux
+        - os: osx
           env: PYTHON_VERSION=3.5 SETUP_CMD='test'
+          compiler: clang
 
         # PEP8 check with flake8 (only once, i.e. "os: linux")
         - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,9 @@ matrix:
 
     include:
 
+        - os: linux
+          env: PYTHON_VERSION=3.5 SETUP_CMD='test'
+
         # PEP8 check with flake8 (only once, i.e. "os: linux")
         - os: linux
           env: MAIN_CMD='flake8 --count'
@@ -53,6 +56,8 @@ matrix:
                PIP_DEPENDENCIES='sphinx_rtd_theme sphinx-automodapi'
 
     allow_failures:
+        - env: PYTHON_VERSION=3.5 SETUP_CMD='test'
+
         # PEP8 will fail for numerous reasons. Ignore it.
         - env: MAIN_CMD='flake8 --count'
                SETUP_CMD='jwst' TEST_CMD='flake8 --version'


### PR DESCRIPTION
Follow up of #1395.

There seems to be concern that Python 3.5 is no longer tested. However, Python 3.5 mysteriously times out on Travis CI. So this PR adds it back but as an allowed failure.