### PR TITLE
Update documentation for extract_1d and flat_field

### DIFF
--- a/docs/jwst/extract_1d/description.rst
+++ b/docs/jwst/extract_1d/description.rst
@@ -7,6 +7,10 @@ data through any one or more of the fixed slits, MIRI LRS data through
 the slit or in the slitless region, and NIRISS slitless data) as well as
 IFU data and NIRSpec MOS (micro-shutter array) data.
 
+For GRISM data (NIS_WFSS or NRC_GRISM), no reference file is used.
+The extraction region is taken to be the full size of the input subarray,
+and the dispersion direction is assumed to be the longer axis.
+
 For IFU data, the extraction options differ depending on
 whether the target is a point source or an extended source.  For a point
 source, the spectrum will be extracted using circular aperture photometry,
@@ -23,8 +27,9 @@ subsampled N x N, and the "center" option will be used for each sub-pixel.
 Input
 =====
 Level 2-b countrate data, or level-3 data.  The format should be a
-CubeModel, an IFUCubeModel, an ImageModel, or a MultiSlitModel, with at
-least SCI and RELSENS extensions for each slit.  The SCI extensions should
+CubeModel, an IFUCubeModel, an ImageModel, a DrizProductModel,
+a MultiSlitModel, a MultiProductModel, or a ModelContainer.
+The SCI extensions should
 have keyword SLTNAME to specify which slit was extracted, though if there
 is only one slit (e.g. full-frame data), the slit name can be taken from
 the JSON reference file instead.

--- a/docs/jwst/flatfield/main.rst
+++ b/docs/jwst/flatfield/main.rst
@@ -22,6 +22,9 @@ applied to the corresponding slit in the science data.
 Multiple-integration datasets (the _rateints.fits products from the ramp_fit
 step) are handled by applying the flat-field to each integration.
 
+NIRSpec imaging data are corrected the same as non-NIRSpec data,
+i.e. they will just be divided by a flat-field reference image.
+
 For pixels whose DQ is NO_FLAT_FIELD in the reference file, the flat
 value is reset to 1.0. Similarly, for pixels whose flat value is NaN, the flat
 value is reset to 1.0 and DQ value in the output science data is set to
@@ -33,7 +36,8 @@ COMPLETE in the output science data.
 
 NIRSpec Data
 ------------
-The difference with NIRSpec data is that the flat field array that will be
+Flat-fielding of NIRSpec spectrographic data differs from other modes
+in that the flat field array that will be
 divided into the SCI and ERR arrays of the input science data set is not
 read directly from CRDS.  This is because the flat field varies with
 wavelength, and the wavelength of light that falls on any given pixel
@@ -43,6 +47,16 @@ by extracting the relevant section from the reference files, and then --
 for each pixel -- interpolating to the appropriate wavelength for that
 pixel.  See the Reference File section for further details.  There is
 an option to save the on-the-fly flat field to a file.
+
+NIRSpec NRS_BRIGHTOBJ data are processed much like other NIRSpec
+spectrographic data, except that NRS_BRIGHTOBJ data are in a CubeModel,
+rather than a MultiSlitModel or ImageModel (used for IFU data).  A 2-D
+flat field image will be constructed on-the-fly as usual, but this image
+will be divided into each plane of the 3-D science data and error array,
+resulting in an output CubeModel.
+
+When this step is called with NIRSpec imaging data as input, the data will be
+flat-fielded as described in the section for non-NIRSpec data.
 
 Subarrays
 ---------


### PR DESCRIPTION
Support for GRISM data in `extract_1d` was mentioned.  The `flat_field` step can process NIRSpec imaging data and BRIGHTOBJ data.