### PR TITLE
Fix NIRSpec resampling output frame

### DIFF
--- a/jwst/resample/gwcs_blot.py
+++ b/jwst/resample/gwcs_blot.py
@@ -1,19 +1,8 @@
 from __future__ import (division, print_function, unicode_literals,
     absolute_import)
 
-import os
-import os.path
-
 import numpy as np
-from astropy import wcs
-from astropy.io import fits
 
-from astropy import wcs as fitswcs
-from gwcs import wcs
-from gwcs import wcstools
-
-from drizzle import util
-from drizzle import doblot
 from drizzle.cdrizzle import tblot
 from . import resample_utils
 

--- a/jwst/resample/resample_spec.py
+++ b/jwst/resample/resample_spec.py
@@ -1,24 +1,21 @@
 from __future__ import (division, print_function, unicode_literals,
     absolute_import)
 
-import time
 import functools
-from collections import OrderedDict
+from collections import OrderedDict, namedtuple
 
 import numpy as np
-from scipy import interpolate
 
-from astropy.io import fits
 from astropy.coordinates import SkyCoord
+from astropy import coordinates as coord
 from astropy import units as u
 from astropy.modeling.models import (Shift, Scale, Mapping, Identity,
-    Rotation2D, Pix2Sky_TAN, RotateNative2Celestial)
-from astropy.modeling import fitting
+    Rotation2D, Pix2Sky_TAN, RotateNative2Celestial, Tabular1D, Const1D)
 from gwcs import wcstools, WCS
 from gwcs.utils import _compute_lon_pole
+from gwcs import coordinate_frames as cf
 
 from .. import datamodels
-from ..assign_wcs import util
 from . import gwcs_drizzle
 from . import bitmask
 from . import resample_utils
@@ -69,13 +66,9 @@ class ResampleSpecData(object):
         self.input_models = input_models
         if output is None:
             output = input_models.meta.resample.output
-        self.output_filename = output
         self.ref_filename = ref_filename
 
-        self.output_spatial_scale = None
-        self.output_spectral_scale = None
-        self.output_wcs = None
-        self.data_size = None
+        self.pscale_ratio = 1.
         self.blank_output = None
 
         # If user specifies use of drizpars ref file (default for pipeline use)
@@ -85,22 +78,19 @@ class ResampleSpecData(object):
         self.drizpars.update(pars)
 
         # Define output WCS based on all inputs, including a reference WCS
-        wcslist = [m.meta.wcs for m in self.input_models]
-        instr_name = self.input_models[0].meta.instrument.name
-        if instr_name in ['NIRSPEC']:
-            self.build_nirspec_output_wcs()
-        elif instr_name in ['MIRI']:
-            self.build_miri_output_wcs()
-        self.build_size_from_bounding_box()
-        self.blank_output = datamodels.DrizProductModel(self.data_size)
-        self.blank_output.meta.wcs = self.output_wcs
+        # wcslist = [m.meta.wcs for m in self.input_models]
 
-        # Default to defining output models metadata as
-        # a copy of the first input_model's metadata
-        ### TO DO:
-        ###    replace this with a call to a generalized version of fitsblender
-        ###
+        self.instrument_name = self.input_models[0].meta.instrument.name
+        if self.instrument_name in ['NIRSPEC']:
+            self.output_wcs = self.build_nirspec_output_wcs()
+        elif self.instrument_name in ['MIRI']:
+            self.output_wcs = self.build_miri_output_wcs()
+
+        self.data_size = self.build_size_from_bounding_box()
+        self.blank_output = datamodels.DrizProductModel(self.data_size)
+
         self.blank_output.update(datamodels.ImageModel(self.input_models[0]._instance))
+        self.blank_output.meta.wcs = self.output_wcs
         self.output_models = datamodels.ModelContainer()
 
 
@@ -121,7 +111,8 @@ class ResampleSpecData(object):
         row = None
         drizpars = ref_model.drizpars_table
 
-        filter_match = False # flag to support wild-card rows in drizpars table
+        # Flag to support wild-card rows in drizpars table
+        filter_match = False
         for n, filt, num in zip(range(1, drizpars.numimages.shape[0] + 1),
             drizpars.filter, drizpars.numimages):
             # only remember this row if no exact match has already been made for
@@ -147,126 +138,86 @@ class ResampleSpecData(object):
                 self.drizpars[kw] = ref_model['drizpars_table.{0}'.format(kw)][row]
 
 
-    def create_output_metadata(self):
-        """ Create new output metadata based on blending all input metadata
+    def build_nirspec_output_wcs(self, refmodel=None):
         """
-        # TODO: Modify API for fitsblender
-        pass
-
-
-    def build_nirspec_output_wcs(self, refwcs=None):
+        Create a spatial/spectral WCS covering footprint of the input
         """
-        Create a simple output wcs covering footprint of the input datamodels
-        """
-        # TODO: generalize this for more than one input datamodel
-        # TODO: generalize this for imaging modes with distorted wcs
-        input_model = self.input_models[0]
-        if refwcs == None:
-            refwcs = input_model.meta.wcs
-
-        # Generate grid of sky coordinates for area within bounding box
+        if not refmodel:
+            refmodel = self.input_models[0]
+        refwcs = refmodel.meta.wcs
         bb = refwcs.bounding_box
-        det = x, y = wcstools.grid_from_bounding_box(bb, step=(1, 1),
-            center=True)
-        sky = ra, dec, lam = refwcs(*det)
-        x_center = int((bb[0][1] - bb[0][0]) / 2)
-        y_center = int((bb[1][1] - bb[1][0]) / 2)
-        log.debug("Center of bounding box: {}  {}".format(x_center, y_center))
 
-        # Compute slit angular size, slit center sky coords
-        xpos = []
-        sz = 3
-        for row in lam:
-            if np.isnan(row[x_center]):
-                xpos.append(np.nan)
-            else:
-                f = interpolate.interp1d(row[x_center - sz + 1:x_center + sz],
-                    x[y_center, x_center - sz + 1:x_center + sz],
-                    bounds_error=False, fill_value='extrapolate')
-                xpos.append(f(lam[y_center, x_center]))
-        x_arg = np.array(xpos)[~np.isnan(lam[:, x_center])]
-        y_arg = y[~np.isnan(lam[:, x_center]), x_center]
-        # slit_coords, spect0 = refwcs(x_arg, y_arg, output='numericals_plus')
-        slit_ra, slit_dec, slit_spec_ref = refwcs(x_arg, y_arg)
-        slit_coords = SkyCoord(ra=slit_ra, dec=slit_dec, unit=u.deg)
-        pix_num = np.flipud(np.arange(len(slit_ra)))
-        # pix_num = np.arange(len(slit_ra))
-        interpol_ra = interpolate.interp1d(pix_num, slit_ra)
-        interpol_dec = interpolate.interp1d(pix_num, slit_dec)
-        slit_center_pix = len(slit_spec_ref) / 2. - 1
-        log.debug('Slit center pix: {0}'.format(slit_center_pix))
-        slit_center_sky = SkyCoord(ra=interpol_ra(slit_center_pix),
-            dec=interpol_dec(slit_center_pix), unit=u.deg)
-        log.debug('Slit center: {0}'.format(slit_center_sky))
-        log.debug('Fiducial: {0}'.format(resample_utils.compute_spec_fiducial([refwcs])))
-        angular_slit_size = np.abs(slit_coords[0].separation(slit_coords[-1]))
-        log.debug('Slit angular size: {0}'.format(angular_slit_size.arcsec))
-        dra, ddec = slit_coords[0].spherical_offsets_to(slit_coords[-1])
-        offset_up_slit = (dra.to(u.arcsec), ddec.to(u.arcsec))
-        log.debug('Offset up the slit: {0}'.format(offset_up_slit))
+        ref_det2slit = refwcs.get_transform('detector', 'slit_frame')
+        ref_slit2world = refwcs.get_transform('slit_frame', 'world')
 
-        # Compute spatial and spectral scales
-        xposn = np.array(xpos)[~np.isnan(xpos)]
-        dx = xposn[-1] - xposn[0]
-        slit_npix = np.sqrt(dx**2 + np.array(len(xposn) - 1)**2)
-        spatial_scale = angular_slit_size / slit_npix
-        log.debug('Spatial scale: {0}'.format(spatial_scale.arcsec))
-        spectral_scale = lam[y_center, x_center] - lam[y_center, x_center - 1]
+        grid = x, y = wcstools.grid_from_bounding_box(bb, step=(1, 1))
+        Grid = namedtuple('Grid', refwcs.slit_frame.axes_names)
+        grid_slit = Grid(*ref_det2slit(*grid))
 
-        # Compute slit angle relative (clockwise) to y axis
-        slit_rot_angle = (np.arcsin(dx / slit_npix) * u.radian).to(u.degree)
-        slit_rot_angle = slit_rot_angle.value
-        log.debug('Slit rotation angle: {0}'.format(slit_rot_angle))
+        # Compute spatial transform from detector to slit
+        ref_wavelength = np.nanmean(grid_slit.wavelength)
 
-        # Compute transform for output frame
-        roll_ref = input_model.meta.wcsinfo.roll_ref
-        min_lam = np.nanmin(lam)
-        offset = Shift(-slit_center_pix) & Shift(-slit_center_pix)
+        # find the number of pixels sampled by a single shutter
+        fid = np.array([[0., 0.], [-.5, .5], np.repeat(ref_wavelength, 2)])
+        slit_extents = np.array(ref_det2slit.inverse(*fid)).T
+        pix_per_shutter = np.linalg.norm(slit_extents[0] - slit_extents[1])
 
-        # TODO: double-check the signs on the following rotation angles
-        rot = Rotation2D(roll_ref + slit_rot_angle)
-        scale = Scale(spatial_scale.value) & Scale(spatial_scale.value)
-        tan = Pix2Sky_TAN()
-        lon_pole = _compute_lon_pole(slit_center_sky, tan)
-        skyrot = RotateNative2Celestial(slit_center_sky.ra.value, slit_center_sky.dec.value,
-            lon_pole.value)
+        # Get min and max of slit in pixel units
+        ymin = np.nanmin(grid_slit.y_slit) * pix_per_shutter
+        ymax = np.nanmax(grid_slit.y_slit) * pix_per_shutter
+        slit_height_pix = int(abs(ymax - ymin + 0.5))
 
-        spatial_trans = offset | rot | scale | tan | skyrot
-        spectral_trans = Scale(spectral_scale) | Shift(min_lam)
-        mapping = Mapping((1, 1, 0))
-        mapping.inverse = Mapping((2, 1))
-        transform = mapping | spatial_trans & spectral_trans
-        transform.outputs = ('ra', 'dec', 'lamda')
+        # Compute grid of wavelengths and make tabular model w/inverse
+        lookup_table = np.nanmean(grid_slit.wavelength, axis=0)
+        wavelength_transform = Tabular1D(lookup_table=lookup_table,
+            bounds_error=False, fill_value=np.nan)
+        wavelength_transform.inverse = Tabular1D(points=lookup_table,
+            lookup_table=np.arange(grid_slit.wavelength.shape[1]),
+            bounds_error=False, fill_value=np.nan)
 
-        # Build the output wcs
-        input_frame = refwcs.input_frame
-        output_frame = refwcs.output_frame
-        wnew = WCS(output_frame=output_frame, forward_transform=transform)
+        # Define detector to slit transforms
+        yslit_transform = Scale(-1 / pix_per_shutter) | Shift(ymax / pix_per_shutter)
+        xslit_transform = Const1D(-0.)
+        xslit_transform.inverse = Const1D(0.)
 
-        # Build the bounding_box in the output frame wcs object
-        bounding_box_grid = wnew.backward_transform(ra, dec, lam)
-        bounding_box = []
-        for axis in input_frame.axes_order:
-            axis_min = np.nanmin(bounding_box_grid[axis])
-            axis_max = np.nanmax(bounding_box_grid[axis])
-            bounding_box.append((axis_min, axis_max))
-        wnew.bounding_box = tuple(bounding_box)
+        # Construct the final transform
+        coord_mapping = Mapping((0, 1, 0))
+        coord_mapping.inverse = Mapping((2, 1))
+        the_transform = xslit_transform & yslit_transform & wavelength_transform
+        out_det2slit = coord_mapping | the_transform
 
-        # Update class properties
-        self.output_spatial_scale = spatial_scale
-        self.output_spectral_scale = spectral_scale
-        self.output_wcs = wnew
+        # Create coordinate frames
+        det = cf.Frame2D(name='detector', axes_order=(0, 1))
+        slit_spatial = cf.Frame2D(name='slit_spatial', axes_order=(0, 1),
+            unit=("", ""), axes_names=('x_slit', 'y_slit'))
+        spec = cf.SpectralFrame(name='spectral', axes_order=(2,),
+            unit=(u.micron,), axes_names=('wavelength',))
+        slit_frame = cf.CompositeFrame([slit_spatial, spec], name='slit_frame')
+        sky = cf.CelestialFrame(name='sky', axes_order=(0, 1),
+            reference_frame=coord.ICRS())
+        world = cf.CompositeFrame([sky, spec], name='world')
+
+        pipeline = [(det, out_det2slit),
+                    (slit_frame, ref_slit2world),
+                    (world, None)]
+
+        output_wcs = WCS(pipeline)
+
+        self.data_size = (slit_height_pix, len(lookup_table))
+        bounding_box = resample_utils.bounding_box_from_shape(self.data_size)
+        output_wcs.bounding_box = bounding_box
+        return output_wcs
 
 
-    def build_miri_output_wcs(self, refwcs=None):
+    def build_miri_output_wcs(self, refmodel=None):
         """
         Create a simple output wcs covering footprint of the input datamodels
         """
         # TODO: generalize this for more than one input datamodel
         # TODO: generalize this for imaging modes with distorted wcs
-        input_model = self.input_models[0]
-        if refwcs == None:
-            refwcs = input_model.meta.wcs
+        if not refmodel:
+            refmodel = self.input_models[0]
+        refwcs = refmodel.meta.wcs
 
         x, y = wcstools.grid_from_bounding_box(refwcs.bounding_box, step=(1, 1),
             center=True)
@@ -280,11 +231,10 @@ class ResampleSpecData(object):
         # Find rotation of the slit from y axis from the wcs forward transform
         # TODO: figure out if angle is necessary for MIRI.  See for discussion
         # https://github.com/STScI-JWST/jwst/pull/347
-        rotation = [m for m in refwcs.forward_transform if \
-            isinstance(m, Rotation2D)]
+        rotation = [m for m in refwcs.forward_transform
+                    if isinstance(m, Rotation2D)]
         if rotation:
             rot_slit = functools.reduce(lambda x, y: x | y, rotation)
-            rot_angle = rot_slit.inverse.angle.value
             unrotate = rot_slit.inverse
             refwcs_minus_rot = refwcs.forward_transform | \
                 unrotate & Identity(1)
@@ -324,9 +274,8 @@ class ResampleSpecData(object):
 
         # Compute transform for output frame
         log.debug('Slit center %s' % slit_center_pix)
-        offset = Shift(-slit_center_pix) & Shift(-slit_center_pix)
         # TODO: double-check the signs on the following rotation angles
-        roll_ref = input_model.meta.wcsinfo.roll_ref * u.deg
+        roll_ref = refmodel.meta.wcsinfo.roll_ref * u.deg
         rot = Rotation2D(roll_ref)
         tan = Pix2Sky_TAN()
         lon_pole = _compute_lon_pole(slit_center_sky, tan)
@@ -358,22 +307,19 @@ class ResampleSpecData(object):
             bounding_box.append((axis_min, axis_max))
         wnew.bounding_box = tuple(bounding_box)
 
-        # Update class properties
-        self.output_spatial_scale = spatial_scale
-        self.output_spectral_scale = spectral_scale
         self.output_wcs = wnew
 
 
     def build_size_from_bounding_box(self, refwcs=None):
         """ Compute the size of the output frame based on the bounding_box
         """
-        if refwcs == None:
+        if not refwcs:
             refwcs = self.output_wcs
         size = []
         for axis in refwcs.bounding_box:
             delta = axis[1] - axis[0]
             size.append(int(delta + 0.5))
-        self.data_size = tuple(reversed(size))
+        return tuple(reversed(size))
 
 
     def do_drizzle(self, **pars):
@@ -393,7 +339,7 @@ class ResampleSpecData(object):
             for group in model_groups:
                 group_exptime.append(group[0].meta.exposure.exposure_time)
         else:
-            final_output = self.input_models.meta.resample.output # get global name
+            final_output = self.input_models.meta.resample.output
             driz_outputs = [final_output]
             model_groups = [self.input_models]
 
@@ -407,9 +353,7 @@ class ResampleSpecData(object):
         for obs_product, group, texptime in zip(driz_outputs, model_groups, group_exptime):
             output_model = self.blank_output.copy()
             output_model.meta.wcs = self.output_wcs
-            # # TODO: do this properly in wcs_from_spec_footprints()
-            # output_model.meta.wcs.domain = self.output_wcs.domain
-            # # Instead we do a cludge below to get the domain to not be neg.
+
             bb = resample_utils.bounding_box_from_shape(output_model.data.shape)
             output_model.meta.wcs.bounding_box = bb
             output_model.meta.filename = obs_product
@@ -419,8 +363,11 @@ class ResampleSpecData(object):
 
             exposure_times = {'start': [], 'end': []}
 
+            outwcs = output_model.meta.wcs
+
             # Initialize the output with the wcs
             driz = gwcs_drizzle.GWCSDrizzle(output_model,
+                                outwcs = outwcs,
                                 single=self.drizpars['single'],
                                 pixfrac=self.drizpars['pixfrac'],
                                 kernel=self.drizpars['kernel'],
@@ -430,23 +377,18 @@ class ResampleSpecData(object):
                 exposure_times['start'].append(img.meta.exposure.start_time)
                 exposure_times['end'].append(img.meta.exposure.end_time)
 
-                # outwcs_pscale = output_model.meta.wcsinfo.cdelt3
-                # wcslin_pscale = img.meta.wcsinfo.cdelt3
-                # TODO: make it possible for users to subsample in spatial scale
-                outwcs_pixel_scale = self.output_spatial_scale
-                inwcs_pixel_scale = self.output_spatial_scale
-                pscale_ratio = outwcs_pixel_scale / inwcs_pixel_scale
+                inwht = self.build_driz_weight(img,
+                    wht_type=self.drizpars['wht_type'],
+                    good_bits=self.drizpars['good_bits'])
+                if hasattr(img, 'name'):
+                    log.info('Resampling slit {} {}'.format(img.name, self.data_size))
+                else:
+                    log.info('Resampling slit {}'.format(self.data_size))
 
-                inwht = build_driz_weight(img, wht_type=self.drizpars['wht_type'],
-                                    good_bits=self.drizpars['good_bits'])
-                try:
-                    log.info('Resampling slit {0} {1}'.format(img.name,
-                        self.data_size))
-                except:
-                    log.info('Resampling slit {0}'.format(self.data_size))
-                driz.add_image(img.data, img.meta.wcs, inwht=inwht,
+                in_wcs = img.meta.wcs
+                driz.add_image(img.data, in_wcs, inwht=inwht,
                         expin=img.meta.exposure.exposure_time,
-                        pscale_ratio=pscale_ratio)
+                        pscale_ratio=self.pscale_ratio)
 
             # Update some basic exposure time values based on all the inputs
             output_model.meta.exposure.exposure_time = texptime
@@ -479,33 +421,35 @@ class ResampleSpecData(object):
             self.output_models.append(output_model)
 
 
-def build_mask(dqarr, bitvalue):
-    """ Builds a bit-mask from an input DQ array and a bitvalue flag
-    """
+    def build_driz_weight(self, model, wht_type=None, good_bits=None):
+        """ Create input weighting image
+        """
+        if good_bits is not None and good_bits < 0:
+            good_bits = None
+        dqmask = self.build_mask(model.dq, good_bits)
+        exptime = model.meta.exposure.exposure_time
 
-    bitvalue = bitmask.interpret_bits_value(bitvalue)
+        if wht_type.lower()[:3] == 'err':
+            inwht = (exptime / model.err)**2 * dqmask
+        # elif wht_type == 'IVM':
+        #     _inwht = img.buildIVMmask(chip._chip,dqarr,pix_ratio)
+        elif wht_type.lower()[:3] == 'exp':
+            # inwht = exptime * dqmask
+            inwht = np.ones(model.data.shape, dtype=model.data.dtype) * exptime
+        else:
+            inwht = np.ones(model.data.shape, dtype=model.data.dtype)
+        return inwht
 
-    if bitvalue is None:
-        return (np.ones(dqarr.shape, dtype=np.uint8))
-    return np.logical_not(np.bitwise_and(dqarr, ~bitvalue)).astype(np.uint8)
+
+    @staticmethod
+    def build_mask(dqarr, bitvalue):
+        """ Builds a bit-mask from an input DQ array and a bitvalue flag
+        """
+
+        bitvalue = bitmask.interpret_bits_value(bitvalue)
+
+        if bitvalue is None:
+            return (np.ones(dqarr.shape, dtype=np.uint8))
+        return np.logical_not(np.bitwise_and(dqarr, ~bitvalue)).astype(np.uint8)
 
 
-def build_driz_weight(model, wht_type=None, good_bits=None):
-    """ Create input weighting image based on user inputs
-    """
-    if good_bits is not None and good_bits < 0:
-        good_bits = None
-    dqmask = build_mask(model.dq, good_bits)
-    exptime = model.meta.exposure.exposure_time
-
-    if wht_type.lower()[:3] == 'err':
-        # Multiply the scaled ERR file by the input mask in place.
-        inwht = (exptime / model.err)**2 * dqmask
-    #elif wht_type == 'IVM':
-    #    _inwht = img.buildIVMmask(chip._chip,dqarr,pix_ratio)
-    elif wht_type.lower()[:3] == 'exp':# or wht_type is None, as used for single=True
-        inwht = exptime * dqmask
-    else:
-        # Create an identity input weight map
-        inwht = np.ones(model.data.shape, dtype=model.data.dtype)
-    return inwht

--- a/jwst/resample/resample_utils.py
+++ b/jwst/resample/resample_utils.py
@@ -2,61 +2,16 @@ from __future__ import (division, print_function, unicode_literals,
     absolute_import)
 
 import numpy as np
-import numpy.ma as ma
-from scipy import interpolate
 
-from astropy.utils.misc import isiterable
 from astropy import wcs as fitswcs
 from astropy.coordinates import SkyCoord
-from astropy.modeling.models import (Shift, Scale, Mapping, Rotation2D,
-    Pix2Sky_TAN, RotateNative2Celestial, Tabular1D, AffineTransformation2D)
-from gwcs import WCS, utils, wcstools
-
-
-from .. import assign_wcs
+from astropy.modeling.models import Scale, AffineTransformation2D
+from astropy.modeling import Model
+from gwcs import WCS, wcstools
 
 import logging
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
-
-
-def make_output_wcs(input_models):
-    """ Generate output WCS here based on footprints of all input WCS objects
-    Parameters
-    ----------
-    wcslist : list of gwcs.WCS objects
-
-    Returns
-    -------
-    output_wcs : object
-        WCS object, with defined domain, covering entire set of input frames
-
-    """
-
-    # The API needing input_models instead of just wcslist is because
-    # currently the domain is not defined in any of imaging modes for NIRCam
-    # NIRISS or MIRI
-    #
-    # TODO: change the API to take wcslist instead of input_models and
-    #       remove the following block
-    wcslist = [i.meta.wcs for i in input_models]
-    for w, i in zip(wcslist, input_models):
-        if w.bounding_box is None:
-            w.bounding_box = bounding_box_from_shape(i.data.shape)
-
-    output_frame = wcslist[0].output_frame
-    naxes = wcslist[0].output_frame.naxes
-
-    if naxes == 3:
-        # THIS BLOCK CURRENTLY ISN"T USED BY resample_spec
-        output_wcs = wcs_from_spec_footprints(wcslist)
-        data_size = shape_from_bounding_box(output_wcs.bounding_box)
-    elif naxes == 2:
-        output_wcs = assign_wcs.util.wcs_from_footprints(input_models)
-        data_size = shape_from_bounding_box(output_wcs.bounding_box)
-
-    output_wcs.data_size = (data_size[1], data_size[0])
-    return output_wcs
 
 
 def compute_output_transform(refwcs, filename, fiducial):
@@ -74,8 +29,6 @@ def compute_output_transform(refwcs, filename, fiducial):
     position_ydir = SkyCoord(ra=ra_ydir, dec=dec_ydir, unit='deg')
     offset_xdir = position0.spherical_offsets_to(position_xdir)
     offset_ydir = position0.spherical_offsets_to(position_ydir)
-    #coeff_x = np.mean([np.abs(offset_x[1].value), np.abs(offset_y[0].value)])
-    #coeff_y = np.mean([np.abs(offset_x[0].value), np.abs(offset_y[1].value)])
 
     xscale = np.abs(position0.separation(position_xdir).value)
     yscale = np.abs(position0.separation(position_ydir).value)
@@ -106,7 +59,6 @@ def shape_from_bounding_box(bounding_box):
     size = []
     for axs in bounding_box:
         delta = axs[1] - axs[0]
-        #for i in [axs['includes_lower'], axs['includes_upper']]: delta += 1
         size.append(int(delta + 0.5))
     return tuple(reversed(size))
 
@@ -121,29 +73,23 @@ def calc_gwcs_pixmap(in_wcs, out_wcs, shape=None):
         bb = in_wcs.bounding_box
         log.debug("Bounding box from WCS: {}".format(in_wcs.bounding_box))
 
-    grid = wcstools.grid_from_bounding_box(bb, step=(1, 1), center=True)
+    grid = wcstools.grid_from_bounding_box(bb, step=(1, 1))
     pixmap = np.dstack(reproject(in_wcs, out_wcs)(grid[0], grid[1]))
     return pixmap
 
 
 def reproject(wcs1, wcs2):
     """
-    Given two WCSs return a function which takes pixel coordinates in
-    the first WCS and computes them in the second one.
-    It performs the forward transformation of ``wcs1`` followed by the
+    Given two WCSs or transforms return a function which takes pixel
+    coordinates in the first WCS or transform and computes them in the second
+    one. It performs the forward transformation of ``wcs1`` followed by the
     inverse of ``wcs2``.
-
-    NOTE
-    ----
-    This function should be removed when it can be found in another
-    accessible package for JWST pipeline use.
 
     Parameters
     ----------
-    wcs1, wcs2 : `~astropy.wcs.WCS` or `~gwcs.wcs.WCS`
+    wcs1, wcs2 : `~astropy.wcs.WCS` or `~gwcs.wcs.WCS` or `~astropy.modeling.Model`
         WCS objects.
-    origin : {0, 1}
-        Whether to use 0- or 1-based pixel coordinates.
+
     Returns
     -------
     _reproject : func
@@ -151,21 +97,25 @@ def reproject(wcs1, wcs2):
         positions in ``wcs1`` and returns x, y positions in ``wcs2``.
     """
 
-    args = []
     if isinstance(wcs1, fitswcs.WCS):
         forward_transform = wcs1.all_pix2world
-    elif isinstance(wcs2, WCS):
+    elif isinstance(wcs1, WCS):
         forward_transform = wcs1.forward_transform
+    elif issubclass(wcs1, Model):
+        forward_transform = wcs1
     else:
-        raise ValueError("Expected astropy.wcs.WCS or gwcs.WCS object.")
+        raise TypeError("Expected input to be astropy.wcs.WCS or gwcs.WCS "
+            "object or astropy.modeling.Model subclass")
 
     if isinstance(wcs2, fitswcs.WCS):
         backward_transform = wcs2.all_world2pix
     elif isinstance(wcs2, WCS):
-        #inverse = wcs2.forward_transform.inverse
         backward_transform = wcs2.backward_transform
+    elif issubclass(wcs2, Model):
+        backward_transform = wcs2.inverse
     else:
-        raise ValueError("Expected astropy.wcs.WCS or gwcs.WCS object.")
+        raise TypeError("Expected input to be astropy.wcs.WCS or gwcs.WCS "
+            "object or astropy.modeling.Model subclass")
 
     def _reproject(x, y):
         sky = forward_transform(x, y)
@@ -178,186 +128,3 @@ def reproject(wcs1, wcs2):
             det_reshaped.append(axis.reshape(x.shape))
         return tuple(det_reshaped)
     return _reproject
-
-# Following function can be deprecated
-def spec_bounding_box(inwcs, bounding_box=None):
-    """
-    Returns a boolean mask of the pixels where the wcs is defined.
-
-    Build-7 workaround.
-
-    Parameters
-    ----------
-    inwcs : gwcs.WCS object
-
-    bounding_box : optional bounding_box
-
-    Returns
-    -------
-    Boolean mask where pixels in the input that produced NaNs in the output
-    are set to True.  Valid wcs transform pixels are set to False.
-    """
-    if not bounding_box:
-        bounding_box = inwcs.bounding_box
-    x, y = wcstools.grid_from_bounding_box(in_wcs.bounding_box, step=(1, 1),
-        center=True)
-    ra, dec, lam = inwcs(x, y)
-    return np.isnan(lam)
-
-# Following function can be deprecated
-def grid_from_spec_bounding_box(inwcs, bounding_box=None, mask=None):
-    """
-    Returns grid of x, y coordinates using a bounding_box or mask.
-
-    Build-7 workaround.
-
-    Parameters
-    ----------
-    inwcs : gwcs.WCS object
-
-    bounding_box : optional bounding_box
-
-    mask : option Boolean bounding_box mask
-
-    Returns
-    -------
-    ndarray
-    Grid array if y, x inputs for the included or specified domain mask.
-    """
-    if not mask:
-        try:
-            mask = inwcs.bounding_box_mask
-        except AttributeError:
-            mask = spec_bounding_box(inwcs)
-    if not bounding_box:
-        bounding_box = inwcs.bounding_box
-    x, y = wcstools.grid_from_bounding_box(in_wcs.bounding_box, step=(1, 1),
-        center=True)
-    return x, y
-
-
-def spec_footprint(in_wcs, bounding_box=None, mask=None):
-    """
-    Returns wcs footprint grid coordinates where NaNs are masked.
-
-    Build-7 workaround.
-    """
-    x, y = wcstools.grid_from_bounding_box(in_wcs.bounding_box, step=(1, 1),
-        center=True)
-    ra, dec, lam = in_wcs(x, y)
-    m = np.isnan(lam)
-    return ma.array([ra, dec, lam], mask=[m, m, m])
-
-
-def wcs_from_spec_footprints(wcslist, refwcs=None, transform=None,
-    bounding_box=None):
-    """
-    Create a WCS from a list of spatial/spectral WCS.
-
-    Build-7 workaround.
-    """
-    if not isiterable(wcslist):
-        raise ValueError("Expected 'wcslist' to be an iterable of gwcs.WCS")
-    if not all([isinstance(w, WCS) for w in wcslist]):
-        raise TypeError("All items in 'wcslist' must have instance of gwcs.WCS")
-    if refwcs is None:
-        refwcs = wcslist[0]
-    else:
-        if not isinstance(refwcs, WCS):
-            raise TypeError("Expected refwcs to be an instance of gwcs.WCS.")
-
-    # TODO: generalize an approach to do this for more than one wcs.  For
-    # now, we just do it for one, using the api for a list of wcs.
-    # Compute a fiducial point for the output frame at center of input data
-    fiducial = compute_spec_fiducial(wcslist)
-    # Create transform for output frame
-    transform = compute_spec_transform(fiducial, refwcs)
-    output_frame = refwcs.output_frame
-    wnew = WCS(output_frame=output_frame, forward_transform=transform)
-
-    # Build the bounding_box in the output frame wcs object by running the
-    # input wcs footprints through the backward transform of the output wcs
-    sky = [spec_footprint(w) for w in wcslist]
-    bounding_box_grid = [wnew.backward_transform(*f) for f in sky]
-
-    sky0 = sky[0]
-    det = bounding_box_grid[0]
-    offsets = []
-    input_frame = refwcs.input_frame
-    for axis in input_frame.axes_order:
-        axis_min = np.nanmin(det[axis])
-        offsets.append(axis_min)
-    transform = Shift(offsets[0]) & Shift(offsets[1]) | transform
-    wnew = WCS(output_frame=output_frame, input_frame=input_frame,
-        forward_transform=transform)
-
-    # Build the bounding_box in the output frame wcs object
-    bounding_box = []
-    for axis in input_frame.axes_order:
-        axis_min = np.nanmin(bounding_box_grid[axis])
-        axis_max = np.nanmax(bounding_box_grid[axis])
-        bounding_box.append((axis_min, axis_max))
-    wnew.bounding_box = tuple(bounding_box)
-    return wnew
-
-
-def compute_spec_transform(fiducial, refwcs):
-    """
-    Compute a simple transform given a fidicial point in a spatial-spectral wcs.
-    """
-    cdelt1 = refwcs.wcsinfo.cdelt1 / 3600.
-    cdelt2 = refwcs.wcsinfo.cdelt2 / 3600.
-    cdelt3 = refwcs.wcsinfo.cdelt3
-    roll_ref = refwcs.wcsinfo.roll_ref
-
-    y, x = grid_from_spec_domain(refwcs)
-    ra, dec, lam = refwcs(x, y)
-
-    min_lam = np.nanmin(lam)
-
-    offset = Shift(0.) & Shift(0.)
-    rot = Rotation2D(roll_ref)
-    scale = Scale(cdelt1) & Scale(cdelt2)
-    tan = Pix2Sky_TAN()
-    skyrot = RotateNative2Celestial(fiducial[0][0], fiducial[0][1], 180.0)
-    spatial = offset | rot | scale | tan | skyrot
-    spectral = Scale(cdelt3) | Shift(min_lam)
-    mapping = Mapping((1, 1, 0),)
-    mapping.inverse = Mapping((2, 1))
-    transform = mapping | spatial & spectral
-    transform.outputs = ('ra', 'dec', 'lamda')
-    return transform
-
-
-def compute_spec_fiducial(wcslist):
-    """
-    For a celestial footprint this is the center.
-    For a spectral footprint, it is the beginning of the range.
-
-    This function assumes all WCSs have the same output coordinate frame.
-
-    Build-7 workaround.
-    """
-    output_frame = wcslist[0].output_frame
-    axes_types = wcslist[0].output_frame.axes_type
-    spatial_axes = np.array(axes_types) == 'SPATIAL'
-    spectral_axes = np.array(axes_types) == 'SPECTRAL'
-    footprints = ma.hstack([spec_footprint(w,
-        bounding_box=w.bounding_box) for w in wcslist])
-    spatial_footprint = footprints[spatial_axes]
-    spectral_footprint = footprints[spectral_axes]
-    # Compute center of footprint
-    fiducial = np.empty(len(axes_types))
-    if (spatial_footprint).any():
-        lon, lat = spatial_footprint
-        lon, lat = np.deg2rad(lon), np.deg2rad(lat)
-        x_mean = np.mean(np.cos(lat) * np.cos(lon))
-        y_mean = np.mean(np.cos(lat) * np.sin(lon))
-        z_mean = np.mean(np.sin(lat))
-        lon_fiducial = np.rad2deg(np.arctan2(y_mean, x_mean)) % 360.0
-        lat_fiducial = np.rad2deg(np.arctan2(z_mean, np.sqrt(x_mean ** 2 +
-            y_mean ** 2)))
-        fiducial[spatial_axes] = lon_fiducial, lat_fiducial
-    if (spectral_footprint).any():
-        fiducial[spectral_axes] = spectral_footprint.min()
-    return ((fiducial[spatial_axes]), fiducial[spectral_axes])


### PR DESCRIPTION
Implements new method for computing the output frame wcs for NIRSpec from the intermediate `slit_frame` in the WCS transform.

Resolves #1006 