### PR TITLE
Fix bug in srctype_step

### DIFF
--- a/jwst/srctype/srctype_step.py
+++ b/jwst/srctype/srctype_step.py
@@ -18,18 +18,16 @@ class SourceTypeStep(Step):
 
     def process(self, input):
 
-        with datamodels.open(input) as input_model:
+        input_model = datamodels.open(input)
 
-            # Call the source selection routine
-            result = set_source_type(input_model)
+        # Call the source selection routine
+        result = set_source_type(input_model)
 
-            # Set the step status in the output model
-            if result is None:
-                result = input_model.copy()
-                input_model.close()
-                result.meta.cal_step.srctype = 'SKIPPED'
-            else:
-                result.meta.cal_step.srctype = 'COMPLETE'
+        # Set the step status in the output model
+        if result is None:
+            result = input_model
+            result.meta.cal_step.srctype = 'SKIPPED'
+        else:
+            result.meta.cal_step.srctype = 'COMPLETE'
 
         return result
-


### PR DESCRIPTION
#1405 introduced a bug in the srctype_step module. The "result" is not a copy of input_model, hence it goes out of scope when exiting a "with datamodels.open() ..." block, so the return statement ends up returning a closed model, which throws an error in stpipe. Removed the "with" block and just open the input directly. No need to close the input model, because it is the (updated) model that gets returned.