### PR TITLE
Add TSO configuration for calwebb_detector1 [skip ci]

### DIFF
--- a/jwst/pipeline/calwebb_tso1.cfg
+++ b/jwst/pipeline/calwebb_tso1.cfg
@@ -1,0 +1,22 @@
+name = "Detector1Pipeline"
+class = "jwst.pipeline.Detector1Pipeline"
+save_calibrated_ramp = False
+
+    [steps]
+      [[group_scale]]
+      [[dq_init]]
+      [[saturation]]
+      [[ipc]]
+        skip = True
+      [[superbias]]
+      [[refpix]]
+      [[rscd]]
+      [[lastframe]]
+        skip = True
+      [[linearity]]
+      [[dark_current]]
+      [[persistence]]
+        skip = True
+      [[jump]]
+      [[ramp_fit]]
+      [[gain_scale]]


### PR DESCRIPTION
Add a configuration file for the detector1 pipeline that is setup to skip certain steps for TSO exposures. The new cfg file is `calwebb_tso1.cfg.` By default the steps ipc, lastframe, and persistence are skipped.

Fixes #1400.