### PR TITLE
Move build_driz_weight to resample_utils

### DIFF
--- a/jwst/outlier_detection/outlier_detection.py
+++ b/jwst/outlier_detection/outlier_detection.py
@@ -11,7 +11,7 @@ from astropy.stats import sigma_clipped_stats
 from scipy import ndimage
 
 from .. import datamodels
-from ..resample import resample, gwcs_blot
+from ..resample import resample, gwcs_blot, resample_utils
 
 import logging
 log = logging.getLogger(__name__)
@@ -102,7 +102,7 @@ class OutlierDetection(object):
                                               err=self.inputs.err[i],
                                               dq=self.inputs.dq[i])
                 image.meta = self.inputs.meta
-                image.wht = resample.build_driz_weight(image,
+                image.wht = resample_utils.build_driz_weight(image,
                                                        wht_type='exptime',
                                                        good_bits=bits)
                 self.input_models.append(image)
@@ -193,7 +193,7 @@ class OutlierDetection(object):
         else:
             drizzled_models = self.input_models
             for i in range(len(self.input_models)):
-                drizzled_models[i].wht = resample.build_driz_weight(
+                drizzled_models[i].wht = resample_utils.build_driz_weight(
                                         self.input_models[i],
                                         wht_type='exptime',
                                         good_bits=pars['good_bits'])

--- a/jwst/outlier_detection/outlier_detection_scaled.py
+++ b/jwst/outlier_detection/outlier_detection_scaled.py
@@ -9,7 +9,7 @@ from photutils import aperture_photometry, CircularAperture, CircularAnnulus
 import astropy.units as u
 
 from .. import datamodels
-from ..resample import resample
+from ..resample import resample_utils
 from ..tso_photometry.tso_photometry import tso_aperture_photometry
 from .outlier_detection import OutlierDetection
 
@@ -100,7 +100,7 @@ class OutlierDetectionScaled(OutlierDetection):
 
         # Convert CubeModel into ModelContainer of 2-D DataModels
         for image in self.input_models:
-            image.wht = resample.build_driz_weight(image,
+            image.wht = resample_utils.build_driz_weight(image,
                                                    wht_type='exptime',
                                                    good_bits=pars['good_bits'])
 

--- a/jwst/outlier_detection/outlier_detection_spec.py
+++ b/jwst/outlier_detection/outlier_detection_spec.py
@@ -4,7 +4,7 @@ from __future__ import (division, print_function, unicode_literals,
                         absolute_import)
 
 from .. import datamodels
-from ..resample import resample_spec, resample
+from ..resample import resample_spec, resample_utils
 from .outlier_detection import OutlierDetection
 
 import logging
@@ -81,7 +81,7 @@ class OutlierDetectionSpec(OutlierDetection):
         else:
             drizzled_models = self.input_models
             for i in range(len(self.input_models)):
-                drizzled_models[i].wht = resample.build_driz_weight(
+                drizzled_models[i].wht = resample_utils.build_driz_weight(
                                             self.input_models[i],
                                             wht_type='exptime',
                                             good_bits=pars['good_bits'])

--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -7,7 +7,6 @@ from collections import OrderedDict
 from .. import datamodels
 
 from . import gwcs_drizzle
-from . import bitmask
 from . import resample_utils
 from . import blend
 
@@ -94,9 +93,9 @@ class ResampleData(object):
         row = None
         drizpars = ref_model.drizpars_table
 
-        filter_match = False # flag to support wild-card rows in drizpars table
+        filter_match = False  # flag to support wild-card rows in drizpars table
         for n, filt, num in zip(range(0, len(drizpars)), drizpars.filter,
-            drizpars.numimages):
+                drizpars.numimages):
             # only remember this row if no exact match has already been made for
             # the filter. This allows the wild-card row to be anywhere in the
             # table; since it may be placed at beginning or end of table.
@@ -121,7 +120,7 @@ class ResampleData(object):
     def update_driz_outputs(self):
         """ Define output arrays for use with drizzle operations.
         """
-        numchips = len(self.input_models) # assuming 1 chip per model
+        numchips = len(self.input_models)  # assuming 1 chip per model
         numplanes = (numchips // 32) + 1
 
         # Replace CONTEXT array with full set of planes needed for all inputs
@@ -198,7 +197,7 @@ class ResampleData(object):
                 outwcs_pscale = output_model.meta.wcsinfo.cdelt1
                 wcslin_pscale = img.meta.wcsinfo.cdelt1
 
-                inwht = self.build_driz_weight(img,
+                inwht = resample_utils.build_driz_weight(img,
                     wht_type=self.drizpars['wht_type'],
                     good_bits=self.drizpars['good_bits'])
                 driz.add_image(img.data, img.meta.wcs, inwht=inwht,
@@ -225,38 +224,6 @@ class ResampleData(object):
             self.update_fits_wcs(output_model)
 
             self.output_models.append(output_model)
-
-
-    def build_driz_weight(self, model, wht_type=None, good_bits=None):
-        """ Create input weighting image
-        """
-        if good_bits is not None and good_bits < 0:
-            good_bits = None
-        dqmask = self.build_mask(model.dq, good_bits)
-        exptime = model.meta.exposure.exposure_time
-
-        if wht_type.lower()[:3] == 'err':
-            inwht = (exptime / model.err)**2 * dqmask
-            log.debug("DEBUG weight mask: {} {}".format(type(inwht), np.sum(inwht)))
-        # elif wht_type == 'IVM':
-        #     _inwht = img.buildIVMmask(chip._chip,dqarr,pix_ratio)
-        elif wht_type.lower()[:3] == 'exp':
-            inwht = exptime * dqmask
-        else:
-            inwht = np.ones(model.data.shape, dtype=model.data.dtype)
-        return inwht
-
-
-    @staticmethod
-    def build_mask(dqarr, bitvalue):
-        """ Builds a bit-mask from an input DQ array and a bitvalue flag
-        """
-
-        bitvalue = bitmask.interpret_bits_value(bitvalue)
-
-        if bitvalue is None:
-            return (np.ones(dqarr.shape, dtype=np.uint8))
-        return np.logical_not(np.bitwise_and(dqarr, ~bitvalue)).astype(np.uint8)
 
 
     def update_fits_wcs(self, model):

--- a/jwst/resample/resample_step.py
+++ b/jwst/resample/resample_step.py
@@ -1,7 +1,7 @@
 from __future__ import (division, print_function, unicode_literals,
     absolute_import)
 
-from ..stpipe import Step, cmdline
+from ..stpipe import Step
 from .. import datamodels
 from . import resample
 from .. assign_wcs.util import update_s_region
@@ -61,4 +61,3 @@ class ResampleStep(Step):
                 model.meta.cal_step.resample = "COMPLETE"
                 update_s_region(model)
         return result
-


### PR DESCRIPTION
- Move `build_driz_weight` out of the `ResampleData` class and into `resample_utils`, reverting it back to being a function so it can easily be called by `outlier_detection` when needed.
- Put `make_output_wcs back` into `resample_utils`.  It had inadvertently been deleted in #1412.