### PR TITLE
Update calwebb_dark to open input with RampModel

### DIFF
--- a/jwst/pipeline/calwebb_dark.py
+++ b/jwst/pipeline/calwebb_dark.py
@@ -51,7 +51,7 @@ class DarkPipeline(Pipeline):
         log.info('Starting calwebb_dark ...')
 
         # open the input
-        input = datamodels.open(input)
+        input = datamodels.RampModel(input)
 
         if input.meta.instrument.name == 'MIRI':
 


### PR DESCRIPTION
Updated the calwebb_dark pipeline to open the input as a RampModel, just as we did in #1389 for the calwebb_detector1 pipeline. Should've made this update along with that PR.