### PR TITLE
Resample coron3

### DIFF
--- a/jwst/outlier_detection/outlier_detection.py
+++ b/jwst/outlier_detection/outlier_detection.py
@@ -4,7 +4,6 @@ from __future__ import (division, print_function, unicode_literals,
                         absolute_import)
 
 import numpy as np
-import copy
 
 from stsci.image import median
 from stsci.tools import bitmask
@@ -203,7 +202,8 @@ class OutlierDetection(object):
         # Initialize intermediate products used in the outlier detection
         median_model = datamodels.ImageModel(
                                         init=drizzled_models[0].data.shape)
-        median_model.meta = copy.deepcopy(drizzled_models[0].meta)
+#        median_model.meta = copy.deepcopy(drizzled_models[0].meta)
+        median_model.update(drizzled_models[0])
         base_filename = self.input_models[0].meta.filename
         median_model.meta.filename = '_'.join(
                         base_filename.split('_')[:2] + ['median.fits'])

--- a/jwst/outlier_detection/outlier_detection.py
+++ b/jwst/outlier_detection/outlier_detection.py
@@ -202,7 +202,6 @@ class OutlierDetection(object):
         # Initialize intermediate products used in the outlier detection
         median_model = datamodels.ImageModel(
                                         init=drizzled_models[0].data.shape)
-#        median_model.meta = copy.deepcopy(drizzled_models[0].meta)
         median_model.update(drizzled_models[0])
         base_filename = self.input_models[0].meta.filename
         median_model.meta.filename = '_'.join(

--- a/jwst/pipeline/calwebb_coron3.cfg
+++ b/jwst/pipeline/calwebb_coron3.cfg
@@ -7,4 +7,3 @@ class = "jwst.pipeline.Coron3Pipeline"
       [[klip]]
       [[outlier_detection]]
       [[resample]]
-        skip = True

--- a/jwst/pipeline/calwebb_coron3.py
+++ b/jwst/pipeline/calwebb_coron3.py
@@ -1,5 +1,5 @@
+"""Interface for running CALCORON3 pipeline."""
 #!/usr/bin/env python
-import os
 
 from ..stpipe import Pipeline
 from ..associations import load_asn
@@ -10,7 +10,7 @@ from ..resample import blend
 from ..coron import stack_refs_step
 from ..coron import align_refs_step
 from ..coron import klip_step
-from ..outlier_detection import outlier_detection_stack_step
+from ..outlier_detection import outlier_detection_step
 from ..resample import resample_step
 
 
@@ -18,7 +18,8 @@ __version__ = '0.8.0'
 
 
 class Coron3Pipeline(Pipeline):
-    """
+    """Class for defining Coron3Pipeline.
+
     Coron3Pipeline: Apply all level-3 calibration steps to a
     coronagraphic association of exposures. Included steps are:
     stack_refs (assemble reference PSF inputs)
@@ -26,6 +27,7 @@ class Coron3Pipeline(Pipeline):
     klip (PSF subtraction using the KLIP algorithm)
     outlier_detection (flag outliers)
     resample (image combination and resampling)
+
     """
 
     spec = """
@@ -37,12 +39,12 @@ class Coron3Pipeline(Pipeline):
                  'align_refs': align_refs_step.AlignRefsStep,
                  'klip': klip_step.KlipStep,
                  'outlier_detection':
-                     outlier_detection_stack_step.OutlierDetectionStackStep,
+                     outlier_detection_step.OutlierDetectionStep,
                  'resample': resample_step.ResampleStep
                  }
 
     def process(self, input):
-
+        """Primary method for performing pipeline."""
         self.log.info('Starting calwebb_coron3 ...')
 
         # Load the input association table
@@ -53,17 +55,21 @@ class Coron3Pipeline(Pipeline):
         prod = asn['products'][0]
 
         # Construct lists of all the PSF and science target members
-        psf_files = [m['expname'] for m in prod['members'] if m['exptype'].upper() == 'PSF']
-        targ_files = [m['expname'] for m in prod['members'] if m['exptype'].upper() == 'SCIENCE']
+        psf_files = [m['expname'] for m in prod['members']
+                     if m['exptype'].upper() == 'PSF']
+        targ_files = [m['expname'] for m in prod['members']
+                      if m['exptype'].upper() == 'SCIENCE']
 
         # Make sure we found some PSF and target members
         if len(psf_files) == 0:
-            self.log.error('No reference PSF members found in association table')
+            err_str1 = 'No reference PSF members found in association table.'
+            self.log.error(err_str1)
             self.log.error('Calwebb_coron3 processing will be aborted')
             return
 
         if len(targ_files) == 0:
-            self.log.error('No science target members found in association table')
+            err_str1 = 'No science target members found in association table'
+            self.log.error(err_str1)
             self.log.error('Calwebb_coron3 processing will be aborted')
             return
 
@@ -108,7 +114,8 @@ class Coron3Pipeline(Pipeline):
             target_models = datamodels.ModelContainer()
             for i in range(psf_sub.data.shape[0]):
                 image = datamodels.ImageModel(data=psf_sub.data[i],
-                        err=psf_sub.err[i], dq=psf_sub.dq[i])
+                                              err=psf_sub.err[i],
+                                              dq=psf_sub.dq[i])
                 image.update(psf_sub)
                 image.meta.wcs = psf_sub.meta.wcs
                 target_models.append(image)
@@ -118,7 +125,8 @@ class Coron3Pipeline(Pipeline):
 
             # Create Level 2c products
             if target_models[0].meta.cal_step.outlier_detection == 'COMPLETE':
-                self.log.info("Creating Level 2c output with updated DQ arrays...")
+                err_str1 = "Creating Level 2c output with updated DQ arrays..."
+                self.log.info(err_str1)
                 lev2c_model = psf_sub.copy()
                 # Replace Level 2b product DQ array with Level 2c DQ array
                 for i in range(len(target_models)):
@@ -131,19 +139,21 @@ class Coron3Pipeline(Pipeline):
             for i in range(len(target_models)):
                 resample_input.append(target_models[i])
 
-        # Call the resample step to combine all the psf-subtracted target images
+        # Call the resample step to combine all psf-subtracted target images
         result = self.resample(resample_input)
 
         if result == resample_input:
-        # Resampling was skipped, 
-        #  yet we need to return a DrizProductModel, so...
-            self.log.warning('Creating fake resample results until step is available')
+            # Resampling was skipped,
+            #     yet we need to return a DrizProductModel, so...
+            warn1 = 'Creating fake resample results until step is available'
+            self.log.warning(warn1)
             result = datamodels.DrizProductModel(data=resample_input[0].data,
-                                             con=resample_input[0].dq,
-                                             wht=resample_input[0].err)
+                                                 con=resample_input[0].dq,
+                                                 wht=resample_input[0].err)
             result.update(resample_input[0])
             # The resample step blends headers already...
-            self.log.debug('Blending metadata for {}'.format(result.meta.filename))
+            self.log.debug('Blending metadata for {}'.format(
+                            result.meta.filename))
             blend.blendfitsdata(targ_files, result)
 
         result.meta.asn.pool_name = asn['asn_pool']


### PR DESCRIPTION
These changes address issue #1184 and will enable 'resampling' in this pipeline with full use of the new unified outlier_detection interface.  The full set of changes in this PR include:
- **BUG FIX:** outlier_detection case where resampling was turned off used references to metadata instead of copies to create median image datamodel. This was fixed to use model.update.  
- PEP8 updates to the formatting of the code (based on Flake8 and pylint checks)
- Change use of outlier_detection to call the unified interface
- Delete 'skip' command from default pipeline config file

These changes were tested interactively against the test_coron3_1 regression test before submission, after turning on resampling in the test.