### PR TITLE
Unset model_type when opening images as DataModel and with open

### DIFF
--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -194,11 +194,15 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
             self.meta.date = current_date.value
         
         # store the data model type, if not already set
+        klass = self.__class__.__name__
+        if klass == 'DataModel':
+            klass = None
+            
         if hasattr(self.meta, 'model_type'):
             if self.meta.model_type is None:
-                self.meta.model_type = self.__class__.__name__
+                self.meta.model_type = klass
         else:
-            self.meta.model_type = None
+            self.meta.model_type = klass
 
         if is_array:
             primary_array_name = self.get_primary_array_name()
@@ -284,8 +288,6 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         current_date = Time(datetime.datetime.now())
         current_date.format = 'isot'
         self.meta.date = current_date.value
-        if self.meta.model_type is not None:
-            self.meta.model_type = self.__class__.__name__
 
     def save(self, path, *args, **kwargs):
         """

--- a/jwst/datamodels/util.py
+++ b/jwst/datamodels/util.py
@@ -146,6 +146,7 @@ def open(init=None, extensions=None, **kwargs):
 
     # Actually open the model
     model = new_class(init, extensions=extensions, **kwargs)
+    model.meta.model_type = None
     
     # Close the hdulist if we opened it
     if file_to_close is not None:


### PR DESCRIPTION
If the DATAMODL keyword is not found in the primary image header, DataModel and its inheritors add it. If an image is opened with the open() function, and DATAMODL is not set, open() should not set it, because the class it chooses is only a best guess. So this update sets model_type to None after opening the image, so DATAMODL is not written to the header. In addition, when an image is opened with the base class, DataModel, DATAMODL should not be set, as there is no image of
the base type. So this update also sets model_type to None in that case. This update also moves all the code that sets model_type to __init__ from on_save, so that code which calls DataModel can override model_type.