### PR TITLE
Remove astropy.test.helper.pytest

### DIFF
--- a/jwst/transforms/tags/tests/test_models.py
+++ b/jwst/transforms/tags/tests/test_models.py
@@ -7,7 +7,7 @@ from astropy.modeling.models import Shift, Rotation2D
 from asdf.tests import helpers
 from ...import jwextension
 from ...models import *
-from astropy.tests.helper import pytest
+import pytest
 
 
 m1 = Shift(1) & Shift(2) | Rotation2D(3.1)


### PR DESCRIPTION
Lim said we should drop this,  believe it is general advice not critical to any specific problem or B7.1 release.

