### PR TITLE
Update meta data in calimage2 resampled product

### DIFF
--- a/jwst/pipeline/calwebb_image2.py
+++ b/jwst/pipeline/calwebb_image2.py
@@ -136,6 +136,10 @@ class Image2Pipeline(Pipeline):
         if input.meta.exposure.type.upper() in self.image_exptypes:
             result = self.resample(input)
             if result:
+
+                # update meta data in resampled image
+                result.update(input)
+
                 # write out resampled exposure
                 self.save_model(result, suffix='i2d')
                 result.close()

--- a/jwst/pipeline/calwebb_image2.py
+++ b/jwst/pipeline/calwebb_image2.py
@@ -138,7 +138,7 @@ class Image2Pipeline(Pipeline):
             if result:
 
                 # update meta data in resampled image
-                result.update(input)
+                result.update(input, only="PRIMARY")
 
                 # write out resampled exposure
                 self.save_model(result, suffix='i2d')


### PR DESCRIPTION
Quick fix for #1449, by calling .update on the resampled result model before saving it in the calwebb_image2 pipeline. A real fix should be done within the resample step itself in the future.