### PR TITLE
Add WCS to median_model

### DIFF
--- a/jwst/outlier_detection/outlier_detection.py
+++ b/jwst/outlier_detection/outlier_detection.py
@@ -203,6 +203,7 @@ class OutlierDetection(object):
         median_model = datamodels.ImageModel(
                                         init=drizzled_models[0].data.shape)
         median_model.update(drizzled_models[0])
+        median_model.meta.wcs = drizzled_models[0].meta.wcs
         base_filename = self.input_models[0].meta.filename
         median_model.meta.filename = '_'.join(
                         base_filename.split('_')[:2] + ['median.fits'])


### PR DESCRIPTION
This PR corrects the failure seen in the calimage3 regression test where the WCS was not defined for the median image.  
The problem turned out to be caused by relying on update to add the WCS from the input model to the newly created updated datamodel.  However, since the WCS is not defined in the schema for an ImageModel (or any model for that matter), the update operation does not see the WCS attribute and therefore does not copy it over.  This behavior makes perfect sense for model.update() and should simply be documented prominently.  