### PR TITLE
Remove searchunits from tweakreg.cfg

### DIFF
--- a/jwst/pipeline/tweakreg.cfg
+++ b/jwst/pipeline/tweakreg.cfg
@@ -5,7 +5,6 @@ enforce_user_order = True
 expand_refcat = False
 minobj = 15
 searchrad = 1.0
-searchunits = 'arcseconds'
 use2dhist = True
 separation = 0.5
 tolerance = 1.0


### PR DESCRIPTION
`searchunits` is not longer in tweakreg spec, so it should be removed from the default config file.