### PR TITLE
Remove Python 2 support from datamodels

### DIFF
--- a/jwst/datamodels/__init__.py
+++ b/jwst/datamodels/__init__.py
@@ -27,13 +27,11 @@
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
 # DAMAGE.
 
-from __future__ import absolute_import, division, print_function
 
 __version__ = '0.8.0'
 
 import numpy as np
 from os.path import basename
-import six
 from astropy.io import registry
 
 from . import ndmodel

--- a/jwst/datamodels/amilg.py
+++ b/jwst/datamodels/amilg.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals, division, print_function
-
 from . import model_base
 
 __all__ = ['AmiLgModel']

--- a/jwst/datamodels/arrays.py
+++ b/jwst/datamodels/arrays.py
@@ -5,12 +5,9 @@ structured arrays.
 
 # TODO: Add __all__ members to modules
 
-from __future__ import absolute_import, unicode_literals, division, print_function
-
 import re
 
 import numpy as np
-import six
 
 def _schema_dtype_to_numpy_dtype_single(dtype):
     names = {
@@ -29,7 +26,7 @@ def _schema_dtype_to_numpy_dtype_single(dtype):
         'complex128': np.complex128,
         }
 
-    if isinstance(dtype, six.string_types):
+    if isinstance(dtype, str):
         if dtype in names:
             return names[dtype]
         elif re.match('string[0-9]+', dtype):
@@ -44,7 +41,7 @@ def _schema_dtype_to_numpy_dtype_single(dtype):
 
 
 def _parse_column(i, entry):
-    if isinstance(entry, six.string_types):
+    if isinstance(entry, str):
         col_dtype = _schema_dtype_to_numpy_dtype_single(entry)
         col_name = b'f{0}'.format(i)
         col_shape = 1
@@ -57,11 +54,11 @@ def _parse_column(i, entry):
 
         if 'name' in entry:
             col_name = entry['name']
-            if not isinstance(col_name, six.string_types):
+            if isinstance(col_name, bytes):
+                col_name = col_name.encode('ascii')
+            if not isinstance(col_name, str):
                 raise ValueError(
                     "Invalid name {0} in dtype".format(col_name))
-            if isinstance(col_name, six.text_type):
-                col_name = col_name.encode('ascii')
         else:
             col_name = b'f{0}'.format(i)
 
@@ -101,7 +98,7 @@ def schema_dtype_to_numpy_dtype(dtype):
     """
     Given a schema dtype, returns a numpy dtype.
     """
-    if isinstance(dtype, (six.string_types, type)):
+    if isinstance(dtype, str):
         return _schema_dtype_to_numpy_dtype_single(dtype)
     elif isinstance(dtype, list):
         new_dtype = []

--- a/jwst/datamodels/asn.py
+++ b/jwst/datamodels/asn.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals, division, print_function
-
 import os
 from . import model_base
 

--- a/jwst/datamodels/barshadow.py
+++ b/jwst/datamodels/barshadow.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals, division, print_function
-
 from . import model_base
 
 __all__ = ['BarshadowModel']

--- a/jwst/datamodels/combinedspec.py
+++ b/jwst/datamodels/combinedspec.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals, division, print_function
-
 from . import model_base
 
 

--- a/jwst/datamodels/container.py
+++ b/jwst/datamodels/container.py
@@ -1,5 +1,3 @@
-from __future__ import (absolute_import, unicode_literals, division,
-                        print_function)
 import os.path as op
 import os
 import copy
@@ -7,7 +5,6 @@ import warnings
 from collections import OrderedDict
 
 from asdf import AsdfFile
-import six
 
 from ..associations import (
     AssociationError,
@@ -85,7 +82,7 @@ class ModelContainer(model_base.DataModel):
             self._ctx = self
             self.__class__ = init.__class__
             self._models = init._models
-        elif isinstance(init, six.string_types):
+        elif isinstance(init, str):
             try:
                 self.from_asn(init, **kwargs)
             except (IOError):
@@ -99,7 +96,7 @@ class ModelContainer(model_base.DataModel):
 
     def _open_model(self, index):
         model = self._models[index]
-        if isinstance(model, six.string_types):
+        if isinstance(model, str):
             model = datamodel_open(model,
                                    extensions=self._extensions,
                                    pass_invalid_values=self._pass_invalid_values)
@@ -120,7 +117,7 @@ class ModelContainer(model_base.DataModel):
         for model in models:
             if isinstance(model, ModelContainer):
                 raise ValueError("ModelContainer cannot contain ModelContainer")
-            if not isinstance(model, (six.string_types, model_base.DataModel)):
+            if not isinstance(model, (str, model_base.DataModel)):
                 raise ValueError('model must be string or DataModel')
 
 
@@ -336,7 +333,7 @@ class ModelContainer(model_base.DataModel):
         return self.__get_recursively(field, self.meta._instance)
 
 
-class ModelContainerIterator(six.Iterator):
+class ModelContainerIterator:
     """
     An iterator for model containers that opens one model at a time
     """
@@ -358,7 +355,7 @@ class ModelContainerIterator(six.Iterator):
         self.index += 1    
         if self.index < len(self.container._models):
             model = self.container._models[self.index]
-            if isinstance(model, six.string_types):
+            if isinstance(model, str):
                 name = model
                 model = self.container._open_model(self.index)
                 self.open_filename = name

--- a/jwst/datamodels/contrast.py
+++ b/jwst/datamodels/contrast.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals, division, print_function
-
 from . import model_base
 
 __all__ = ['ContrastModel']

--- a/jwst/datamodels/cube.py
+++ b/jwst/datamodels/cube.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals, division, print_function
-
 from . import model_base
 
 

--- a/jwst/datamodels/dark.py
+++ b/jwst/datamodels/dark.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals, division, print_function
-
 from . import model_base
 from .dynamicdq import dynamic_mask
 

--- a/jwst/datamodels/darkMIRI.py
+++ b/jwst/datamodels/darkMIRI.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals, division, print_function
-
 from . import model_base
 from .dynamicdq import dynamic_mask
 

--- a/jwst/datamodels/drizpars.py
+++ b/jwst/datamodels/drizpars.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals, division, print_function
-
 from . import model_base
 
 __all__ = ['DrizParsModel', 'NircamDrizParsModel', 'MiriImgDrizParsModel']

--- a/jwst/datamodels/drizproduct.py
+++ b/jwst/datamodels/drizproduct.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals, division, print_function
-
 from . import model_base
 
 

--- a/jwst/datamodels/dynamicdq.py
+++ b/jwst/datamodels/dynamicdq.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import numpy as np
 from . import dqflags
 

--- a/jwst/datamodels/extension.py
+++ b/jwst/datamodels/extension.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, unicode_literals, print_function
 import os.path
 from asdf.extension import AsdfExtension
 from asdf import util

--- a/jwst/datamodels/filetype.py
+++ b/jwst/datamodels/filetype.py
@@ -1,7 +1,4 @@
-from __future__ import absolute_import, unicode_literals, division, print_function
-
 import os.path
-import six
 
 def check(init):
     """
@@ -17,7 +14,7 @@ def check(init):
     file_type: a string with the file type ("asdf", "asn", or "fits")
     """
 
-    if isinstance(init, six.string_types):
+    if isinstance(init, str):
         if os.path.exists(init):
             fd = open(init, "rb")
             magic = fd.read(5)

--- a/jwst/datamodels/fits_support.py
+++ b/jwst/datamodels/fits_support.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-
-from __future__ import absolute_import, division, unicode_literals, print_function
-
 import datetime
 import os
 import re
@@ -11,7 +7,6 @@ import numpy as np
 
 import jsonschema
 
-import six
 from astropy.io import fits
 from astropy import time
 
@@ -77,7 +72,7 @@ def _get_indexed_keyword(keyword, i):
                 raise ValueError(
                     "Too many entries for given keyword '{0}'".format(keyword))
             if r is None:
-                val = six.text_type(i)
+                val = str(i)
             else:
                 val = r[i]
             keyword = keyword.replace(sub, val)
@@ -85,24 +80,14 @@ def _get_indexed_keyword(keyword, i):
     return keyword
 
 
-if six.PY3:
-    def fits_hdu_name(name):
-        """
-        Returns a FITS hdu name in the correct form for the current
-        version of Python.
-        """
-        if isinstance(name, bytes):
-            return name.decode('ascii')
-        return name
-else:
-    def fits_hdu_name(name):
-        """
-        Returns a FITS hdu name in the correct form for the current
-        version of Python.
-        """
-        if isinstance(name, six.text_type):
-            return name.encode('ascii')
-        return name
+def fits_hdu_name(name):
+    """
+    Returns a FITS hdu name in the correct form for the current
+    version of Python.
+    """
+    if isinstance(name, bytes):
+        return name.decode('ascii')
+    return name
 
 
 def _get_hdu_name(schema):
@@ -140,7 +125,7 @@ def get_hdu(hdulist, hdu_name, index=None):
         hdu = hdulist[pair]
     except (KeyError, IndexError, AttributeError):
         try:
-            if isinstance(pair, six.string_types):
+            if isinstance(pair, str):
                 hdu = hdulist[(pair, 1)]
             elif isinstance(pair, tuple) and index == 0:
                 hdu = hdulist[pair[0]]
@@ -188,7 +173,7 @@ def _get_or_make_hdu(hdulist, hdu_name, index=None, hdu_type=None, value=None):
         if hdu_type is not None and not isinstance(hdu, hdu_type):
             new_hdu = _make_hdu(hdulist, hdu_name, index=index,
                                 hdu_type=hdu_type, value=value)
-            for key, val in six.iteritems(hdu.header):
+            for key, val in hdu.header.items():
                 if not _is_builtin_fits_keyword(key):
                     new_hdu.header[key] = val
             hdulist.remove(hdu)
@@ -217,7 +202,7 @@ def _fits_comment_section_handler(validator, properties, instance, schema):
         current_comment_stack = validator.comment_stack
         current_comment_stack.append(util.ensure_ascii(title))
 
-    for property, subschema in six.iteritems(properties):
+    for property, subschema in properties.items():
         if property in instance:
             for error in validator.descend(
                 instance[property],
@@ -343,7 +328,7 @@ def _save_from_schema(hdulist, tree, schema):
         if isinstance(node, datetime.datetime):
             node = time.Time(node)
         if isinstance(node, time.Time):
-            node = six.text_type(time.Time(node, format='iso'))
+            node = str(time.Time(node, format='iso'))
         return node
     tree = treeutil.walk_and_modify(tree, convert_datetimes)
 
@@ -359,7 +344,7 @@ def _save_from_schema(hdulist, tree, schema):
 
 def _save_extra_fits(hdulist, tree):
     # Handle _extra_fits
-    for hdu_name, parts in six.iteritems(tree.get('extra_fits', {})):
+    for hdu_name, parts in tree.get('extra_fits', {}).items():
         hdu_name = fits_hdu_name(hdu_name)
         if 'data' in parts:
             hdu = _get_or_make_hdu(hdulist, hdu_name, value=parts['data'])

--- a/jwst/datamodels/flat.py
+++ b/jwst/datamodels/flat.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals, division, print_function
-
 from . import model_base
 from .dynamicdq import dynamic_mask
 

--- a/jwst/datamodels/fringe.py
+++ b/jwst/datamodels/fringe.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals, division, print_function
-
 from . import model_base
 from .dynamicdq import dynamic_mask
 

--- a/jwst/datamodels/gain.py
+++ b/jwst/datamodels/gain.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals, division, print_function
-
 from . import model_base
 
 

--- a/jwst/datamodels/gls_rampfit.py
+++ b/jwst/datamodels/gls_rampfit.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals, division, print_function
-
 from . import model_base
 
 __all__ = ['GLS_RampFitModel']

--- a/jwst/datamodels/guidercal.py
+++ b/jwst/datamodels/guidercal.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals, division, print_function
-
 from . import model_base
 from .dynamicdq import dynamic_mask
 

--- a/jwst/datamodels/guiderraw.py
+++ b/jwst/datamodels/guiderraw.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals, division, print_function
-
 from . import model_base
 from .dynamicdq import dynamic_mask
 

--- a/jwst/datamodels/ifucube.py
+++ b/jwst/datamodels/ifucube.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals, division, print_function
-
 from . import model_base
 
 

--- a/jwst/datamodels/ifucubepars.py
+++ b/jwst/datamodels/ifucubepars.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals, division, print_function
-
 from . import model_base
 
 __all__ = ['IFUCubeParsModel']

--- a/jwst/datamodels/image.py
+++ b/jwst/datamodels/image.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals, division, print_function
-
 from . import model_base
 
 

--- a/jwst/datamodels/ipc.py
+++ b/jwst/datamodels/ipc.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals, division, print_function
-
 from . import model_base
 
 __all__ = ['IPCModel']

--- a/jwst/datamodels/irs2.py
+++ b/jwst/datamodels/irs2.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals, division, print_function
-
 from . import model_base
 
 

--- a/jwst/datamodels/lastframe.py
+++ b/jwst/datamodels/lastframe.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals, division, print_function
-
 from . import model_base
 from .dynamicdq import dynamic_mask
 

--- a/jwst/datamodels/level1b.py
+++ b/jwst/datamodels/level1b.py
@@ -1,6 +1,3 @@
-from __future__ import (
-    absolute_import, unicode_literals, division, print_function
-)
 import numpy as np
 
 from . import model_base

--- a/jwst/datamodels/linearity.py
+++ b/jwst/datamodels/linearity.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals, division, print_function
-
 from . import model_base
 from .dynamicdq import dynamic_mask
 

--- a/jwst/datamodels/mask.py
+++ b/jwst/datamodels/mask.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals, division, print_function
-
 from . import model_base
 from .dynamicdq import dynamic_mask
 

--- a/jwst/datamodels/miri_ramp.py
+++ b/jwst/datamodels/miri_ramp.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals, division, print_function
-
 from . import ramp
 
 

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -1,8 +1,6 @@
-# -*- coding: utf-8 -*-
 """
 Data model class heirarchy
 """
-from __future__ import absolute_import, unicode_literals, division, print_function
 
 import copy
 import datetime
@@ -14,7 +12,6 @@ import warnings
 import numpy as np
 import jsonschema
 
-import six
 from astropy.io import fits
 from astropy.time import Time
 from astropy.wcs import WCS
@@ -147,7 +144,7 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
             asdf = fits_support.from_fits(init, self._schema, extensions,
                                           pass_invalid_values)
 
-        elif isinstance(init, (six.string_types, bytes)):
+        elif isinstance(init, (str, bytes)):
             if isinstance(init, bytes):
                 init = init.decode(sys.getfilesystemencoding())
             file_type = filetype.check(init)
@@ -178,7 +175,7 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         self._ctx = self
 
         # if the input is from a file, set the filename attribute
-        if isinstance(init, six.string_types):
+        if isinstance(init, str):
             self.meta.filename = os.path.basename(init)
         elif isinstance(init, fits.HDUList):
             info = init.fileinfo(0)
@@ -278,7 +275,7 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         path : str
             The path to the file that we're about to save to.
         """
-        if isinstance(path, six.string_types):
+        if isinstance(path, str):
             self.meta.filename = os.path.basename(path)
 
         current_date = Time(datetime.datetime.now())
@@ -496,7 +493,7 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         """
         Get a metadata value using a dotted name.
         """
-        assert isinstance(key, six.string_types)
+        assert isinstance(key, str)
         meta = self
         for part in key.split('.'):
             try:
@@ -510,7 +507,7 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         Equivalent to __getitem__, except returns the value as a JSON
         basic type, rather than an arbitrary Python type.
         """
-        assert isinstance(key, six.string_types)
+        assert isinstance(key, str)
         meta = self
         parts = key.split('.')
         for part in parts:
@@ -524,7 +521,7 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         """
         Set a metadata value using a dotted name.
         """
-        assert isinstance(key, six.string_types)
+        assert isinstance(key, str)
         meta = self
         parts = key.split('.')
         for part in parts[:-1]:
@@ -558,7 +555,7 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         """
         def recurse(tree, path=[]):
             if isinstance(tree, dict):
-                for key, val in six.iteritems(tree):
+                for key, val in tree.items():
                     for x in recurse(val, path + [key]):
                         yield x
             elif isinstance(tree, (list, tuple)):
@@ -566,7 +563,7 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
                     for x in recurse(val, path + [i]):
                         yield x
             elif tree is not None:
-                yield (str('.'.join(six.text_type(x) for x in path)), tree)
+                yield ('.'.join(str(x) for x in path), tree)
 
         for x in recurse(self._instance):
             yield x
@@ -587,19 +584,7 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         for key, val in self.iteritems():
             yield key
 
-    if six.PY3:
-        keys = iterkeys
-    else:
-        def keys(self):
-            """
-            Gets all of the schema keys in a flat way.
-
-            Each result of the iterator is a `key`.  Each `key` is a
-            dot-separated name.  For example, the schema element
-            `meta.observation.date` will end up in the result as the
-            string `"meta.observation.date"`.
-            """
-            return list(self.iterkeys())
+    keys = iterkeys
 
     def itervalues(self):
         """
@@ -608,14 +593,7 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         for key, val in self.iteritems():
             yield val
 
-    if six.PY3:
-        values = itervalues
-    else:
-        def values(self):
-            """
-            Gets all of the schema values in a flat way.
-            """
-            return list(self.itervalues())
+    values = itervalues
 
     def update(self, d, only=''):
         """
@@ -692,7 +670,7 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         # are limited to those hdus
 
         if only:
-            if isinstance(only, six.string_types):
+            if isinstance(only, str):
                 hdu_names = set([only])
             else:
                 hdu_names = set(list(only))

--- a/jwst/datamodels/multiexposure.py
+++ b/jwst/datamodels/multiexposure.py
@@ -1,9 +1,3 @@
-from __future__ import (
-    absolute_import,
-    unicode_literals,
-    division,
-    print_function
-)
 from copy import deepcopy
 import inspect
 import os

--- a/jwst/datamodels/multiprod.py
+++ b/jwst/datamodels/multiprod.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals, division, print_function
-
 from . import model_base
 from .drizproduct import DrizProductModel
 

--- a/jwst/datamodels/multislit.py
+++ b/jwst/datamodels/multislit.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals, division, print_function
-
 from . import model_base
 from .image import ImageModel
 

--- a/jwst/datamodels/multispec.py
+++ b/jwst/datamodels/multispec.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals, division, print_function
-
 from . import model_base
 from .spec import SpecModel
 

--- a/jwst/datamodels/ndmodel.py
+++ b/jwst/datamodels/ndmodel.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals, division, print_function
-
 """
 Subclass of NDDataBase to support DataModel compatibility with NDData
 """
@@ -8,7 +6,6 @@ import os.path
 import numpy as np
 import collections
 
-import six
 from astropy.units import Quantity
 from astropy.nddata import nddata_base
 
@@ -95,7 +92,7 @@ def write(data, path, *args, **kwargs):
     else:
         model = data
     
-    if isinstance(path, six.string_types): 
+    if isinstance(path, str): 
         model.save(path, *args, **kwargs)
     else:
         raise ValueError("Path to write DataModel was not found")
@@ -243,7 +240,7 @@ class MetaNode(properties.ObjectNode, collections.MutableMapping):
     def __len__(self):
         def recurse(val):
             n = 0
-            for subval in six.itervalues(val):
+            for subval in val.values():
                 if isinstance(subval, dict):
                     n += recurse(subval)
                 else:

--- a/jwst/datamodels/nirspec_flat.py
+++ b/jwst/datamodels/nirspec_flat.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals, division, print_function
-
 from . import model_base
 from .dynamicdq import dynamic_mask
 

--- a/jwst/datamodels/outlierpars.py
+++ b/jwst/datamodels/outlierpars.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals, division, print_function
-
 from . import model_base
 
 __all__ = ['OutlierParsModel']

--- a/jwst/datamodels/pathloss.py
+++ b/jwst/datamodels/pathloss.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals, division, print_function
-
 from . import model_base
 from .dynamicdq import dynamic_mask
 

--- a/jwst/datamodels/persat.py
+++ b/jwst/datamodels/persat.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals, division, print_function
-
 from . import model_base
 from .dynamicdq import dynamic_mask
 

--- a/jwst/datamodels/photom.py
+++ b/jwst/datamodels/photom.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals, division, print_function
-
 from . import model_base
 from .dynamicdq import dynamic_mask
 

--- a/jwst/datamodels/pixelarea.py
+++ b/jwst/datamodels/pixelarea.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals, division, print_function
-
 from . import model_base
 
 

--- a/jwst/datamodels/properties.py
+++ b/jwst/datamodels/properties.py
@@ -1,14 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# -*- coding: utf-8 -*-
-
-from __future__ import absolute_import, division, unicode_literals, print_function
 
 import copy
 import numpy as np
 import jsonschema
 import warnings
 
-import six
 from astropy.utils.compat.misc import override__dir__
 
 from asdf import schema
@@ -191,7 +187,7 @@ class Node(object):
 class ObjectNode(Node):
     @override__dir__
     def __dir__(self):
-        return list(six.iterkeys(self._schema.get('properties', {})))
+        return list(self._schema.get('properties', {}).keys())
 
     def __eq__(self, other):
         if isinstance(other, ObjectNode):
@@ -386,13 +382,13 @@ class ListNode(Node):
         obj._validate()
         return obj
 
-class NodeIterator(six.Iterator):
+class NodeIterator:
     """
     An iterator for a node which flattens the hierachical structure
     """
     def __init__(self, node):
         self.key_stack = []
-        self.iter_stack = [six.iteritems(node._instance)]
+        self.iter_stack = [node._instance.items()]
 
     def __iter__(self):
         return self
@@ -400,7 +396,7 @@ class NodeIterator(six.Iterator):
     def __next__(self):
         while self.iter_stack:
             try:
-                key, val = six.next(self.iter_stack[-1])
+                key, val = next(self.iter_stack[-1])
             except StopIteration:
                 self.iter_stack.pop()
                 if self.iter_stack:
@@ -409,7 +405,7 @@ class NodeIterator(six.Iterator):
                 
             if isinstance(val, dict):
                 self.key_stack.append(key)
-                self.iter_stack.append(six.iteritems(val))
+                self.iter_stack.append(val.items())
             else:
                 return '.'.join(self.key_stack + [key])
                 
@@ -457,7 +453,7 @@ def merge_tree(a, b):
         if isinstance(b, dict):
             if not isinstance(a, dict):
                 return copy.deepcopy(b)
-            for key, val in six.iteritems(b):
+            for key, val in b.items():
                 a[key] = recurse(a.get(key), val)
             return a
         return copy.deepcopy(b)

--- a/jwst/datamodels/psfmask.py
+++ b/jwst/datamodels/psfmask.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals, division, print_function
-
 from . import model_base
 
 

--- a/jwst/datamodels/quad.py
+++ b/jwst/datamodels/quad.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals, division, print_function
-
 from . import model_base
 
 

--- a/jwst/datamodels/ramp.py
+++ b/jwst/datamodels/ramp.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals, division, print_function
-
 from . import model_base
 
 

--- a/jwst/datamodels/rampfitoutput.py
+++ b/jwst/datamodels/rampfitoutput.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals, division, print_function
-
 from . import model_base
 
 

--- a/jwst/datamodels/readnoise.py
+++ b/jwst/datamodels/readnoise.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals, division, print_function
-
 from . import model_base
 
 

--- a/jwst/datamodels/reference.py
+++ b/jwst/datamodels/reference.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals, division, print_function
-
 from . import model_base
 
 

--- a/jwst/datamodels/reset.py
+++ b/jwst/datamodels/reset.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals, division, print_function
-
 from . import model_base
 from .dynamicdq import dynamic_mask
 

--- a/jwst/datamodels/resolution.py
+++ b/jwst/datamodels/resolution.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals, division, print_function
-
 from . import model_base
 
 __all__ = ['ResolutionModel', 'MiriResolutionModel']

--- a/jwst/datamodels/rscd.py
+++ b/jwst/datamodels/rscd.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals, division, print_function
-
 from . import model_base
 
 

--- a/jwst/datamodels/saturation.py
+++ b/jwst/datamodels/saturation.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals, division, print_function
-
 from . import model_base
 from .dynamicdq import dynamic_mask
 

--- a/jwst/datamodels/schema.py
+++ b/jwst/datamodels/schema.py
@@ -1,10 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# -*- coding: utf-8 -*-
 
-from __future__ import absolute_import, division, unicode_literals, print_function
-
-
-import six
 from collections import OrderedDict
 
 
@@ -166,7 +161,7 @@ def walk_schema(schema, callback, ctx={}):
                 recurse(sub, path + [i], c, ctx)
 
         if schema.get('type') == 'object':
-            for key, val in six.iteritems(schema.get('properties', {})):
+            for key, val in schema.get('properties', {}).items():
                 recurse(val, path + [key], combiner, ctx)
 
         if schema.get('type') == 'array':

--- a/jwst/datamodels/schema_editor.py
+++ b/jwst/datamodels/schema_editor.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 # The schema editor is desgned to be run as a command line script. It can be
 # run either interactively or not. To run it non-inteactively, you must set
 # the options when creating  a new editor object, as in the following
@@ -53,11 +51,6 @@ import datetime
 import argparse
 from urllib.parse import urlparse
 from collections import OrderedDict
-
-try:
-  basestring
-except NameError:
-  basestring = str
 
 from asdf import schema as aschema
 from asdf import resolver as aresolver
@@ -559,7 +552,7 @@ class Options(object):
         Coerce value to type of the current value of a parameter
         """
         if isinstance(current_value, bool):
-            if isinstance(value, basestring):
+            if isinstance(value, str):
                 value = value[0]
                 value = value.lower()
                 if value == "y":
@@ -773,8 +766,8 @@ class Options(object):
         Check that the type of a new value agrees with the current type
         """
         badtype = "Invalid paramater value for %s (%s)"
-        if isinstance(parameters[name], basestring):
-            if not isinstance(value, basestring):
+        if isinstance(parameters[name], str):
+            if not isinstance(value, str):
                 raise ValueError(badtype % (name, value))
 
         elif isinstance(parameters[name], set):
@@ -1028,8 +1021,8 @@ class Schema_editor(object):
         """
         Compare iwo values for type specific kind of equality
         """
-        if (isinstance(keyword_value, basestring) and
-            isinstance(model_value, basestring)):
+        if (isinstance(keyword_value, str) and
+            isinstance(model_value, str)):
             result = (keyword_value.lower().strip() ==
                       model_value.lower().strip())
     
@@ -1464,7 +1457,7 @@ class Schema_editor(object):
         Remove leading and trailing blanks from values
         """
         def strip_single(elem):
-            if isinstance(elem, basestring):
+            if isinstance(elem, str):
                 elem = elem.strip()
             return elem
         

--- a/jwst/datamodels/source_container.py
+++ b/jwst/datamodels/source_container.py
@@ -1,6 +1,3 @@
-from __future__ import (absolute_import, unicode_literals, division,
-                        print_function)
-
 from . import (
     ImageModel,
     ModelContainer,

--- a/jwst/datamodels/spec.py
+++ b/jwst/datamodels/spec.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals, division, print_function
-
 from . import model_base
 
 

--- a/jwst/datamodels/storage.py
+++ b/jwst/datamodels/storage.py
@@ -15,8 +15,6 @@ There are currently 2 storage backends implemented:
     hierarchy.  This includes all of the nice things about
     ``astropy.io.fits``, such as mmap'ing of array data.
 """
-from __future__ import absolute_import, unicode_literals, division, print_function
-
 
 class Storage(object):
     def close(self):

--- a/jwst/datamodels/straylight.py
+++ b/jwst/datamodels/straylight.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals, division, print_function
-
 from . import model_base
 
 

--- a/jwst/datamodels/superbias.py
+++ b/jwst/datamodels/superbias.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals, division, print_function
-
 from . import model_base
 from .dynamicdq import dynamic_mask
 

--- a/jwst/datamodels/tests/test_fits.py
+++ b/jwst/datamodels/tests/test_fits.py
@@ -1,7 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# -*- coding: utf-8 -*-
-
-from __future__ import absolute_import, division, unicode_literals, print_function
 
 import os
 import shutil

--- a/jwst/datamodels/tests/test_history.py
+++ b/jwst/datamodels/tests/test_history.py
@@ -1,7 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# -*- coding: utf-8 -*-
-
-from __future__ import absolute_import, division, unicode_literals, print_function
 
 import datetime
 import os

--- a/jwst/datamodels/tests/test_models.py
+++ b/jwst/datamodels/tests/test_models.py
@@ -1,6 +1,3 @@
-from __future__ import absolute_import, unicode_literals, division, print_function
-
-import six
 import datetime
 import os
 import shutil
@@ -276,11 +273,7 @@ def test_multislit_metadata():
     with MultiSlitModel() as ms:
         ms.slits.append(ms.slits.item())
         for key, val in ms.iteritems():
-            if six.PY2:
-                assert isinstance(val, (bytes, unicode, int, long, float, bool,
-                                        Time))
-            else:
-                assert isinstance(val, (bytes, str, int, float, bool, Time))
+            assert isinstance(val, (bytes, str, int, float, bool, Time))
 
 
 def test_multislit_copy():

--- a/jwst/datamodels/tests/test_open.py
+++ b/jwst/datamodels/tests/test_open.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals, division, print_function
-
 """
 Test datamodel.open
 """

--- a/jwst/datamodels/tests/test_schema.py
+++ b/jwst/datamodels/tests/test_schema.py
@@ -1,7 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# -*- coding: utf-8 -*-
-
-from __future__ import absolute_import, division, unicode_literals, print_function
 
 import datetime
 import os

--- a/jwst/datamodels/tests/test_storage.py
+++ b/jwst/datamodels/tests/test_storage.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals, division, print_function
-
 import numpy as np
 from .. import util
 

--- a/jwst/datamodels/tests/test_wcs.py
+++ b/jwst/datamodels/tests/test_wcs.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, unicode_literals, print_function
-
 import os
 import shutil
 import tempfile

--- a/jwst/datamodels/throughput.py
+++ b/jwst/datamodels/throughput.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals, division, print_function
-
 from . import model_base
 
 

--- a/jwst/datamodels/trapdensity.py
+++ b/jwst/datamodels/trapdensity.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals, division, print_function
-
 from . import model_base
 from .dynamicdq import dynamic_mask
 

--- a/jwst/datamodels/trappars.py
+++ b/jwst/datamodels/trappars.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals, division, print_function
-
 from . import model_base
 
 

--- a/jwst/datamodels/trapsfilled.py
+++ b/jwst/datamodels/trapsfilled.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals, division, print_function
-
 from . import model_base
 
 __all__ = ['TrapsFilledModel']

--- a/jwst/datamodels/util.py
+++ b/jwst/datamodels/util.py
@@ -1,12 +1,10 @@
 """
 Various utility functions and data types
 """
-from __future__ import absolute_import, unicode_literals, division, print_function
 
 import sys
 from os.path import basename
 import numpy as np
-import six
 from astropy.io import fits
 
 import logging
@@ -68,11 +66,11 @@ def open(init=None, extensions=None, **kwargs):
         # Copy the object so it knows not to close here
         return init.__class__(init)
 
-    elif isinstance(init, (six.text_type, bytes)) or hasattr(init, "read"):
+    elif isinstance(init, (str, bytes)) or hasattr(init, "read"):
         # If given a string, presume its a file path.
         # if it has a read method, assume a file descriptor
 
-        if isinstance(init, (bytes)):
+        if isinstance(init, bytes):
             init = init.decode(sys.getfilesystemencoding())
 
         file_type = filetype.check(init)
@@ -139,7 +137,7 @@ def open(init=None, extensions=None, **kwargs):
         raise TypeError("Can't determine datamodel class from argument to open")
 
     # Log a message about how the model was opened
-    if isinstance(init, six.text_type):
+    if isinstance(init, str):
         log.debug('Opening {0} as {1}'.format(basename(init), new_class))
     else:
         log.debug('Opening as {0}'.format(new_class))
@@ -281,24 +279,14 @@ def to_camelcase(token):
     return ''.join(x.capitalize() for x in token.split('_-'))
 
 
-if six.PY3:
-    def fits_header_name(name):
-        """
-        Returns a FITS header name in the correct form for the current
-        version of Python.
-        """
-        if isinstance(name, bytes):
-            return name.decode('ascii')
-        return name
-else:
-    def fits_header_name(name):
-        """
-        Returns a FITS header name in the correct form for the current
-        version of Python.
-        """
-        if isinstance(name, unicode):
-            return name.encode('ascii')
-        return name
+def fits_header_name(name):
+    """
+    Returns a FITS header name in the correct form for the current
+    version of Python.
+    """
+    if isinstance(name, bytes):
+        return name.decode('ascii')
+    return name
 
 
 def gentle_asarray(a, dtype):
@@ -364,10 +352,8 @@ def get_short_doc(schema):
 
 
 def ensure_ascii(s):
-    if isinstance(s, six.text_type):
-        s = s.encode('ascii', 'replace')
-        if six.PY3:
-            s = s.decode('ascii')
+    if isinstance(s, bytes):
+        s = s.decode('ascii')
     return s
 
 

--- a/jwst/datamodels/wcs_ref_models.py
+++ b/jwst/datamodels/wcs_ref_models.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, unicode_literals, division, print_function
 import numpy as np
 from astropy.modeling.core import Model
 from astropy import units as u


### PR DESCRIPTION
References to the six package and the "from __future__" line have been
stripped from the source code. There are no significant changes to the
functionality.