### PR TITLE
Account for recent changes to asdf and astropy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,9 @@ env:
     matrix:
         - SETUP_CMD='install'
         - SETUP_CMD='test'
-        - PYTHON_VERSION=2.7 SETUP_CMD='install' ASTROPY_VERSION=stable
-        - PYTHON_VERSION=2.7 SETUP_CMD='test' ASTROPY_VERSION=stable
+        # These will no longer work unless we add an explicit dependency on asdf-1.3.1
+        #- PYTHON_VERSION=2.7 SETUP_CMD='install' ASTROPY_VERSION=stable
+        #- PYTHON_VERSION=2.7 SETUP_CMD='test' ASTROPY_VERSION=stable
 
 matrix:
 

--- a/jwst/transforms/jwextension.py
+++ b/jwst/transforms/jwextension.py
@@ -21,6 +21,7 @@ class JWSTExtension(AsdfExtension):
                 SnellType,
                 NIRCAMGrismDispersionType,
                 NIRISSGrismDispersionType,
+                LogicalType,
                 ]
 
     @property

--- a/jwst/transforms/tags/jwst_models.py
+++ b/jwst/transforms/tags/jwst_models.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, unicode_literals,
                         print_function)
 from numpy.testing import assert_array_equal
 from asdf import yamlutil
-from asdf.tags.transform.basic import TransformType
+from astropy.io.misc.asdf.tags.transform.basic import TransformType
 from .. import models
 from ..models import (WavelengthFromGratingEquation, AngleFromGratingEquation,
                       Unitless2DirCos, DirCos2Unitless, Rotation3DToGWA, LRSWavelength, Gwa2Slit,


### PR DESCRIPTION
We just moved astropy-specific tag implementations from asdf to the astropy core repository. This required a few minor changes to gwcs and to the JWST pipeline. This PR should account for those changes, assuming that the latest versions of asdf, astropy, and gwcs are pulled in by the travis build.

These changes exposed a minor issue with `JWSTExtension`, which has been addressed in this PR as well.