### PR TITLE
Add WCS to CALTSO3 ModelContainer

### DIFF
--- a/jwst/pipeline/calwebb_tso3.py
+++ b/jwst/pipeline/calwebb_tso3.py
@@ -68,6 +68,7 @@ class Tso3Pipeline(Pipeline):
                 image = datamodels.ImageModel(data=cube.data[i],
                         err=cube.err[i], dq=cube.dq[i])
                 image.update(cube)
+                image.meta.wcs = cube.meta.wcs
                 input_2dmodels.append(image)
 
             if not self.scale_detection:


### PR DESCRIPTION
This PR fixes a problem with CALTSO3 where the WCS was not getting passed along when the input CubeModel was transformed into a ModelContainer.  The error arose from use of .update() which does NOT include an update for the WCS or any other element not defined explicitly in the schema.  

The update can be seen to work when the regression tests `test_nrc_tso3_1` and `test_nrc_tso3_2` start working again, since they are trying to access the WCS when performing outlier_detection and it was not provided during the conversion performed by CALTSO3.  