### PR TITLE
define a JWSTTransformType, fix typos, add tests

### DIFF
--- a/jwst/transforms/jwextension.py
+++ b/jwst/transforms/jwextension.py
@@ -1,8 +1,9 @@
-from __future__ import absolute_import, division, unicode_literals, print_function
 import os.path
 from asdf.extension import AsdfExtension
 from asdf import util
 from .tags import *
+from .jwst_types import _jwst_types
+
 
 SCHEMA_PATH = os.path.abspath(
     os.path.join(os.path.dirname(__file__), 'schemas'))
@@ -11,24 +12,10 @@ SCHEMA_PATH = os.path.abspath(
 class JWSTExtension(AsdfExtension):
     @property
     def types(self):
-        return [GratingEquationType,
-                CoordsType,
-                RotationSequenceType,
-                LRSWavelengthType,
-                Gwa2SlitType,
-                Slit2MsaType,
-                MIRI_AB2SliceType,
-                SnellType,
-                NIRCAMGrismDispersionType,
-                NIRISSGrismDispersionType,
-                LogicalType,
-                TPCorrType,
-                ]
+        return _jwst_types
 
     @property
     def tag_mapping(self):
-        # return [('tag:stsci.edu:jwst',
-                 # 'http://stsci.edu/schemas/jwst{tag_suffix}')]
         return [('tag:stsci.edu:jwst_pipeline',
                  'http://stsci.edu/schemas/jwst_pipeline{tag_suffix}')]
 

--- a/jwst/transforms/jwst_types.py
+++ b/jwst/transforms/jwst_types.py
@@ -7,7 +7,6 @@ All types are added automatically to ``_jwst_types`` and the JWSTExtension.
 """
 import six
 
-from asdf.asdftypes import ExtensionTypeMeta
 from astropy.io.misc.asdf.tags.transform.basic import TransformType
 from astropy.io.misc.asdf.types import AstropyTypeMeta
 
@@ -25,7 +24,7 @@ class JWSTTypeMeta(AstropyTypeMeta):
     def __new__(mcls, name, bases, attrs):
         cls = super(JWSTTypeMeta, mcls).__new__(mcls, name, bases, attrs)
         # Classes using this metaclass are automatically added to the list of
-        # astropy extensions
+        # jwst types and JWSTExtensions.types.
         if cls.organization == 'stsci.edu' and cls.standard == 'jwst_pipeline':
             _jwst_types.add(cls)
 

--- a/jwst/transforms/jwst_types.py
+++ b/jwst/transforms/jwst_types.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+
+"""
+Defines a ``JWSTTransformType`` used by jwst pipeine transform types.
+All types are added automatically to ``_jwst_types`` and the JWSTExtension.
+
+"""
+import six
+
+from asdf.asdftypes import ExtensionTypeMeta
+from astropy.io.misc.asdf.tags.transform.basic import TransformType
+from astropy.io.misc.asdf.types import AstropyTypeMeta
+
+__all__ = ['JWSTTransformType']
+
+
+_jwst_types = set()
+
+
+class JWSTTypeMeta(AstropyTypeMeta):
+    """
+    Keeps track of `JWSTType` subclasses that are created so that they can
+    be stored automatically by astropy extensions for ASDF.
+    """
+    def __new__(mcls, name, bases, attrs):
+        cls = super(JWSTTypeMeta, mcls).__new__(mcls, name, bases, attrs)
+        # Classes using this metaclass are automatically added to the list of
+        # astropy extensions
+        if cls.organization == 'stsci.edu' and cls.standard == 'jwst_pipeline':
+            _jwst_types.add(cls)
+
+        return cls
+
+
+@six.add_metaclass(JWSTTypeMeta)
+class JWSTTransformType(TransformType):
+    """
+    This class represents types that have schemas and tags implemented within
+    the jwst pipeline.
+    """
+    organization = 'stsci.edu'
+    standard = 'jwst_pipeline'

--- a/jwst/transforms/tags/jwst_models.py
+++ b/jwst/transforms/tags/jwst_models.py
@@ -5,6 +5,7 @@ import numpy as np
 from numpy.testing import assert_array_equal
 from asdf import yamlutil
 from astropy.io.misc.asdf.tags.transform.basic import TransformType
+from ..jwst_types import JWSTTransformType
 from .. import models
 from ..models import (WavelengthFromGratingEquation, AngleFromGratingEquation,
                       Unitless2DirCos, DirCos2Unitless, Rotation3DToGWA, LRSWavelength, Gwa2Slit,
@@ -15,12 +16,12 @@ from ..models import (WavelengthFromGratingEquation, AngleFromGratingEquation,
 from ..tpcorr import TPCorr
 
 __all__ = ['GratingEquationType', 'CoordsType', 'RotationSequenceType', 'LRSWavelengthType',
-           'Gwa2SlitType', 'Slit2MsaType', 'LogicalType', 'NirissSOSSType', 'V23ToSky',
+           'Gwa2SlitType', 'Slit2MsaType', 'LogicalType', 'NirissSOSSType', 'V23ToSkyType',
            'RefractionIndexType', 'SnellType', 'MIRI_AB2SliceType', 'NIRCAMGrismDispersionType',
            'NIRISSGrismDispersionType', 'TPCorrType']
 
 
-class NIRCAMGrismDispersionType(TransformType):
+class NIRCAMGrismDispersionType(JWSTTransformType):
     name = "nircam_grism_dispersion"
     types = [NIRCAMForwardRowGrismDispersion, NIRCAMForwardColumnGrismDispersion,
              NIRCAMBackwardGrismDispersion]
@@ -56,7 +57,7 @@ class NIRCAMGrismDispersionType(TransformType):
         assert_array_equal(a.orders, b.orders)
 
 
-class NIRISSGrismDispersionType(TransformType):
+class NIRISSGrismDispersionType(JWSTTransformType):
     name = "niriss_grism_dispersion"
     types = [NIRISSForwardRowGrismDispersion, NIRISSForwardColumnGrismDispersion,
              NIRISSBackwardGrismDispersion]
@@ -97,7 +98,7 @@ class NIRISSGrismDispersionType(TransformType):
         assert_array_equal(a.theta, b.theta)
 
 
-class RotationSequenceType(TransformType):
+class RotationSequenceType(JWSTTransformType):
     name = "rotation_sequence"
     types = [Rotation3DToGWA]
     standard = "jwst_pipeline"
@@ -116,7 +117,7 @@ class RotationSequenceType(TransformType):
         return yamlutil.custom_tree_to_tagged_tree(node, ctx)
 
 
-class V23ToSkyType(TransformType):
+class V23ToSkyType(JWSTTransformType):
     name = "v23tosky"
     types = [V23ToSky]
     standard = "jwst_pipeline"
@@ -135,7 +136,7 @@ class V23ToSkyType(TransformType):
         return yamlutil.custom_tree_to_tagged_tree(node, ctx)
 
 
-class CoordsType(TransformType):
+class CoordsType(JWSTTransformType):
     name = "coords"
     types = [Unitless2DirCos, DirCos2Unitless]
     standard = "jwst_pipeline"
@@ -164,7 +165,7 @@ class CoordsType(TransformType):
         return yamlutil.custom_tree_to_tagged_tree(node, ctx)
 
 
-class GratingEquationType(TransformType):
+class GratingEquationType(JWSTTransformType):
     name = "grating_equation"
     types = [WavelengthFromGratingEquation, AngleFromGratingEquation]
     standard = "jwst_pipeline"
@@ -199,7 +200,7 @@ class GratingEquationType(TransformType):
         return yamlutil.custom_tree_to_tagged_tree(node, ctx)
 
 
-class LRSWavelengthType(TransformType):
+class LRSWavelengthType(JWSTTransformType):
     name = "lrs_wavelength"
     types = [LRSWavelength]
     standard = "jwst_pipeline"
@@ -218,7 +219,7 @@ class LRSWavelengthType(TransformType):
         return yamlutil.custom_tree_to_tagged_tree(node, ctx)
 
 
-class Gwa2SlitType(TransformType):
+class Gwa2SlitType(JWSTTransformType):
     name = "gwa_to_slit"
     types = [Gwa2Slit]
     standard = "jwst_pipeline"
@@ -235,7 +236,7 @@ class Gwa2SlitType(TransformType):
         return yamlutil.custom_tree_to_tagged_tree(node, ctx)
 
 
-class Slit2MsaType(TransformType):
+class Slit2MsaType(JWSTTransformType):
     name = "slit_to_msa"
     types = [Slit2Msa]
     standard = "jwst_pipeline"
@@ -252,7 +253,7 @@ class Slit2MsaType(TransformType):
         return yamlutil.custom_tree_to_tagged_tree(node, ctx)
 
 
-class LogicalType(TransformType):
+class LogicalType(JWSTTransformType):
     name = "logical"
     types = [Logical]
     standard = "jwst_pipeline"
@@ -270,7 +271,7 @@ class LogicalType(TransformType):
         return yamlutil.custom_tree_to_tagged_tree(node, ctx)
 
 
-class NirissSOSSType(TransformType):
+class NirissSOSSType(JWSTTransformType):
     name = "niriss_soss"
     types = [NirissSOSSModel]
     standard = "jwst_pipeline"
@@ -288,7 +289,7 @@ class NirissSOSSType(TransformType):
         return yamlutil.custom_tree_to_tagged_tree(node, ctx)
 
 
-class RefractionIndexType(TransformType):
+class RefractionIndexType(JWSTTransformType):
     name = "refraction_index_from_prism"
     types = [RefractionIndexFromPrism]
     standard = "jwst_pipeline"
@@ -312,7 +313,7 @@ class RefractionIndexType(TransformType):
         assert_array_equal(a.prism_angle, b.prism_angle)
 
 
-class SnellType(TransformType):
+class SnellType(JWSTTransformType):
     name = "snell"
     types = [Snell]
     standard = "jwst_pipeline"
@@ -351,7 +352,7 @@ class SnellType(TransformType):
         assert_array_equal(a.pressure, b.pressure)
 
 
-class MIRI_AB2SliceType(TransformType):
+class MIRI_AB2SliceType(JWSTTransformType):
     name = "miri_ab2slice"
     types = [MIRI_AB2Slice]
     standard = "jwst_pipeline"

--- a/jwst/transforms/tags/jwst_models.py
+++ b/jwst/transforms/tags/jwst_models.py
@@ -379,7 +379,7 @@ class MIRI_AB2SliceType(JWSTTransformType):
         assert_array_equal(a.channel, b.channel)
 
 
-class TPCorrType(TransformType):
+class TPCorrType(JWSTTransformType):
     name = "tpcorr"
     types = [TPCorr]
     standard = "jwst_pipeline"

--- a/jwst/transforms/tags/jwst_models.py
+++ b/jwst/transforms/tags/jwst_models.py
@@ -4,7 +4,6 @@ from __future__ import (absolute_import, division, unicode_literals,
 import numpy as np
 from numpy.testing import assert_array_equal
 from asdf import yamlutil
-from astropy.io.misc.asdf.tags.transform.basic import TransformType
 from ..jwst_types import JWSTTransformType
 from .. import models
 from ..models import (WavelengthFromGratingEquation, AngleFromGratingEquation,
@@ -49,7 +48,7 @@ class NIRCAMGrismDispersionType(JWSTTransformType):
 
     @classmethod
     def assert_equal(cls, a, b):
-        TransformType.assert_equal(a, b)
+        JWSTTransformType.assert_equal(a, b)
         assert (isinstance(a, type(b)))
         assert_array_equal(a.xmodels, b.xmodels)
         assert_array_equal(a.ymodels, b.ymodels)
@@ -89,7 +88,7 @@ class NIRISSGrismDispersionType(JWSTTransformType):
 
     @classmethod
     def assert_equal(cls, a, b):
-        TransformType.assert_equal(a, b)
+        JWSTTransformType.assert_equal(a, b)
         assert (isinstance(a, type(b)))
         assert_array_equal(a.xmodels, b.xmodels)
         assert_array_equal(a.ymodels, b.ymodels)
@@ -307,7 +306,7 @@ class RefractionIndexType(JWSTTransformType):
 
     @classmethod
     def assert_equal(cls, a, b):
-        TransformType.assert_equal(a, b)
+        JWSTTransformType.assert_equal(a, b)
         assert (isinstance(a, RefractionIndexFromPrism) and
                 isinstance(b, RefractionIndexFromPrism))
         assert_array_equal(a.prism_angle, b.prism_angle)
@@ -339,7 +338,7 @@ class SnellType(JWSTTransformType):
 
     @classmethod
     def assert_equal(cls, a, b):
-        TransformType.assert_equal(a, b)
+        JWSTTransformType.assert_equal(a, b)
         assert (isinstance(a, Snell) and
                 isinstance(b, Snell))
         assert_array_equal(a.prism_angle, b.prism_angle)
@@ -372,7 +371,7 @@ class MIRI_AB2SliceType(JWSTTransformType):
 
     @classmethod
     def assert_equal(cls, a, b):
-        TransformType.assert_equal(a, b)
+        JWSTTransformType.assert_equal(a, b)
         assert (isinstance(a, MIRI_AB2Slice) and
                 isinstance(b, MIRI_AB2Slice))
         assert_array_equal(a.beta_zero, b.beta_zero)

--- a/jwst/transforms/tags/tests/test_models.py
+++ b/jwst/transforms/tags/tests/test_models.py
@@ -17,7 +17,11 @@ m2 = Shift(2) & Shift(2) | Rotation2D(23.1)
 test_models = [DirCos2Unitless(), Unitless2DirCos(),
                Rotation3DToGWA(angles=[12.1, 1.3, 0.5, 3.4], axes_order='xyzx'),
                AngleFromGratingEquation(20000, -1), WavelengthFromGratingEquation(25000, 2),
-               Logical('GT', 5, 10), Logical('LT', np.ones((10,))* 5, np.arange(10))
+               Logical('GT', 5, 10), Logical('LT', np.ones((10,))* 5, np.arange(10)),
+               V23ToSky(angles=[0.1259, -0.1037, -146.03468, 69.503032, 80.46448], axes_order="zyxyz"),
+               Snell(angle=-16.5, kcoef=[0.583, 0.462, 3.891], lcoef=[0.002526, 0.01, 1200.556],
+                     tcoef=[-2.66e-05, 0.0, 0.0, 0.0, 0.0, 0.0], tref=35, pref=0,
+                     temperature=35, pressure=0),
                ]
 
 


### PR DESCRIPTION
Transforms used in the pipeline should inherit now from JWSTTransformType. They don't need to be added to the JWSTExtension any more as this is done automatically.