### PR TITLE
Change syntax for checking for existence of DQ

### DIFF
--- a/jwst/persistence/persistence.py
+++ b/jwst/persistence/persistence.py
@@ -1,5 +1,3 @@
-from __future__ import (absolute_import, unicode_literals, division,
-                        print_function)
 #
 #  Module for correcting for persistence
 

--- a/jwst/persistence/persistence.py
+++ b/jwst/persistence/persistence.py
@@ -1,3 +1,5 @@
+from __future__ import (absolute_import, unicode_literals, division,
+                        print_function)
 #
 #  Module for correcting for persistence
 
@@ -435,7 +437,7 @@ class DataSet():
         # two, use this syntax:
         # refsub.data = ref.data[..., slc[0], slc[1]].copy()
         refsub.data = ref.data[slc[0], slc[1]].copy()
-        if "dq" in ref:
+        if hasattr(ref, "dq"):
             refsub.dq = ref.dq[slc[0], slc[1]].copy()
 
         return refsub


### PR DESCRIPTION
The `get_subarray` method in persistence.py used `if "dq" in ref:` to check whether a reference file model has a dq array.  This no longer works, so it has been changed to `if hasattr(ref, "dq"):`.