### PR TITLE
Correct? default suffixes assigned to TSO output products

### DIFF
--- a/jwst/outlier_detection/outlier_detection_step.py
+++ b/jwst/outlier_detection/outlier_detection_step.py
@@ -106,13 +106,13 @@ class OutlierDetectionStep(Step):
                 # algorithm selected for TSO data (no resampling)
                 pars['resample_data'] = False  # force resampling off...
                 detection_step = outlier_registry['imaging']
-                pars['resample_suffix'] = 'i2d'
+                pars['resample_suffix'] = 's2d'
             elif exptype in TSO_IMAGE_MODES+CORON_IMAGE_MODES and \
                     not self.scale_detection:
                 # algorithm selected for TSO data (no resampling)
                 pars['resample_data'] = False  # force resampling off...
                 detection_step = outlier_registry['imaging']
-                pars['resample_suffix'] = 's2d'
+                pars['resample_suffix'] = 'i2d'
             elif exptype in TSO_IMAGE_MODES and self.scale_detection:
                 # selected scaled algorithm for TSO data
                 detection_step = outlier_registry['scaled']


### PR DESCRIPTION
The default suffix defined for outlier detection intermediate products appears to have been mis-assigned previously.  This PR resets the default so that 's2d' is used for spectroscopic data and 'i2d' for imaging, as opposed to the exact opposite assignment delivered in B7.1.  