### PR TITLE
Update pipeline docs

### DIFF
--- a/docs/jwst/coron/main.rst
+++ b/docs/jwst/coron/main.rst
@@ -90,6 +90,8 @@ ModelContainer is passed as input to the ``stack_refs`` step. The output
 of ``stack_refs`` will be a single CubeModel containing all of the
 concatenated data cubes from the input psf files.
 
+.. automodapi:: jwst.coron.stack_refs_step
+
 Align_refs
 ==========
 
@@ -113,6 +115,8 @@ model (QuadModel), where the 3rd axis has length equal to the total
 number of reference PSF images in the input PSF stack and the 4th
 axis has length equal to the number of integrations in the input
 science target product.
+
+.. automodapi:: jwst.coron.align_refs_step
 
 Klip
 ====
@@ -151,10 +155,14 @@ target product, and contains the PSF-subtracted images for every integration
 of the science target product.
 
 Arguments
----------
+---------.. automodapi:: jwst.coron.align_refs
+
+
 The task takes one optional argument, `truncate`, which is used to specify the
 number of KL transform rows to keep when computing the PSF fit to the target.
 The default value is 50.
+
+.. automodapi:: jwst.coron.klip_step
 
 HLSP
 ====
@@ -183,3 +191,5 @@ The ``hslp`` task produces two output products. The first is the snr image (file
 name suffix "_snr") and the second is the table of contrast data (file name
 suffix "_contrast"). The contrast data are stored as a 2-column table giving
 radius (in pixels) and noise (1-sigma).
+
+.. automodapi:: jwst.coron.hlsp_step

--- a/docs/jwst/coron/main.rst
+++ b/docs/jwst/coron/main.rst
@@ -155,8 +155,7 @@ target product, and contains the PSF-subtracted images for every integration
 of the science target product.
 
 Arguments
----------.. automodapi:: jwst.coron.align_refs
-
+---------
 
 The task takes one optional argument, `truncate`, which is used to specify the
 number of KL transform rows to keep when computing the PSF fit to the target.

--- a/docs/jwst/pipeline/description.rst
+++ b/docs/jwst/pipeline/description.rst
@@ -35,8 +35,8 @@ the instrument modes to which they can be applied.
 
 Input Files, Output Files and Data Models
 =========================================
-An important concept used throughout the JWST pipeline is the :ref:`Data
-Model`. Nearly all data used by any of the pipeline code is
+An important concept used throughout the JWST pipeline is the :py:class:`Data
+Model <jwst.datamodels.DataModel>`. Nearly all data used by any of the pipeline code is
 encapsulated in a data model. Most input is read into a data model and
 all output is produced by a data model. When possible, this document
 will indicate the data model associated with a file type, usually as a
@@ -326,7 +326,8 @@ Inputs
 Outputs
 -------
 
-* Resampled 2D Image product (:ref:`DrizProductModel`): A resampled/rectified 2D image product of type
+* Resampled 2D Image product (:py:class:`DrizProductModel
+  <jwst.datamodels.DrizProductModel>`): A resampled/rectified 2D image product of type
   ``_i2d`` is created containing the rectified single exposure or the rectified
   and combined association of exposures, which is the direct output of the
   ``resample`` step.
@@ -371,17 +372,20 @@ Inputs
 Outputs
 -------
 
-* LG product (:ref:`AmiLgModel`): For every input exposure, the fringe
+* LG product (:py:class:`AmiLgModel <jwst.datamodels.AmiLgModel>`):
+  For every input exposure, the fringe
   parameters and closure phases caculated by the ``ami_analyze`` step
   are saved to an ``_lg`` product type file.
 
-* Averaged LG product (:ref:`AmiLgModel`): The LG results averaged over all science or reference
+* Averaged LG product (:py:class:`AmiLgModel <jwst.datamodels.AmiLgModel>`):
+  The LG results averaged over all science or reference
   exposures, calculated by the ``ami_average`` step, are saved to an ``_lgavgt``
   (for the science target) or ``_lgavgr`` (for the reference target) file. Note
   that these output products are only created if the pipeline argument
   ``save_averages`` (see below) is set to ``True``.
 
-* Normalized LG product (:ref:`AmiLgModel`): If reference target exposures are included in the input
+* Normalized LG product (:py:class:`AmiLgModel <jwst.datamodels.AmiLgModel>`):
+  If reference target exposures are included in the input
   ASN, the LG results for the science target will be normalized by the LG
   results for the reference target, via the ``ami_normalize`` step, and will be
   saved to an ``_lgnorm`` product file.

--- a/docs/jwst/pipeline/description.rst
+++ b/docs/jwst/pipeline/description.rst
@@ -397,21 +397,35 @@ sets this agument to ``True``, the results of the ``ami_average`` step will be
 saved, as described above.
 
 
-Stage 3 Time-Series Observation(TSO) Pipeline Step Flow (calwebb_tso3)
+Stage 3 CORONAGRAPHIC Observation Pipeline Step Flow (calwebb_coron3)
 ===============================================================================
-The stage 3 TSO pipeline (``calwebb_tso3``) is intended to be applied to
-associations of calibrated NIRISS SOSS and NIRCam TSO exposures and is used to
-produce calibrated time-series photometry of the source object.
+The stage 3 coronagraphic pipeline (``calwebb_coron3``) is intended to be applied to
+associations of calibrated NIRCam coronagraphic and MIRI Lyot and MIRI 4QPM
+exposures and is used to produce psf-subtracted, resampled, combined image
+of the source object.
 
-The steps applied by the ``calwebb_tso3`` pipeline are shown below for
-a NIRCam TSO observation:
+The steps applied by the ``calwebb_coron3`` pipeline are shown below for
+a NIRCam coronagraphic observation:
+
+Included steps are:
+stack_refs (assemble reference PSF inputs)
+align_refs (align reference PSFs to target images)
+klip (PSF subtraction using the KLIP algorithm)
+outlier_detection (flag outliers)
+resample (image combination and resampling)
 
 +---------------------+
-| calwebb_tso3        |
+| calwebb_coron3      |
 +=====================+
+| :py:class:`jwst.coron.stack_refs_step.StackRefsStep <stack_refs>``          |
++---------------------+
+| align_refs          |
++---------------------+
+| klip                |
++---------------------+
 | outlier_detection   |
 +---------------------+
-| tso_photometry      |
+| resample            |
 +---------------------+
 
 The steps applied by the ``calwebb_tso3`` pipeline are shown below for a
@@ -462,35 +476,36 @@ Outputs
   the white-light photometry of the source object.
 
 
-Stage 3 CORONOGRAPHIC Observation Pipeline Step Flow (calwebb_coron3)
+
+Stage 3 Time-Series Observation(TSO) Pipeline Step Flow (calwebb_tso3)
 ===============================================================================
-  The stage 3 TSO pipeline (``calwebb_tso3``) is intended to be applied to
-  associations of calibrated NIRISS SOSS and NIRCam TSO exposures and is used to
-  produce calibrated time-series photometry of the source object.
+The stage 3 TSO pipeline (``calwebb_tso3``) is intended to be applied to
+associations of calibrated NIRISS SOSS and NIRCam TSO exposures and is used to
+produce calibrated time-series photometry of the source object.
 
-  The steps applied by the ``calwebb_tso3`` pipeline are shown below for
-  a NIRCam TSO observation:
+The steps applied by the ``calwebb_tso3`` pipeline are shown below for
+a NIRCam TSO observation:
 
-  +---------------------+
-  | calwebb_tso3        |
-  +=====================+
-  | outlier_detection   |
-  +---------------------+
-  | tso_photometry      |
-  +---------------------+
++---------------------+
+| calwebb_tso3        |
++=====================+
+| outlier_detection   |
++---------------------+
+| tso_photometry      |
++---------------------+
 
-  The steps applied by the ``calwebb_tso3`` pipeline are shown below for a
-  NIRISS SOSS observation:
+The steps applied by the ``calwebb_tso3`` pipeline are shown below for a
+NIRISS SOSS observation:
 
-  +---------------------+
-  | calwebb_tso3        |
-  +=====================+
-  | outlier_detection   |
-  +---------------------+
-  | extract_1d          |
-  +---------------------+
-  | white_light         |
-  +---------------------+
++---------------------+
+| calwebb_tso3        |
++=====================+
+| outlier_detection   |
++---------------------+
+| extract_1d          |
++---------------------+
+| white_light         |
++---------------------+
 
 Inputs
 ------

--- a/docs/jwst/pipeline/description.rst
+++ b/docs/jwst/pipeline/description.rst
@@ -407,74 +407,54 @@ of the source object.
 The steps applied by the ``calwebb_coron3`` pipeline are shown below for
 a NIRCam coronagraphic observation:
 
-Included steps are:
-stack_refs (assemble reference PSF inputs)
-align_refs (align reference PSFs to target images)
-klip (PSF subtraction using the KLIP algorithm)
-outlier_detection (flag outliers)
-resample (image combination and resampling)
++---------------------------------------------------------------------------------------------------+
+| :py:class:`calwebb_coron3 <jwst.pipeline.calwebb_coron3.Coron3Pipeline>`                          |
++===================================================================================================+
+| :py:class:`stack_refs <jwst.coron.stack_refs_step.StackRefsStep>`                                 |
++---------------------------------------------------------------------------------------------------+
+| :py:class:`align_refs <jwst.coron.align_refs_step.AlignRefsStep>`                                 |
++---------------------------------------------------------------------------------------------------+
+| :py:class:`klip <jwst.coron.klip_step.KlipStep>`                                                  |
++---------------------------------------------------------------------------------------------------+
+| :py:class:`outlier_detection <jwst.outlier_detection.outlier_detection_step.OutlierDetectionStep` |
++---------------------------------------------------------------------------------------------------+
+| :py:class:`resample <jwst.resample.resample_step.ResampleStep>`                                   |
++---------------------------------------------------------------------------------------------------+
 
-+---------------------+
-| calwebb_coron3      |
-+=====================+
-| :py:class:`jwst.coron.stack_refs_step.StackRefsStep <stack_refs>``          |
-+---------------------+
-| align_refs          |
-+---------------------+
-| klip                |
-+---------------------+
-| outlier_detection   |
-+---------------------+
-| resample            |
-+---------------------+
-
-The steps applied by the ``calwebb_tso3`` pipeline are shown below for a
-NIRISS SOSS observation:
-
-+---------------------+
-| calwebb_tso3        |
-+=====================+
-| outlier_detection   |
-+---------------------+
-| extract_1d          |
-+---------------------+
-| white_light         |
-+---------------------+
 
 Inputs
 ------
 
-* Associated 2D Calibrated products: The input to ``calwebb_tso3`` is assumed
+* Associated 2D Calibrated products: The input to ``calwebb_coron3`` is assumed
   to be in the form of an ASN file that lists multiple science observations of
-  a science target either with NIRCam or NIRISS. The individual NIRCam exposures
-  should be in the form of calibrated (``_cal``) products from ``calwebb_image2``
-  processing, while the individual NIRISS exposures should be in the form of
-  calibrated (``_calints``) products from ``calwebb_spec2``.
+  a science target either with NIRCam or MIRI. The individual exposures
+  should be in the form of calibrated (``_calints``) products from ``calwebb_image2``
+  processing.
 
 Outputs
 -------
 
-* CR-flagged products: If the
+* Aligned PSF images: The initial processing requires aligning all input PSFs
+  specified in the ASN.  The aligned PSF image then gets written to disk in the
+  form of psfalign (``_psfalign``) products from
+  :py:class:`align_refs step <jwst.coron.align_refs_step.AlignRefsStep>`.
+
+* PSF-subtracted exposures: The :py:class:`klip step <jwst.coron.klip_step.KlipStep>`
+  takes the aligned PSF images and applies them to each of the science exposures
+  in the ASN to create the psfsub (``_psfsub``) products.
+
+* CR-flagged products: The
   :py:class:`~jwst.outlier_detection.outlier_detection_step.OutlierDetectionStep`
-  step is applied, a new version
-  of each input calibrated exposure product is created, which contains a DQ array
-  that has been updated to flag pixels detected as outliers. This updated
+  step is applied to the psfsub products to flag pixels in the DQ array
+  that have been detected as outliers. This updated
   product is known as a CR-flagged product. A outlier-cleaned calibrated product of
   type ``_crfints`` is created and can optionally get written to disk.
 
-* Source photometry catalog for NIRCam observations: A source catalog produced
-  from the ``_crfints`` product is saved as an ASCII file in ``ecsv`` format
-  with a product type of ``_phot``.
-
-* Extracted 1D spectra for NIRISS SOSS observations: The ``extract_1d`` step is
-  applied to create a ``MultiSpecModel`` for the entire set of SOSS
-  observations with a product type of ``_x1dints``.
-
-* White-light photometry for NIRISS SOSS observations:  The ``white_light`` step
-  is applied to the ``_x1dints`` extracted data to produce an ASCII catalog
-  in ``ecsv`` format with a product type of ``_whtlht`` of
-  the white-light photometry of the source object.
-
+* Resampled product: The
+  :py:class:`resample step <jwst.resample.resample_step.ResampleStep>` is
+  applied to the CR-flagged products to create a single resampled, combined
+  product.  This resampled product of type ``_i2d`` gets written to disk and
+  returned as the final product from this pipeline.
 
 
 Stage 3 Time-Series Observation(TSO) Pipeline Step Flow (calwebb_tso3)
@@ -486,26 +466,26 @@ produce calibrated time-series photometry of the source object.
 The steps applied by the ``calwebb_tso3`` pipeline are shown below for
 a NIRCam TSO observation:
 
-+---------------------+
-| calwebb_tso3        |
-+=====================+
-| outlier_detection   |
-+---------------------+
-| tso_photometry      |
-+---------------------+
++---------------------------------------------------------------------------------------------------+
+| :py:class:`calwebb_tso3 <jwst.pipeline.calwebb_tso3.Tso3Pipeline>`                                |
++===================================================================================================+
+| :py:class:`outlier_detection <jwst.outlier_detection.outlier_detection_step.OutlierDetectionStep` |
++---------------------------------------------------------------------------------------------------+
+| tso_photometry                                                                                    |
++---------------------------------------------------------------------------------------------------+
 
 The steps applied by the ``calwebb_tso3`` pipeline are shown below for a
 NIRISS SOSS observation:
 
-+---------------------+
-| calwebb_tso3        |
-+=====================+
-| outlier_detection   |
-+---------------------+
-| extract_1d          |
-+---------------------+
-| white_light         |
-+---------------------+
++---------------------------------------------------------------------------------------------------+
+| :py:class:`calwebb_tso3 <jwst.pipeline.calwebb_tso3.Tso3Pipeline>`                                |
++===================================================================================================+
+| :py:class:`outlier_detection <jwst.outlier_detection.outlier_detection_step.OutlierDetectionStep` |
++---------------------------------------------------------------------------------------------------+
+| :py:class:`extract_1d <jwst.extract_1d.extract_1d_step.Extract1dStep>`                            |
++---------------------------------------------------------------------------------------------------+
+| :py:class:`white_light <jwst.white_light.white_light_step.WhiteLightStep>`                        |
++---------------------------------------------------------------------------------------------------+
 
 Inputs
 ------

--- a/docs/jwst/pipeline/description.rst
+++ b/docs/jwst/pipeline/description.rst
@@ -63,20 +63,20 @@ pipeline is as follows.
 calwebb_detector1 calwebb_detector1
 (All Near-IR)     (MIRI)
 ================= =================
-group_scale     group_scale
-dq_init         dq_init
-saturation      saturation
-ipc             ipc
-superbias       linearity
-refpix          rscd
-linearity       lastframe
-persistence     dark_current
-dark_current    refpix
-\               persistence
-jump            jump
-ramp_fit        ramp_fit
-gain_scale      gain_scale
-==============  ==============
+group_scale       group_scale
+dq_init           dq_init
+saturation        saturation
+ipc               ipc
+superbias         linearity
+refpix            rscd
+linearity         lastframe
+persistence       dark_current
+dark_current      refpix
+\                 persistence
+jump              jump
+ramp_fit          ramp_fit
+gain_scale        gain_scale
+================= =================
 
 Inputs
 ------
@@ -329,7 +329,7 @@ Outputs
 * Resampled 2D Image product (:ref:`DrizProductModel`): A resampled/rectified 2D image product of type
   ``_i2d`` is created containing the rectified single exposure or the rectified
   and combined association of exposures, which is the direct output of the
-  ``resample`` step. This is the
+  ``resample`` step.
 
 * Source catalog: A source catalog produced from the ``_i2d`` product is saved
   as an ASCII file in ``ecsv`` format, with a product type of ``_cat``.
@@ -365,7 +365,7 @@ Inputs
 * Associated 2D Calibrated products: The inputs to ``calwebb_ami3`` are assumed
   to be in the form of an ASN file that lists multiple science target exposures,
   and optionally reference target exposures as well. The individual exposures
-  should be in the form of calibrated (``_cal``) products from ``calwebb_image2``
+  should be in the form of calibrated (``_cal``) pro        ducts from ``calwebb_image2``
   processing.
 
 Outputs
@@ -395,3 +395,133 @@ The ``calwebb_ami3`` pipeline has one optional argument:
 which is a Boolean parameter set to a default value of ``False``. If the user
 sets this agument to ``True``, the results of the ``ami_average`` step will be
 saved, as described above.
+
+
+Stage 3 Time-Series Observation(TSO) Pipeline Step Flow (calwebb_tso3)
+===============================================================================
+The stage 3 TSO pipeline (``calwebb_tso3``) is intended to be applied to
+associations of calibrated NIRISS SOSS and NIRCam TSO exposures and is used to
+produce calibrated time-series photometry of the source object.
+
+The steps applied by the ``calwebb_tso3`` pipeline are shown below for
+a NIRCam TSO observation:
+
++---------------------+
+| calwebb_tso3        |
++=====================+
+| outlier_detection   |
++---------------------+
+| tso_photometry      |
++---------------------+
+
+The steps applied by the ``calwebb_tso3`` pipeline are shown below for a
+NIRISS SOSS observation:
+
++---------------------+
+| calwebb_tso3        |
++=====================+
+| outlier_detection   |
++---------------------+
+| extract_1d          |
++---------------------+
+| white_light         |
++---------------------+
+
+Inputs
+------
+
+* Associated 2D Calibrated products: The input to ``calwebb_tso3`` is assumed
+  to be in the form of an ASN file that lists multiple science observations of
+  a science target either with NIRCam or NIRISS. The individual NIRCam exposures
+  should be in the form of calibrated (``_cal``) products from ``calwebb_image2``
+  processing, while the individual NIRISS exposures should be in the form of
+  calibrated (``_calints``) products from ``calwebb_spec2``.
+
+Outputs
+-------
+
+* CR-flagged products: If the
+  :py:class:`~jwst.outlier_detection.outlier_detection_step.OutlierDetectionStep`
+  step is applied, a new version
+  of each input calibrated exposure product is created, which contains a DQ array
+  that has been updated to flag pixels detected as outliers. This updated
+  product is known as a CR-flagged product. A outlier-cleaned calibrated product of
+  type ``_crfints`` is created and can optionally get written to disk.
+
+* Source photometry catalog for NIRCam observations: A source catalog produced
+  from the ``_crfints`` product is saved as an ASCII file in ``ecsv`` format
+  with a product type of ``_phot``.
+
+* Extracted 1D spectra for NIRISS SOSS observations: The ``extract_1d`` step is
+  applied to create a ``MultiSpecModel`` for the entire set of SOSS
+  observations with a product type of ``_x1dints``.
+
+* White-light photometry for NIRISS SOSS observations:  The ``white_light`` step
+  is applied to the ``_x1dints`` extracted data to produce an ASCII catalog
+  in ``ecsv`` format with a product type of ``_whtlht`` of
+  the white-light photometry of the source object.
+
+
+Stage 3 CORONOGRAPHIC Observation Pipeline Step Flow (calwebb_coron3)
+===============================================================================
+  The stage 3 TSO pipeline (``calwebb_tso3``) is intended to be applied to
+  associations of calibrated NIRISS SOSS and NIRCam TSO exposures and is used to
+  produce calibrated time-series photometry of the source object.
+
+  The steps applied by the ``calwebb_tso3`` pipeline are shown below for
+  a NIRCam TSO observation:
+
+  +---------------------+
+  | calwebb_tso3        |
+  +=====================+
+  | outlier_detection   |
+  +---------------------+
+  | tso_photometry      |
+  +---------------------+
+
+  The steps applied by the ``calwebb_tso3`` pipeline are shown below for a
+  NIRISS SOSS observation:
+
+  +---------------------+
+  | calwebb_tso3        |
+  +=====================+
+  | outlier_detection   |
+  +---------------------+
+  | extract_1d          |
+  +---------------------+
+  | white_light         |
+  +---------------------+
+
+Inputs
+------
+
+* Associated 2D Calibrated products: The input to ``calwebb_tso3`` is assumed
+  to be in the form of an ASN file that lists multiple science observations of
+  a science target either with NIRCam or NIRISS. The individual NIRCam exposures
+  should be in the form of calibrated (``_cal``) products from ``calwebb_image2``
+  processing, while the individual NIRISS exposures should be in the form of
+  calibrated (``_calints``) products from ``calwebb_spec2``.
+
+Outputs
+-------
+
+* CR-flagged products: If the
+  :py:class:`~outlier_detection.outlier_detection_step.OutlierDetectionStep`
+  step is applied, a new version
+  of each input calibrated exposure product is created, which contains a DQ array
+  that has been updated to flag pixels detected as outliers. This update
+  product is known as a CR-flagged product. A outlier-cleaned calibrated product of
+  type ``_crfints`` is created and can optionally get written to disk.
+
+* Source photometry catalog for NIRCam observations: A source catalog produced
+  from the ``_crfints`` product is saved as an ASCII file in ``ecsv`` format
+  with a product type of ``_phot``.
+
+* Extracted 1D spectra for NIRISS SOSS observations: The ``extract_1d`` step is
+  applied to create a ``MultiSpecModel`` for the entire set of SOSS
+  observations with a product type of ``_x1dints``.
+
+* White-light photometry for NIRISS SOSS observations:  The ``white_light`` step
+  is applied to the ``_x1dints`` extracted data to produce an ASCII catalog
+  in ``ecsv`` format with a product type of ``_whtlht`` of
+  the white-light photometry of the source object.

--- a/jwst/pipeline/calwebb_coron3.py
+++ b/jwst/pipeline/calwebb_coron3.py
@@ -22,11 +22,12 @@ class Coron3Pipeline(Pipeline):
 
     Coron3Pipeline: Apply all level-3 calibration steps to a
     coronagraphic association of exposures. Included steps are:
-    stack_refs (assemble reference PSF inputs)
-    align_refs (align reference PSFs to target images)
-    klip (PSF subtraction using the KLIP algorithm)
-    outlier_detection (flag outliers)
-    resample (image combination and resampling)
+
+    #. stack_refs (assemble reference PSF inputs)
+    #. align_refs (align reference PSFs to target images)
+    #. klip (PSF subtraction using the KLIP algorithm)
+    #. outlier_detection (flag outliers)
+    #. resample (image combination and resampling)
 
     """
 

--- a/jwst/pipeline/calwebb_tso3.py
+++ b/jwst/pipeline/calwebb_tso3.py
@@ -1,7 +1,5 @@
 from __future__ import unicode_literals, absolute_import
 
-import os
-
 from astropy.table import vstack
 
 from ..stpipe import Pipeline
@@ -21,10 +19,11 @@ class Tso3Pipeline(Pipeline):
                     any JWST instrument.
 
     Included steps are:
-        outlier_detection
-        tso_photometry
-        extract_1d
-        white_light
+
+        * outlier_detection
+        * tso_photometry
+        * extract_1d
+        * white_light
     """
 
     spec = """
@@ -33,7 +32,7 @@ class Tso3Pipeline(Pipeline):
 
     # Define alias to steps
     step_defs = {'outlier_detection':
-                        outlier_detection_step.OutlierDetectionStep,
+                 outlier_detection_step.OutlierDetectionStep,
                  'tso_photometry': tso_photometry_step.TSOPhotometryStep,
                  'extract_1d': extract_1d_step.Extract1dStep,
                  'white_light': white_light_step.WhiteLightStep
@@ -66,13 +65,14 @@ class Tso3Pipeline(Pipeline):
                 # convert each plane of data cube into it own array
                 # for outlier detection...
                 image = datamodels.ImageModel(data=cube.data[i],
-                        err=cube.err[i], dq=cube.dq[i])
+                                              err=cube.err[i], dq=cube.dq[i])
                 image.update(cube)
                 image.meta.wcs = cube.meta.wcs
                 input_2dmodels.append(image)
 
             if not self.scale_detection:
-                self.log.info("Performing outlier detection on input images...")
+                l = "Performing outlier detection on input images..."
+                self.log.info(l)
                 input_2dmodels = self.outlier_detection(input_2dmodels)
 
                 # Transfer updated DQ values to original input observation
@@ -83,7 +83,8 @@ class Tso3Pipeline(Pipeline):
                     input_2dmodels[0].meta.cal_step.outlier_detection
 
             else:
-                self.log.info("Performing scaled outlier detection on input images...")
+                l = "Performing scaled outlier detection on input images..."
+                self.log.info(l)
                 self.outlier_detection.scale_detection = True
                 cube = self.outlier_detection(cube)
 
@@ -128,14 +129,16 @@ class Tso3Pipeline(Pipeline):
                 phot_result_list.append(self.white_light(result))
 
             # Update some metadata from the association
-            x1d_result.meta.asn.pool_name = input_models.meta.asn_table.asn_pool
+            x1d_result.meta.asn.pool_name = \
+                input_models.meta.asn_table.asn_pool
             x1d_result.meta.asn.table_name = input
 
             # Save the final x1d Multispec model
             self.save_model(x1d_result, suffix='x1dints')
 
         phot_results = vstack(phot_result_list)
-        self.log.info("Writing Level 3 photometry catalog {}...".format(phot_tab_name))
+        self.log.info("Writing Level 3 photometry catalog {}...".format(
+                      phot_tab_name))
         phot_results.write(phot_tab_name, format='ascii.ecsv')
 
         return


### PR DESCRIPTION
Pipeline documentation has been updated to include a basic description of the CALTSO3 and CALCORON3 pipelines.  This update included making some PEP8 corrections to calwebb_tso3 while also making the docstrings a little more user-friendly.  

The documentation also implements cross-references to the Step API's for all the steps called by each of the pipelines.  These cross-references will also take advantage of the updates implemented in PR #1516 to provide improved documentation for the outlier_detection steps used by these pipelines.  

Finally, the coron3 step documentation was also updated to provide API references that could be called from the pipeline documentation.  