### PR TITLE
Remove the import in __init__.py.  See issue #1392.

### DIFF
--- a/jwst/flatfield/__init__.py
+++ b/jwst/flatfield/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from .flat_field_step import FlatFieldStep
 
 __version__ = '0.8.0'


### PR DESCRIPTION
I had forgotten this file.  I had a `from __future__ import absolute_import` statement, which has now been removed.