### PR TITLE
Update caltso3 to pass along filenames

### DIFF
--- a/jwst/outlier_detection/outlier_detection.py
+++ b/jwst/outlier_detection/outlier_detection.py
@@ -102,7 +102,9 @@ class OutlierDetection(object):
                 image = datamodels.ImageModel(data=self.inputs.data[i],
                                               err=self.inputs.err[i],
                                               dq=self.inputs.dq[i])
-                image.meta = self.inputs.meta
+                image.update(self.inputs)
+                image.meta.wcs = self.inputs.meta.wcs
+                image.meta.filename = self.inputs.meta.filename
                 image.wht = build_driz_weight(image,
                                               wht_type='exptime',
                                               good_bits=bits)

--- a/jwst/pipeline/calwebb_tso3.py
+++ b/jwst/pipeline/calwebb_tso3.py
@@ -29,7 +29,7 @@ class Tso3Pipeline(Pipeline):
 
     # Define alias to steps
     step_defs = {'outlier_detection':
-                        outlier_detection_step.OutlierDetectionStep,
+                 outlier_detection_step.OutlierDetectionStep,
                  'tso_photometry': tso_photometry_step.TSOPhotometryStep,
                  'extract_1d': extract_1d_step.Extract1dStep,
                  'white_light': white_light_step.WhiteLightStep
@@ -50,7 +50,6 @@ class Tso3Pipeline(Pipeline):
         self.log.info('Starting calwebb_tso3...')
         input_models = datamodels.open(input)
         self.output_basename = input_models.meta.asn_table.products[0].name
-
         input_exptype = None
         # Input may consist of multiple exposures, so loop over each of them
         for cube in input_models:
@@ -62,13 +61,15 @@ class Tso3Pipeline(Pipeline):
                 # convert each plane of data cube into it own array
                 # for outlier detection...
                 image = datamodels.ImageModel(data=cube.data[i],
-                        err=cube.err[i], dq=cube.dq[i])
+                                              err=cube.err[i], dq=cube.dq[i])
                 image.update(cube)
+                image.meta.filename = cube.meta.filename
                 image.meta.wcs = cube.meta.wcs
                 input_2dmodels.append(image)
 
             if not self.scale_detection:
-                self.log.info("Performing outlier detection on input images...")
+                l = "Performing outlier detection on input images..."
+                self.log.info(l)
                 input_2dmodels = self.outlier_detection(input_2dmodels)
 
                 # Transfer updated DQ values to original input observation
@@ -79,7 +80,8 @@ class Tso3Pipeline(Pipeline):
                     input_2dmodels[0].meta.cal_step.outlier_detection
 
             else:
-                self.log.info("Performing scaled outlier detection on input images...")
+                l = "Performing scaled outlier detection on input images..."
+                self.log.info(l)
                 self.outlier_detection.scale_detection = True
                 cube = self.outlier_detection(cube)
 
@@ -124,14 +126,16 @@ class Tso3Pipeline(Pipeline):
                 phot_result_list.append(self.white_light(result))
 
             # Update some metadata from the association
-            x1d_result.meta.asn.pool_name = input_models.meta.asn_table.asn_pool
+            x1d_result.meta.asn.pool_name = \
+                input_models.meta.asn_table.asn_pool
             x1d_result.meta.asn.table_name = input
 
             # Save the final x1d Multispec model
             self.save_model(x1d_result, suffix='x1dints')
 
         phot_results = vstack(phot_result_list)
-        self.log.info("Writing Level 3 photometry catalog {}...".format(phot_tab_name))
+        self.log.info("Writing Level 3 photometry catalog {}...".format(
+                      phot_tab_name))
         phot_results.write(phot_tab_name, format='ascii.ecsv')
 
         return


### PR DESCRIPTION
This PR addresses problems with CALTSO3 not passing along the filename to outlier_detection, since apparently filename is an attribute which is NOT updated with the .update() method for datamodels.  

Testing indicates it will resolve the regression test errors showing up as of 24 Nov.