### PR TITLE
Remove Python2 compatibility from stpipe

### DIFF
--- a/jwst/stpipe/__init__.py
+++ b/jwst/stpipe/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import sys
 if sys.version_info[0] >= 3:
     __builtins__['unicode'] = str

--- a/jwst/stpipe/cmdline.py
+++ b/jwst/stpipe/cmdline.py
@@ -1,19 +1,10 @@
 """
 Various utilities to handle running Steps from the commandline.
 """
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-    unicode_literals
-)
-
-# import cProfile
 import io
 import os
 import os.path
 import textwrap
-import six
 
 from . import config_parser
 from . import log
@@ -225,12 +216,8 @@ def just_the_step_from_cmdline(args, cls=None):
                     "Error parsing logging config {0!r}:\n{1}".format(
                         log_config, e))
     except Exception as e:
-        if six.PY2:
-            _print_important_message(
-                "ERROR PARSING CONFIGURATION:", unicode(e))
-        else:
-            _print_important_message(
-                "ERROR PARSING CONFIGURATION:", str(e))
+        _print_important_message(
+            "ERROR PARSING CONFIGURATION:", str(e))
         parser1.print_help()
         raise
 
@@ -258,17 +245,9 @@ def just_the_step_from_cmdline(args, cls=None):
             config, name=name, config_file=config_file)
     except config_parser.ValidationError as e:
         # If the configobj validator failed, print usage information.
-        if six.PY2:
-            _print_important_message(
-                "ERROR PARSING CONFIGURATION:",
-                unicode(e)
-            )
-            parser2.print_help()
-            raise ValueError(unicode(e))
-        else:
-            _print_important_message("ERROR PARSING CONFIGURATION:", str(e))
-            parser2.print_help()
-            raise ValueError(str(e))
+        _print_important_message("ERROR PARSING CONFIGURATION:", str(e))
+        parser2.print_help()
+        raise ValueError(str(e))
 
     # Define the primary input file.
     if len(positional):
@@ -321,14 +300,9 @@ def step_from_cmdline(args, cls=None):
     except Exception as e:
         import traceback
         lines = traceback.format_exc()
-        if six.PY2:
-            _print_important_message(
-                "ERROR RUNNING STEP {0!r}:".format(step_class.__name__),
-                unicode(e), lines)
-        else:
-            _print_important_message(
-                "ERROR RUNNING STEP {0!r}:".format(step_class.__name__),
-                str(e), lines)
+        _print_important_message(
+            "ERROR RUNNING STEP {0!r}:".format(step_class.__name__),
+            str(e), lines)
 
         if debug_on_exception:
             import pdb

--- a/jwst/stpipe/config_parser.py
+++ b/jwst/stpipe/config_parser.py
@@ -29,12 +29,9 @@
 """
 Our configuration files are ConfigObj/INI files.
 """
-from __future__ import absolute_import, division, print_function
-
 import os
 import os.path
 import textwrap
-import six
 
 from .configobj.configobj import ConfigObj, Section, \
      flatten_errors, get_extra_values
@@ -55,10 +52,7 @@ def _get_input_file_check(root_dir):
     def _input_file_check(path):
         if not isinstance(path, cmdline.FromCommandLine):
             try:
-                if six.PY2:
-                    path = unicode(path)
-                else:
-                    path = str(path)
+                path = str(path)
             except ValueError:
                 pass
 
@@ -82,10 +76,7 @@ def _get_output_file_check(root_dir):
     def _output_file_check(path):
         if not isinstance(path, cmdline.FromCommandLine):
             try:
-                if six.PY2:
-                    path = unicode(path)
-                else:
-                    path = str(path)
+                path = str(path)
             except ValueError:
                 pass
 
@@ -152,7 +143,7 @@ def load_spec_file(cls, preserve_comments=False):
         spec_file = spec_file.split('\n')
         encoded = []
         for line in spec_file:
-            if isinstance(line, six.text_type):
+            if isinstance(line, str):
                 encoded.append(line.encode('utf8'))
             else:
                 encoded.append(line)

--- a/jwst/stpipe/function_wrapper.py
+++ b/jwst/stpipe/function_wrapper.py
@@ -29,8 +29,6 @@
 """
 A Step whose only purpose is to wrap an ordinary function.
 """
-from __future__ import absolute_import, division, print_function
-
 from . import Step
 
 

--- a/jwst/stpipe/hooks.py
+++ b/jwst/stpipe/hooks.py
@@ -29,8 +29,6 @@
 """
 Pre- and post-hooks
 """
-from __future__ import absolute_import, division, print_function
-
 import types
 
 from . import Step

--- a/jwst/stpipe/linear_pipeline.py
+++ b/jwst/stpipe/linear_pipeline.py
@@ -30,12 +30,8 @@
 LinearPipeline
 
 """
-
-from __future__ import absolute_import, division, print_function
-
 import gc
 
-import six
 from .pipeline import Pipeline
 
 
@@ -54,8 +50,7 @@ class _LinearPipelineMetaclass(type):
 # Since the pipeline_steps member needs to be converted to a step_defs
 # at the class level, we need to use a metaclass.
 
-@six.add_metaclass(_LinearPipelineMetaclass)
-class LinearPipeline(Pipeline):
+class LinearPipeline(Pipeline, metaclass=_LinearPipelineMetaclass):
     """
     A LinearPipeline is a way of combining a number of steps together
     in a simple linear order.

--- a/jwst/stpipe/log.py
+++ b/jwst/stpipe/log.py
@@ -29,8 +29,6 @@
 """
 Logging setup etc.
 """
-from __future__ import absolute_import, division, print_function
-
 import fnmatch
 import io
 import logging
@@ -91,7 +89,7 @@ class BreakHandler(logging.Handler):
 log_config = {}
 
 
-class LogConfig(object):
+class LogConfig():
     """
     Stores a single logging configuration.
 

--- a/jwst/stpipe/pipeline.py
+++ b/jwst/stpipe/pipeline.py
@@ -30,12 +30,7 @@
 Pipeline
 
 """
-
-from __future__ import absolute_import, division, print_function
-
-import gc
-from os.path import dirname, join, split, splitext
-import re
+from os.path import dirname, join
 
 from .configobj.configobj import Section
 
@@ -83,13 +78,13 @@ class Pipeline(Step):
 
     def _collect_active_reftypes(self):
         """Collect the list of all reftypes for child Steps that are not skipped.
-        Overridden reftypes are included but handled normally later by the Pipeline 
+        Overridden reftypes are included but handled normally later by the Pipeline
         version of the _get_ref_override() method defined below.
         """
         return [reftype for step in self._unskipped_steps
                 for reftype in step.reference_file_types]
 
-    @property 
+    @property
     def _unskipped_steps(self):
         """Return a list of the unskipped Step objects launched by `self`."""
         return [getattr(self, name) for name in self.step_defs.keys()
@@ -98,7 +93,7 @@ class Pipeline(Step):
     def _get_ref_override(self, reference_file_type):
         """Return any override for `reference_file_type` for any of the steps in
         Pipeline `self`.  OVERRIDES Step.
-        
+
         Returns
         -------
         override_filepath or None.
@@ -109,7 +104,7 @@ class Pipeline(Step):
             if override is not None:
                 return override
         return None
-            
+
     @classmethod
     def merge_config(cls, config, config_file):
         steps = config.get('steps', {})

--- a/jwst/stpipe/step.py
+++ b/jwst/stpipe/step.py
@@ -1,14 +1,10 @@
 """
 Step
 """
-from __future__ import absolute_import, division, print_function
-
 import gc
 from os.path import dirname, join, basename, splitext, abspath, split
 import re
 import sys
-
-import six
 
 try:
     from astropy.io import fits
@@ -31,7 +27,7 @@ REMOVE_SUFFIX = '^(?P<root>.+?)((?P<separator>_|-)(' \
                 + '|'.join(SUFFIX_LIST) + '))?$'
 
 
-class Step(object):
+class Step():
     """
     Step
     """
@@ -167,7 +163,7 @@ class Step(object):
         if not name:
             name = config.get('name')
             if not name:
-                if isinstance(config_file, six.string_types):
+                if isinstance(config_file, str):
                     name = splitext(basename(config_file))[0]
                 else:
                     name = step_class.__name__

--- a/jwst/stpipe/subproc.py
+++ b/jwst/stpipe/subproc.py
@@ -26,8 +26,6 @@
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
 # DAMAGE.
-from __future__ import absolute_import, division, print_function
-
 import os
 import subprocess
 

--- a/jwst/stpipe/tests/__init__.py
+++ b/jwst/stpipe/tests/__init__.py
@@ -1,6 +1,5 @@
-from __future__ import absolute_import, division, print_function
-
 import io
+
 
 def setup():
     from ..stpipe import log

--- a/jwst/stpipe/tests/steps/local.py
+++ b/jwst/stpipe/tests/steps/local.py
@@ -1,10 +1,9 @@
-from __future__ import absolute_import, division, print_function
-
 from jwst.stpipe import Step
 import logging
 
 log = logging.getLogger("FOO")
 log.setLevel(logging.DEBUG)
+
 
 class DummyStep(Step):
     """

--- a/jwst/stpipe/tests/test_crds.py
+++ b/jwst/stpipe/tests/test_crds.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, print_function
-
 from os.path import join, dirname, basename
 import shutil
 import tempfile
@@ -7,7 +5,6 @@ import tempfile
 from nose.tools import raises
 
 from astropy.io import fits
-import six
 
 from jwst.stpipe import Step
 import crds
@@ -134,5 +131,3 @@ def test_crds_failed_getreferences_reftype():
 #         u'meta.telescope': 'JWST'
 #         }
 #     assert_raises(crds.getreferences, header, reftypes=["foo"], context="jwst_9942.pmap")
-
-

--- a/jwst/stpipe/tests/test_logger.py
+++ b/jwst/stpipe/tests/test_logger.py
@@ -26,9 +26,6 @@
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
 # DAMAGE.
-
-from __future__ import absolute_import, division, print_function
-
 import io
 
 from .. import log as stpipe_log

--- a/jwst/stpipe/tests/test_pipeline.py
+++ b/jwst/stpipe/tests/test_pipeline.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, print_function
-
 import os
 from os.path import dirname, join, abspath
 import sys

--- a/jwst/stpipe/tests/test_saving.py
+++ b/jwst/stpipe/tests/test_saving.py
@@ -1,7 +1,4 @@
 """Test step/pipeline saving"""
-
-from __future__ import absolute_import, division, print_function
-
 import os
 from os.path import (
     dirname,

--- a/jwst/stpipe/tests/test_step.py
+++ b/jwst/stpipe/tests/test_step.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 from os.path import (
     abspath,
     dirname,

--- a/jwst/stpipe/utilities.py
+++ b/jwst/stpipe/utilities.py
@@ -29,8 +29,6 @@
 """
 Utilities
 """
-from __future__ import absolute_import, division, print_function
-
 import inspect
 import os
 import sys


### PR DESCRIPTION
Note: The `configobj` folder is third-party code and has been left
untouched. If the need is felt to deal with this, the code should
first be updated from the source.

WIP #1392