### PR TITLE
Check whether ramp_fit was skipped

### DIFF
--- a/jwst/pipeline/calwebb_detector1.py
+++ b/jwst/pipeline/calwebb_detector1.py
@@ -118,7 +118,15 @@ class Detector1Pipeline(Pipeline):
             self.save_model(input, 'ramp')
 
         # apply the ramp_fit step
-        input, ints_model = self.ramp_fit(input)
+        # This explicit test on self.ramp_fit.skip is a temporary workaround
+        # to fix the problem that the ramp_fit step ordinarily returns two
+        # objects, but when the step is skipped due to `skip = True` in a
+        # cfg file, only the input is returned when the step is invoked.
+        if self.ramp_fit.skip:
+            input = self.ramp_fit(input)
+            ints_model = None
+        else:
+            input, ints_model = self.ramp_fit(input)
 
         # apply the gain_scale step to the exposure-level product
         input = self.gain_scale(input)


### PR DESCRIPTION
The ramp_fit step normally returns two objects.  When ramp_fit is run
in calwebb_detector1, however, the user can specify that the step be
skipped, in which case the step will return just one object, the input
model.  This will fail in the pipeline because the code explicitly
receives two objects from the step, but only one was returned.  This
can be (temporarily) fixed by checking the `skip` flag.  See issue #1532.