### PR TITLE
Remove references to Python 2

### DIFF
--- a/jwst/ipc/__init__.py
+++ b/jwst/ipc/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from .ipc_step import IPCStep
 
 __version__ = '0.8.0'

--- a/jwst/ipc/ipc_corr.py
+++ b/jwst/ipc/ipc_corr.py
@@ -1,5 +1,3 @@
-from __future__ import division, print_function, absolute_import
-
 #
 #  Module for IPC correction.
 #


### PR DESCRIPTION
The only things that needed to be removed were the
"from __future__ import ..." statements.  See issue #1392