### PR TITLE
Remove references to python 2

### DIFF
--- a/jwst/source_catalog/__init__.py
+++ b/jwst/source_catalog/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from .source_catalog_step import SourceCatalogStep
 
 __version__ = '0.8.0'

--- a/jwst/tso_photometry/__init__.py
+++ b/jwst/tso_photometry/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from .tso_photometry_step import TSOPhotometryStep
 
 __version__ = '0.8.0'

--- a/jwst/tweakreg_catalog/__init__.py
+++ b/jwst/tweakreg_catalog/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from .tweakreg_catalog_step import TweakregCatalogStep
 
 __version__ = '0.8.0'


### PR DESCRIPTION
This required removing only `__future__` imports.
See https://github.com/STScI-JWST/jwst/issues/1392.