### PR TITLE
Use wavelength array in preference to wcs function.

### DIFF
--- a/jwst/flatfield/flat_field.py
+++ b/jwst/flatfield/flat_field.py
@@ -304,10 +304,17 @@ def do_NIRSpec_flat_field(output_model,
         got_wcs = hasattr(slit.meta, "wcs") and slit.meta.wcs is not None
 
         # Get the wavelength at each pixel in the extracted slit data.
-        wl = slit.wavelength                    # a 2-D array
+        # If the wavelength attribute exists and is populated, use it
+        # in preference to the wavelengths returned by the wcs function.
         got_wl_attribute = True
-        # There must be either a wavelength array or a meta.wcs.
-        if wl.min() == 0. and wl.max() == 0.:
+        try:
+            wl = slit.wavelength                # a 2-D array
+        except AttributeError:
+            got_wl_attribute = False
+        # The default value is 0, so all 0 values means that the
+        # wavelength attribute was not populated.  We need either a
+        # wavelength array or a meta.wcs.
+        if not got_wl_attribute or wl.min() == 0. and wl.max() == 0.:
             got_wl_attribute = False
             log.warning("The wavelength array for slit %s has not "
                         "been populated,", slit.name)

--- a/jwst/flatfield/flat_field.py
+++ b/jwst/flatfield/flat_field.py
@@ -301,34 +301,47 @@ def do_NIRSpec_flat_field(output_model,
         xstop = xstart + xsize
         ystop = ystart + ysize
 
-        # Make sure there is a WCS.
-        if not hasattr(slit.meta, "wcs") or slit.meta.wcs is None:
-            log.error("Slit %s does not have a 'wcs' attribute.", slit.name)
-            if output_model.meta.cal_step.assign_wcs == 'COMPLETE':
-                raise RuntimeError("WCS was not found, but it isn't clear "
-                                   "why not.")
-            else:
-                raise RuntimeError("The assign_wcs step has not been run.")
+        got_wcs = hasattr(slit.meta, "wcs") and slit.meta.wcs is not None
 
-        # Get the wavelength of each pixel in the extracted slit data.
-        # pixels with respect to the cutout
-        grid = np.indices((ysize, xsize), dtype=np.float64)
-        # The arguments are the X and Y pixel coordinates (in that order).
-        (ra, dec, wl) = slit.meta.wcs(grid[1], grid[0])
-        del ra, dec, grid
+        # Get the wavelength at each pixel in the extracted slit data.
+        wl = slit.wavelength                    # a 2-D array
+        got_wl_attribute = True
+        # There must be either a wavelength array or a meta.wcs.
+        if wl.min() == 0. and wl.max() == 0.:
+            got_wl_attribute = False
+            log.warning("The wavelength array for slit %s has not "
+                        "been populated,", slit.name)
+            if got_wcs:
+                log.warning("so using wcs instead of the wavelength array.")
+                # Pixels with respect to the cutout
+                grid = np.indices((ysize, xsize), dtype=np.float64)
+                # The arguments are the X and Y pixel coordinates.
+                (ra, dec, wl) = slit.meta.wcs(grid[1], grid[0])
+                del ra, dec, grid
+            else:
+                log.warning("and this slit does not have a 'wcs' attribute")
+                if output_model.meta.cal_step.assign_wcs == 'COMPLETE':
+                    log.warning("assign_wcs has been run, however.")
+                else:
+                    log.warning("likely because assign_wcs has not been run.")
+                log.error("skipping ...")
+                continue
+        else:
+            log.debug("Wavelengths are from the wavelength array.")
+
         nan_mask = np.isnan(wl)
         good_mask = np.logical_not(nan_mask)
         sum_nan_mask = nan_mask.sum(dtype=np.intp)
         sum_good_mask = good_mask.sum(dtype=np.intp)
         if sum_nan_mask > 0:
-            log.debug("Number of NaNs in sci wavelength array = %s out of %s",
+            log.debug("Number of NaNs in sci wavelength array = %d out of %d",
                       sum_nan_mask, sum_nan_mask + sum_good_mask)
             if sum_good_mask < 1:
                 log.warning("(all are NaN)")
             # Replace NaNs with a harmless but out-of-bounds value.
             wl[nan_mask] = -1000.
         if wl.max() > 0. and wl.max() < MICRONS_100:
-            log.warning("Wavelengths in SCI data appear to be in meters.")
+            log.warning("Wavelengths in science data appear to be in meters.")
 
         # Combine the three flat fields for the current subarray.
         (flat_2d, flat_dq_2d) = create_flat_field(wl,
@@ -346,6 +359,7 @@ def do_NIRSpec_flat_field(output_model,
             # Save flat_2d and flat_dq_2d for an output file.
             new_flat = datamodels.ImageModel(data=flat_2d, dq=flat_dq_2d)
             interpolated_flats.slits.append(new_flat.copy())
+            del new_flat
             interpolated_flats.slits[k].err[...] = 1.   # xxx not realistic
             # xxx There's more info that could be copied over.
             interpolated_flats.slits[k].name = slit.name
@@ -353,9 +367,12 @@ def do_NIRSpec_flat_field(output_model,
             interpolated_flats.slits[k].xsize = slit.xsize
             interpolated_flats.slits[k].ystart = slit.ystart
             interpolated_flats.slits[k].ysize = slit.ysize
+            if got_wl_attribute:
+                interpolated_flats.slits[k].wavelength = wl.copy()
             # Copy the WCS info from output (same as input).
-            interpolated_flats.slits[k].meta.wcs = \
-                  output_model.slits[k].meta.wcs
+            if got_wcs:
+                interpolated_flats.slits[k].meta.wcs = \
+                      output_model.slits[k].meta.wcs
 
         slit.data /= flat_2d
         slit.err /= flat_2d
@@ -447,13 +464,15 @@ def NIRSpec_brightobj(output_model,
             log.error("Skipping flat_field.")
             output_model.meta.cal_step.flat_field = 'SKIPPED'
             return None
+    else:
+        log.debug("Wavelengths are from the wavelength array.")
 
     nan_mask = np.isnan(wl)
     good_mask = np.logical_not(nan_mask)
     sum_nan_mask = nan_mask.sum(dtype=np.intp)
     sum_good_mask = good_mask.sum(dtype=np.intp)
     if sum_nan_mask > 0:
-        log.debug("Number of NaNs in wavelength array = %s out of %s",
+        log.debug("Number of NaNs in wavelength array = %d out of %d",
                   sum_nan_mask, sum_nan_mask + sum_good_mask)
         if sum_good_mask < 1:
             log.warning("(all are NaN)")


### PR DESCRIPTION
For NIRSpec spectroscopic data, the flat_field step computes the wavelength
at each pixel by calling the WCS function (except for BRIGHTOBJ data, which
already get the wavelength from the wavelength attribute).  If the wavelength
attribute exists and is populated (i.e. not all zeros), that should be used
for the wavelengths instead.  See issue #1374.