### PR TITLE
Modify test for nonexistent WAVELENGTH extension

### DIFF
--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -921,7 +921,10 @@ class ExtractModel:
 
         # If the wavelength attribute exists and is populated, use it
         # in preference to the wavelengths returned by the wcs function.
-        got_wavelength = (wl_array is not None)
+        if wl_array is None or len(wl_array) == 0:
+            got_wavelength = False
+        else:
+            got_wavelength = True               # may be reset later
 
         # The default value is 0, so all 0 values means that the
         # wavelength attribute was not populated.


### PR DESCRIPTION
When there is no WAVELENGTH extension in the input file, the shape of the
wavelength attribute is apparently (0, 0) rather than being the shape of
the science data.  Using .min() or .max() on such an array fails.
See issue #1374.