### PR TITLE
enable MIRI MRS tests

### DIFF
--- a/jwst/assign_wcs/tests/test_miri.py
+++ b/jwst/assign_wcs/tests/test_miri.py
@@ -19,9 +19,9 @@ Notes:
 Both notes have been communicated to the INS team.
 
 """
-import pytest
 import numpy as np
 from astropy.io import fits
+from astropy.modeling.models import Scale, Shift, Identity
 from gwcs import wcs
 from numpy.testing import utils
 
@@ -45,22 +45,26 @@ band_mapping = {'SHORT': 'A', 'MEDIUM': 'B', 'LONG': 'C'}
 def create_hdul(detector, channel, band):
     hdul = fits.HDUList()
     phdu = fits.PrimaryHDU()
+    phdu.header['filename'] = "test" + channel + band
     phdu.header['instrume'] = 'MIRI'
     phdu.header['detector'] = detector
     phdu.header['CHANNEL'] = channel
     phdu.header['BAND'] = band
     phdu.header['time-obs'] = '8:59:37'
-    phdu.header['date-obs'] = '2014-09-05'
+    phdu.header['date-obs'] = '2017-09-05'
     phdu.header['exp_type'] = 'MIR_MRS'
-    phdu.header.update(wcs_kw)
+    scihdu = fits.ImageHDU()
+    scihdu.header.update(wcs_kw)
     hdul.append(phdu)
+    hdul.append(scihdu)
     return hdul
 
 
 def create_datamodel(hdul):
     im = ImageModel(hdul)
     ref = create_reference_files(im)
-
+    print('in create_datamodel', ref['distortion'])
+    print(im.meta.instrument.band)
     pipeline = miri.create_pipeline(im, ref)
     wcsobj = wcs.WCS(pipeline)
     im.meta.wcs = wcsobj
@@ -81,13 +85,13 @@ def run_test(model):
     for ch in model.meta.instrument.channel:
         ref_data = mrs_ref_data[ch + band_mapping[model.meta.instrument.band]]
         detector_to_alpha_beta = wcsobj.get_transform('detector', 'alpha_beta')
-        ab_to_xan_yan = wcsobj.get_transform('alpha_beta', 'Xan_Yan').set_input(int(ch))
+        #ab_to_xan_yan = wcsobj.get_transform('alpha_beta', 'Xan_Yan').set_input(int(ch))
+        ab_to_v2v3 = wcsobj.get_transform('alpha_beta', 'v2v3').set_input(int(ch))
+        ab_to_xan_yan = ab_to_v2v3 | Scale(60) & Scale(60) & Identity(1)| Identity(1) & (Scale(-1) |Shift(-7.8)) & Identity(1)
         ref_alpha = ref_data['alpha']
         ref_beta = ref_data['beta']
         ref_lam = ref_data['lam']
-        #xyan_to_detector = wcsobj.get_transform('Xan_Yan', 'detector')
-        #xin, yin = xyan_to_detector(ref_data['v2'], ref_data['v3'],
-        #                                     ref_data['lam'])
+
         x, y = ref_data['x'], ref_data['y']
         for i, s in enumerate(ref_data['s']):
             sl = int(ch) * 100 + s
@@ -105,70 +109,51 @@ def run_test(model):
         #utils.assert_allclose(yin, y, atol=10**-5)
 
 
-@pytest.mark.xfail(
-    reason="reference file not in CRDS yet, #834",
-    run=False
-)
 def test_miri_mrs_12A():
     hdul = create_hdul(detector="MIRIFUSHORT", channel="12", band="SHORT")
     im = create_datamodel(hdul)
     run_test(im)
 
 
-@pytest.mark.xfail(
-    reason="reference file not in CRDS yet, #834",
-    run=False
-)
 def test_miri_mrs_12B():
     hdul = create_hdul(detector="MIRIFUSHORT", channel="12", band="MEDIUM")
+    print(hdul[0].header)
     im = create_datamodel(hdul)
     run_test(im)
 
 
-@pytest.mark.xfail(
-    reason="reference file not in CRDS yet, #834",
-    run=False
-)
 def test_miri_mrs_12C():
     hdul = create_hdul(detector="MIRIFUSHORT", channel="12", band="LONG")
     im = create_datamodel(hdul)
     run_test(im)
 
 
-@pytest.mark.xfail(
-    reason="reference file not in CRDS yet, #834",
-    run=False
-)
 def test_miri_mrs_34A():
     hdul = create_hdul(detector="MIRIFULONG", channel="34", band="SHORT")
     im = create_datamodel(hdul)
     run_test(im)
 
 
-@pytest.mark.xfail(
-    reason="reference file not in CRDS yet, #834",
-    run=False
-)
 def test_miri_mrs_34B():
     hdul = create_hdul(detector="MIRIFULONG", channel="34", band="MEDIUM")
     im = create_datamodel(hdul)
     run_test(im)
 
 
-@pytest.mark.xfail(
-    reason="reference file not in CRDS yet, #834",
-    run=False
-)
 def test_miri_mrs_34C():
     hdul = create_hdul(detector="MIRIFULONG", channel="34", band="LONG")
     im = create_datamodel(hdul)
     run_test(im)
 
+# The reference data below is from th e"verification Examples" table
+# in MIRI-­TN-­00001-­ETH.
+# The (x, y) coordinates in the original table are 1-based.
+# The reference data are 0-based, (x,y)_data = (x,y)_table -1
 
 mrs_ref_data = {
-    '1A': {'x': np.array([28.310396, 475.02154, 493.9777, 41.282537, 58.998266]),
+    '1A': {'x': np.array([28.310396, 475.02154, 493.9777, 41.282537, 58.998266]) - 1,
            #'x': np.array([28.310396, 475.02154, 493.4777, 41.282537, 58.498266]),
-           'y': np.array([512., 10, 100, 900, 1014]),
+           'y': np.array([512., 10, 100, 900, 1014]) -1,
            's': np.array([11, 1, 1, 21, 21]),
            'alpha': np.array([0, -1.66946, 1.65180, -1.70573, 1.70244]),
            'beta': np.array([0, -1.77210, -1.77210, 1.77210, 1.77210]),
@@ -176,8 +161,8 @@ mrs_ref_data = {
            'v2': np.array([-8.39424, -8.41746, -8.36306, -8.42653, -8.37026]),
            'v3': np.array([-2.48763, -2.52081, -2.51311, -2.46269, -2.45395]),
            },
-    '1B': {'x': np.array([28.648221, 475.07259, 493.98157, 41.559386, 59.738296]),
-           'y': np.array([512., 10, 100, 900, 1014]),
+    '1B': {'x': np.array([28.648221, 475.07259, 493.98157, 41.559386, 59.738296]) - 1,
+           'y': np.array([512., 10, 100, 900, 1014]) - 1,
            's': np.array([11, 1, 1, 21, 21]),
            'alpha': np.array([0., -1.70796, 1.60161, -1.70854, 1.78261]),
            'beta': np.array([0., -1.77204, -1.77204, 1.77204, 1.77204]),
@@ -185,8 +170,8 @@ mrs_ref_data = {
            'v2': np.array([-8.39426, -8.41808, -8.36368, -8.42682, -8.36899]),
            'v3': np.array([-2.48492, -2.51808, -2.51040, -2.46001, -2.45126])
            },
-    '1C': {'x': np.array([30.461871, 477.23742, 495.96228, 43.905314, 60.995683]),
-           'y': np.array([512., 10, 100, 900, 1014]),
+    '1C': {'x': np.array([30.461871, 477.23742, 495.96228, 43.905314, 60.995683]) - 1,
+           'y': np.array([512., 10, 100, 900, 1014]) - 1,
            's': np.array([11, 1, 1, 21, 21]),
            'alpha': np.array([0., -1.60587, 1.67276, -1.60766, 1.68720]),
            'beta': np.array([0., -1.77202, -1.77202, 1.77202, 1.77202]),
@@ -194,8 +179,8 @@ mrs_ref_data = {
            'v2': np.array([-8.39357, -8.41570, -8.36165, -8.42457, -8.36996]),
            'v3': np.array([-2.48987, -2.52271, -2.51525, -2.46467, -2.45649])
            },
-    '2A': {'x': np.array([992.158, 545.38386, 525.76143, 969.29711, 944.19303]),
-           'y': np.array([512., 10, 100, 900, 1014]),
+    '2A': {'x': np.array([992.158, 545.38386, 525.76143, 969.29711, 944.19303]) - 1,
+           'y': np.array([512., 10, 100, 900, 1014]) - 1,
            's': np.array([9, 1, 1, 17, 17]),
            'alpha': np.array([0., -2.11250, 2.10676, -2.17239, 2.10447]),
            'beta': np.array([0., -2.23775, -2.23775, 2.23775, 2.23775]),
@@ -203,8 +188,8 @@ mrs_ref_data = {
            'v2': np.array([-8.39393, -8.42259, -8.35355, -8.43583, -8.36499]),
            'v3': np.array([-2.48181, -2.52375, -2.51357, -2.44987, -2.44022])
            },
-    '2B': {'x': np.array([988.39977, 541.23447, 521.60207, 964.91753, 940.10325]),
-           'y': np.array([512., 10, 100, 900, 1014]),
+    '2B': {'x': np.array([988.39977, 541.23447, 521.60207, 964.91753, 940.10325]) - 1,
+           'y': np.array([512., 10, 100, 900, 1014]) - 1,
            's': np.array([9, 1, 1, 17, 17]),
            'alpha': np.array([0., -2.10593, 2.10015, -2.08817, 2.10422]),
            'beta': np.array([0., -2.23781, -2.23781, 2.23781, 2.23781]),
@@ -212,8 +197,8 @@ mrs_ref_data = {
            'v2': np.array([-8.39645, -8.42502, -8.35603, -8.43716, -8.36742]),
            'v3': np.array([-2.47773, -2.51972, -2.50938, -2.44554, -2.43626])
            },
-    '2C': {'x': np.array([990.89693, 543.82344, 524.34514, 967.98318, 942.77564]),
-           'y': np.array([512., 10, 100, 900, 1014]),
+    '2C': {'x': np.array([990.89693, 543.82344, 524.34514, 967.98318, 942.77564]) - 1,
+           'y': np.array([512., 10, 100, 900, 1014]) - 1,
            's': np.array([9, 1, 1, 17, 17]),
            'alpha': np.array([0., -2.07490, 2.11234, -2.14704, 2.14196]),
            'beta': np.array([0., -2.23778, -2.23778, 2.23778, 2.23778]),
@@ -221,8 +206,8 @@ mrs_ref_data = {
            'v2': np.array([-8.39303, -8.42129, -8.35221, -8.43454, -8.36352]),
            'v3': np.array([-2.47869, -2.52052, -2.51036, -2.44668, -2.43712])
            },
-    '3A': {'x': np.array([574.80828, 1001.0602, 984.6387, 547.27479, 518.89992]),
-           'y': np.array([512., 10, 100, 900, 1014]),
+    '3A': {'x': np.array([574.80828, 1001.0602, 984.6387, 547.27479, 518.89992]) - 1,
+           'y': np.array([512., 10, 100, 900, 1014]) - 1,
            's': np.array([8, 1, 1, 16, 16]),
            'alpha': np.array([0., -2.86745, 3.20982, -3.01230, 2.96643]),
            'beta': np.array([-0.19491, -2.92360, -2.92360, 2.92360, 2.92360]),
@@ -230,8 +215,8 @@ mrs_ref_data = {
            'v2': np.array([-8.40590, -8.44849, -8.34906, -8.46070, -8.36174]),
            'v3': np.array([-2.48992, -2.54104, -2.52854, -2.44547, -2.43112])
            },
-    '3B': {'x': np.array([574.26012, 1001.7349, 985.30166, 548.016, 519.98]),
-           'y': np.array([512., 10., 100, 900, 1014]),
+    '3B': {'x': np.array([574.26012, 1001.7349, 985.30166, 548.016, 519.98]) - 1,
+           'y': np.array([512., 10., 100, 900, 1014]) - 1,
            's': np.array([8, 1, 1, 16, 16]),
            'alpha': np.array([0, -3.17728, 2.92434, -3.29402, 2.60797]),
            'beta': np.array([-0.19491, -2.92360, -2.92360, 2.92360, 2.92360]),
@@ -239,8 +224,8 @@ mrs_ref_data = {
            'v2': np.array([-8.40044, -8.44785, -8.34786, -8.46088, -8.36211]),
            'v3': np.array([-2.48588, -2.53771, -2.52512, -2.44219, -2.42776])
            },
-    '3C': {'x': np.array([573.25446, 1000.21721, 983.92918, 546.00285, 518.2782]),
-           'y': np.array([512., 10, 100, 900, 1014]),
+    '3C': {'x': np.array([573.25446, 1000.21721, 983.92918, 546.00285, 518.2782]) - 1,
+           'y': np.array([512., 10, 100, 900, 1014]) - 1,
            's': np.array([8, 1, 1, 16, 16]),
            'alpha': np.array([0., -2.94573, 3.09057, -3.07810, 2.73161]),
            'beta': np.array([-0.19491, -2.92360, -2.92360, 2.92360, 2.92360]),
@@ -248,8 +233,8 @@ mrs_ref_data = {
            'v2': np.array([-8.40205, -8.44574, -8.34664, -8.45859, -8.36196]),
            'v3': np.array([-2.48627, -2.53761, -2.52502, -2.44221, -2.42787]),
            },
-    '4A': {'x': np.array([80.987181, 434.34987, 461.90855, 26.322503, 53.674656]),
-           'y': np.array([512., 10, 100, 900, 1014]),
+    '4A': {'x': np.array([80.987181, 434.34987, 461.90855, 26.322503, 53.674656]) - 1,
+           'y': np.array([512., 10, 100, 900, 1014]) - 1,
            's': np.array([6, 1, 1, 12, 12]),
            'alpha': np.array([0., -3.74625, 3.72621, -3.94261, 3.62762]),
            'beta': np.array([-0.32802, -3.60821, -3.60821, 3.60821, 3.60821]),
@@ -257,8 +242,8 @@ mrs_ref_data = {
            'v2': np.array([-8.38446, -8.43506, -8.31378, -8.46256, -8.33609]),
            'v3': np.array([-2.48058, -2.5444, -2.52426, -2.42449, -2.40839])
            },
-    '4B': {'x': np.array([77.625553, 431.57061, 458.86869, 23.559111, 50.632416]),
-           'y': np.array([512., 10, 100, 900, 1014]),
+    '4B': {'x': np.array([77.625553, 431.57061, 458.86869, 23.559111, 50.632416]) - 1,
+           'y': np.array([512., 10, 100, 900, 1014]) - 1,
            's': np.array([6, 1, 1, 12, 12]),
            'alpha': np.array([0., -3.64817, 3.73313, -3.73558, 3.74096]),
            'beta': np.array([-0.32802, -3.60821, -3.60821, 3.60821, 3.60821]),
@@ -266,8 +251,8 @@ mrs_ref_data = {
            'v2': np.array([-8.38581, -8.43443, -8.3141, -8.46152, -8.33604]),
            'v3': np.array([-2.48185, -2.54526, -2.52568, -2.42513, -2.40959])
            },
-    '4C': {'x': np.array([79.662059, 433.73384, 460.75026, 25.820431, 52.412219]),
-           'y': np.array([512., 10, 100, 900, 1014]),
+    '4C': {'x': np.array([79.662059, 433.73384, 460.75026, 25.820431, 52.412219]) - 1,
+           'y': np.array([512., 10, 100, 900, 1014]) - 1,
            's': np.array([6, 1, 1, 12, 12]),
            'alpha': np.array([0., -3.61682, 3.69713, -3.66259, 3.69888]),
            'beta': np.array([-0.32802, -3.60819, -3.60819, 3.60819, 3.60819]),


### PR DESCRIPTION
These were commented out because the CDP-6 reference files were not in CRDS. This PR modifies the tests to match the changes in the CDP-6 ref files and enables them again.