### PR TITLE
second attempt at removing WCS defult values

### DIFF
--- a/jwst/assign_wcs/assign_wcs.py
+++ b/jwst/assign_wcs/assign_wcs.py
@@ -1,3 +1,6 @@
+from __future__ import (absolute_import, unicode_literals, division,
+                        print_function)
+
 import logging
 import importlib
 from gwcs.wcs import WCS
@@ -23,6 +26,10 @@ def load_wcs(input_model, reference_files={}):
         raise ValueError("assign_wcs needs reference files to compute the WCS, none were passed")
     instrument = input_model.meta.instrument.name.lower()
     mod = importlib.import_module('.' + instrument, 'jwst.assign_wcs')
+
+    # Add WCS keywords for the spectral axis.
+    if input_model.meta.wcsinfo.wcsaxes == 3:
+        _add_3rd_axis(input_model)
 
     pipeline = mod.create_pipeline(input_model, reference_files)
 
@@ -50,3 +57,18 @@ def load_wcs(input_model, reference_files={}):
             log.info("assign_wcs did not update S_REGION for type {0}".format(output_model.meta.exposure.type))
         log.info("COMPLETED assign_wcs")
     return output_model
+
+
+def _add_3rd_axis(input_model):
+    """
+    Add WCS keywords and their default values for the spectral axis.
+
+    SDP adds CTYPE3 and CUNIT3.
+
+    """
+    input_model.meta.wcsinfo.pc1_3 = 0.
+    input_model.meta.wcsinfo.pc2_3 = 0.
+    input_model.meta.wcsinfo.pc3_3 = 1.
+    input_model.meta.wcsinfo.crval3 = 0.
+    input_model.meta.wcsinfo.crpix3 = 0.
+    input_model.meta.wcsinfo.cdelt3 = 1.

--- a/jwst/assign_wcs/tests/test_miri.py
+++ b/jwst/assign_wcs/tests/test_miri.py
@@ -30,13 +30,15 @@ from .. import miri
 from ..assign_wcs_step import AssignWcsStep
 
 
-wcs_kw = {'wcsaxes': 2, 'ra_ref': 165, 'dec_ref': 54,
+wcs_kw = {'wcsaxes': 3, 'ra_ref': 165, 'dec_ref': 54,
           'v2_ref': -8.3942412, 'v3_ref': -5.3123744, 'roll_ref': 37,
-          'crpix1': 1024, 'crpix2': 1024,
-          'cdelt1': .08, 'cdelt2': .08,
-          'ctype1': 'RA---TAN', 'ctype2': 'DEC--TAN',
-          'pc1_1': 1, 'pc1_2': 0, 'pc2_1': 0, 'pc2_2': 1,
-          'pc3_1': 1, 'pc3_2': 0
+          'crpix1': 1024, 'crpix2': 1024, 'crpix3': 0,
+          'cdelt1': .08, 'cdelt2': .08, 'cdelt3': 1,
+          'ctype1': 'RA---TAN', 'ctype2': 'DEC--TAN', 'ctype3': 'WAVE',
+          'pc1_1': 1, 'pc1_2': 0, 'pc1_3': 0,
+          'pc2_1': 0, 'pc2_2': 1, 'pc2_3': 0,
+          'pc3_1': 0, 'pc3_2': 0, 'pc3_3': 1,
+          'cunit1': 'deg', 'cunit2': 'deg', 'cunit3': 'um',
           }
 
 band_mapping = {'SHORT': 'A', 'MEDIUM': 'B', 'LONG': 'C'}
@@ -45,6 +47,7 @@ band_mapping = {'SHORT': 'A', 'MEDIUM': 'B', 'LONG': 'C'}
 def create_hdul(detector, channel, band):
     hdul = fits.HDUList()
     phdu = fits.PrimaryHDU()
+    phdu.header['telescop'] = "JWST"
     phdu.header['filename'] = "test" + channel + band
     phdu.header['instrume'] = 'MIRI'
     phdu.header['detector'] = detector
@@ -54,6 +57,7 @@ def create_hdul(detector, channel, band):
     phdu.header['date-obs'] = '2017-09-05'
     phdu.header['exp_type'] = 'MIR_MRS'
     scihdu = fits.ImageHDU()
+    scihdu.header['EXTNAME'] = "SCI"
     scihdu.header.update(wcs_kw)
     hdul.append(phdu)
     hdul.append(scihdu)
@@ -63,8 +67,6 @@ def create_hdul(detector, channel, band):
 def create_datamodel(hdul):
     im = ImageModel(hdul)
     ref = create_reference_files(im)
-    print('in create_datamodel', ref['distortion'])
-    print(im.meta.instrument.band)
     pipeline = miri.create_pipeline(im, ref)
     wcsobj = wcs.WCS(pipeline)
     im.meta.wcs = wcsobj

--- a/jwst/assign_wcs/tests/test_nirspec.py
+++ b/jwst/assign_wcs/tests/test_nirspec.py
@@ -59,9 +59,12 @@ def create_hdul():
     phdu.header['time-obs'] = '8:59:37'
     phdu.header['date-obs'] = '2016-09-05'
 
+    scihdu = fits.ImageHDU()
+    scihdu.header['EXTNAME'] = "SCI"
     for item in wcs_kw.items():
-        phdu.header[item[0]] = item[1]
+        scihdu.header[item[0]] = item[1]
     hdul.append(phdu)
+    hdul.append(scihdu)
     return hdul
 
 
@@ -105,11 +108,11 @@ def create_nirspec_ifu_file(filter, grating, lamp='N/A'):
     image[0].header['exp_type'] = 'NRS_IFU'
     image[0].header['filter'] = filter #'F170LP'
     image[0].header['grating'] = grating #'G235H'
-    image[0].header['crval3'] = 0
-    image[0].header['wcsaxes'] = 3
-    image[0].header['ctype3'] = 'WAVE'
-    image[0].header['pc3_1'] = 1
-    image[0].header['pc3_2'] = 0
+    image[1].header['crval3'] = 0
+    image[1].header['wcsaxes'] = 3
+    image[1].header['ctype3'] = 'WAVE'
+    #image[1].header['pc3_1'] = 1
+    #image[1].header['pc3_2'] = 0
     image[0].header['lamp'] = lamp
     image[0].header['GWA_XTIL'] = 0.35986012
     image[0].header['GWA_YTIL'] = 0.13448857
@@ -121,11 +124,11 @@ def create_nirspec_fs_file():
     image[0].header['exp_type'] = 'NRS_FIXEDSLIT'
     image[0].header['filter'] = 'F100LP'
     image[0].header['grating'] = 'G140H'
-    image[0].header['crval3'] = 0
-    image[0].header['wcsaxes'] = 3
-    image[0].header['ctype3'] = 'WAVE'
-    image[0].header['pc3_1'] = 1
-    image[0].header['pc3_2'] = 0
+    image[1].header['crval3'] = 0
+    image[1].header['wcsaxes'] = 3
+    image[1].header['ctype3'] = 'WAVE'
+    #image[1].header['pc3_1'] = 1
+    #image[1].header['pc3_2'] = 0
     image[0].header['GWA_XTIL'] = 3.5896975e-001
     image[0].header['GWA_YTIL'] = 1.3438272e-001
     image[0].header['GWA_TTIL'] = 3.9555361e+001

--- a/jwst/assign_wcs/tests/test_wcs.py
+++ b/jwst/assign_wcs/tests/test_wcs.py
@@ -1,3 +1,5 @@
+from __future__ import (absolute_import, unicode_literals, division,
+                        print_function)
 from numpy.testing import utils
 from astropy import units as u
 from astropy import wcs
@@ -19,6 +21,10 @@ def _create_model_2d():
     im.meta.wcsinfo.cunit2 = 'deg'
     im.meta.wcsinfo.ctype1 = 'RA---TAN'
     im.meta.wcsinfo.ctype2 = 'DEC--TAN'
+    im.meta.wcsinfo.pc1_1 = 1.
+    im.meta.wcsinfo.pc1_2 = 0
+    im.meta.wcsinfo.pc2_1 = 0.
+    im.meta.wcsinfo.pc2_2 = 1.
     return im
 
 
@@ -29,6 +35,11 @@ def _create_model_3d():
     im.meta.wcsinfo.wcsaxes = 3
     im.meta.wcsinfo.cunit3 = 'um'
     im.meta.wcsinfo.ctype3 = 'WAVE'
+    im.meta.wcsinfo.pc3_1 = 0.
+    im.meta.wcsinfo.pc3_2 = 0
+    im.meta.wcsinfo.pc3_3 = 1
+    im.meta.wcsinfo.pc1_3 = 0
+    im.meta.wcsinfo.pc2_3 = 0.
     return im
 
 

--- a/jwst/datamodels/schemas/wcsinfo.schema.yaml
+++ b/jwst/datamodels/schemas/wcsinfo.schema.yaml
@@ -63,37 +63,31 @@ properties:
           crpix1:
             title: axis 1 coordinate of the reference pixel
             type: number
-            default: 0.0
             fits_keyword: CRPIX1
             fits_hdu: SCI
           crpix2:
             title: axis 2 coordinate of the reference pixel
             type: number
-            default: 0.0
             fits_keyword: CRPIX2
             fits_hdu: SCI
           crpix3:
             title: axis 3 coordinate of the reference pixel
             type: number
-            default: 0.0
             fits_keyword: CRPIX3
             fits_hdu: SCI
           crval1:
             title: first axis value at the reference pixel
             type: number
-            default: 0.0
             fits_keyword: CRVAL1
             fits_hdu: SCI
           crval2:
             title: second axis value at the reference pixel
             type: number
-            default: 0.0
             fits_keyword: CRVAL2
             fits_hdu: SCI
           crval3:
             title: third axis value at the reference pixel
             type: number
-            default: 0.0
             fits_keyword: CRVAL3
             fits_hdu: SCI
           ctype1:
@@ -129,73 +123,61 @@ properties:
           cdelt1:
             title: first axis increment per pixel
             type: number
-            default: 1.0
             fits_keyword: CDELT1
             fits_hdu: SCI
           cdelt2:
             title: second axis increment per pixel
             type: number
-            default: 1.0
             fits_keyword: CDELT2
             fits_hdu: SCI
           cdelt3:
             title: third axis increment per pixel
             type: number
-            default: 1.0
             fits_keyword: CDELT3
             fits_hdu: SCI
           pc1_1:
             title: linear transformation matrix element
             type: number
-            default: 1.0
             fits_keyword: PC1_1
             fits_hdu: SCI
           pc1_2:
             title: linear transformation matrix element
             type: number
-            default: 0.0
             fits_keyword: PC1_2
             fits_hdu: SCI
           pc1_3:
             title: linear transformation matrix element
             type: number
-            default: 0.0
             fits_keyword: PC1_3
             fits_hdu: SCI
           pc2_1:
             title: linear transformation matrix element
             type: number
-            default: 0.0
             fits_keyword: PC2_1
             fits_hdu: SCI
           pc2_2:
             title: linear transformation matrix element
             type: number
-            default: 1.0
             fits_keyword: PC2_2
             fits_hdu: SCI
           pc2_3:
             title: linear transformation matrix element
             type: number
-            default: 0.0
             fits_keyword: PC2_3
             fits_hdu: SCI
           pc3_1:
             title: linear transformation matrix element
             type: number
-            default: 0.0
             fits_keyword: PC3_1
             fits_hdu: SCI
           pc3_2:
             title: linear transformation matrix element
             type: number
-            default: 0.0
             fits_keyword: PC3_2
             fits_hdu: SCI
           pc3_3:
             title: linear transformation matrix element
             type: number
-            default: 1.0
             fits_keyword: PC3_3
             fits_hdu: SCI
           s_region:
@@ -222,42 +204,35 @@ properties:
           v2_ref:
             title: Telescope v2 coordinate of the reference point (arcsec)
             type: number
-            default: 0.0
             fits_keyword: V2_REF
             fits_hdu: SCI
           v3_ref:
             title: Telescope v3 coordinate of the reference point (arcsec)
             type: number
-            default: 0.0
             fits_keyword: V3_REF
             fits_hdu: SCI
           vparity:
             title: Relative sense of rotation between Ideal xy and V2V3
             type: integer
-            default: 1
             fits_keyword: VPARITY
             fits_hdu: SCI
           v3yangle:
             title: Angle from V3 axis to Ideal y axis (deg)
             type: number
-            default: 0.0
             fits_keyword: V3I_YANG
             fits_hdu: SCI
           ra_ref:
             title: Right ascension of the reference point (deg)
             type: number
-            default: 0.0
             fits_keyword: RA_REF
             fits_hdu: SCI
           dec_ref:
             title: Declination of the reference point (deg)
             type: number
-            default: 0.0
             fits_keyword: DEC_REF
             fits_hdu: SCI
           roll_ref:
             title: Telescope roll angle of V3 measured from North over East at the ref. point (deg)
             type: number
-            default: 0.0
             fits_keyword: ROLL_REF
             fits_hdu: SCI


### PR DESCRIPTION
This supersedes #1499 with the only difference here is that the newly enabled MIRI MRS tests were fixed to provide default values. #1499 was previously approved.