### PR TITLE
Fix default value for sovler parameter to match_lsq

### DIFF
--- a/jwst/wiimatch/match.py
+++ b/jwst/wiimatch/match.py
@@ -26,7 +26,7 @@ SUPPORTED_SOLVERS = ['RLU', 'PINV']
 
 def match_lsq(images, masks=None, sigmas=None, degree=0,
               center=None, image2world=None, center_cs='image',
-              ext_return=False, solver='LU'):
+              ext_return=False, solver='PINV'):
     """
     Compute coefficients of (multivariate) polynomials that once subtracted
     from input images would provide image intensity matching in the least

--- a/jwst/wiimatch/match.py
+++ b/jwst/wiimatch/match.py
@@ -26,7 +26,7 @@ SUPPORTED_SOLVERS = ['RLU', 'PINV']
 
 def match_lsq(images, masks=None, sigmas=None, degree=0,
               center=None, image2world=None, center_cs='image',
-              ext_return=False, solver='PINV'):
+              ext_return=False, solver='RLU'):
     """
     Compute coefficients of (multivariate) polynomials that once subtracted
     from input images would provide image intensity matching in the least
@@ -267,10 +267,10 @@ array([[ -6.60000000e-01,  -7.50000000e-02,  -3.10000000e-01,
     )
 
     # solve the system:
-    tol = np.finfo(images[0].dtype).eps**(2.0/3.0)
     if solver == 'RLU':
-        bkg_poly_coef = rlu_solve(a, b, nimages, tol)
+        bkg_poly_coef = rlu_solve(a, b, nimages)
     else:
+        tol = np.finfo(images[0].dtype).eps**(2.0/3.0)
         bkg_poly_coef = pinv_solve(a, b, nimages, tol)
 
     if ext_return:


### PR DESCRIPTION
The default given for parameter `solver` was `LU`.
However, according to comments and code, only `RLU` and `PINV`
are supported.

Though it seems to be just a typo and the intent was for `RLU`
to be default, I went with `PINV` because then the code would
actually run for MRS test data.