### PR TITLE
contributing guidelines and code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,24 @@
+# Spacetelescope Open Source Code of Conduct
+
+We expect all "spacetelescope" organization projects to adopt a code of conduct that ensures a productive, respectful environment for all open source contributors and participants. We are committed to providing a strong and enforced code of conduct and expect everyone in our community to follow these guidelines when interacting with others in all forums. Our goal is to keep ours a positive, inclusive, successful, and growing community. The community of participants in open source Astronomy projects is made up of members from around the globe with a diverse set of skills, personalities, and experiences. It is through these differences that our community experiences success and continued growth. 
+
+
+As members of the community,
+
+- We pledge to treat all people with respect and provide a harassment- and bullying-free environment, regardless of sex, sexual orientation and/or gender identity, disability, physical appearance, body size, race, nationality, ethnicity, and religion. In particular, sexual language and imagery, sexist, racist, or otherwise exclusionary jokes are not appropriate.
+
+- We pledge to respect the work of others by recognizing acknowledgment/citation requests of original authors. As authors, we pledge to be explicit about how we want our own work to be cited or acknowledged.
+
+- We pledge to welcome those interested in joining the community, and realize that including people with a variety of opinions and backgrounds will only serve to enrich our community. In particular, discussions relating to pros/cons of various technologies, programming languages, and so on are welcome, but these should be done with respect, taking proactive measure to ensure that all participants are heard and feel confident that they can freely express their opinions.
+
+- We pledge to welcome questions and answer them respectfully, paying particular attention to those new to the community. We pledge to provide respectful criticisms and feedback in forums, especially in discussion threads resulting from code contributions.
+
+- We pledge to be conscientious of the perceptions of the wider community and to respond to criticism respectfully. We will strive to model behaviors that encourage productive debate and disagreement, both within our community and where we are criticized. We will treat those outside our community with the same respect as people within our community.
+
+- We pledge to help the entire community follow the code of conduct, and to not remain silent when we see violations of the code of conduct. We will take action when members of our community violate this code such as such as contacting conduct@stsci.edu (all emails sent to this address will be treated with the strictest confidence) or talking privately with the person.
+
+This code of conduct applies to all community situations online and offline, including mailing lists, forums, social media, conferences, meetings, associated social events, and one-to-one interactions.
+
+Parts of this code of conduct have been adapted from the Astropy and Numfocus codes of conduct.
+http://www.astropy.org/code_of_conduct.html
+https://www.numfocus.org/about/code-of-conduct/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,8 @@
+Please open a new issue or new pull request for bugs, feedback, or new features you would like to see. If there is an issue you would like to work on, please leave a comment and we will be happy to assist. New contributions and contributors are very welcome!
+
+The main development work is done on the "master" branch. The "stable" branch is protected and used for official releases. The rest of the branches are for release maintenance and should not be used normally. Unless otherwise told by a maintainer, pull request should be made and submitted to the "master" branch.
+
+New to github or open source projects? If you are unsure about where to start or haven't used github before, please feel free to contact the package maintainers. 
+
+Feedback and feature requests? Is there something missing you would like to see? Please open an issue or send an email to the maintainers. This package follows the Spacetelescope `Code of Conduct<CODE_OF_CONDUCT.md>`_ strives to provide a welcoming community to all of our users and contributors.
+

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ JWST Calibration Pipeline
 
 Note
 ----
-Beginning with the next version (0.9.0), JWST requires Python 3.5 and above.
+Beginning with the next version (0.9.0), **JWST requires Python 3.5 and above**.
 
 Installing
 ----------
-Releases are made on the "stable" branch. To install the latest release:
+Releases are made on the **stable** branch. To install the latest release:
 
     % git clone https://github.com/STScI-JWST/jwst.git
 
@@ -20,7 +20,7 @@ Releases are made on the "stable" branch. To install the latest release:
 
     % python setup.py install
 
-The main development is on the "master" branch. To install the development version:
+The main development is on the **master** branch. To install the development version:
 
     % git clone https://github.com/STScI-JWST/jwst.git
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,17 @@ Beginning with the next version (0.9.0), JWST requires Python 3.5 and above.
 
 Installing
 ----------
+Releases are made on the "stable" branch. To i nstall the latest release:
 
-For developers:
+    % git clone https://github.com/STScI-JWST/jwst.git
+
+    % cd jwst
+
+    % git checkout stable
+
+    % python setup.py install
+
+The main development is on the "msater" branch. To install the development version:
 
     % git clone https://github.com/STScI-JWST/jwst.git
 
@@ -22,6 +31,13 @@ For developers:
     or
 
     % python setup.py develop
+
+
+Contributing Code, Documentation or Feedback
+--------------------------------------------
+We welcome feedback and contributions to the project. Please follow the contributing guidelines to submit an issue or a pull request.
+
+We strive to provide a welcoming community to all of our users by abiding to the Code of Conduct.
 
 Using
 -----

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Beginning with the next version (0.9.0), JWST requires Python 3.5 and above.
 
 Installing
 ----------
-Releases are made on the "stable" branch. To i nstall the latest release:
+Releases are made on the "stable" branch. To install the latest release:
 
     % git clone https://github.com/STScI-JWST/jwst.git
 
@@ -20,7 +20,7 @@ Releases are made on the "stable" branch. To i nstall the latest release:
 
     % python setup.py install
 
-The main development is on the "msater" branch. To install the development version:
+The main development is on the "master" branch. To install the development version:
 
     % git clone https://github.com/STScI-JWST/jwst.git
 
@@ -35,9 +35,9 @@ The main development is on the "msater" branch. To install the development versi
 
 Contributing Code, Documentation or Feedback
 --------------------------------------------
-We welcome feedback and contributions to the project. Please follow the contributing guidelines to submit an issue or a pull request.
+We welcome feedback and contributions to the project. Please follow the [contributing guidelines](CONTRIBUTING.md) to submit an issue or a pull request.
 
-We strive to provide a welcoming community to all of our users by abiding to the Code of Conduct.
+We strive to provide a welcoming community to all of our users by abiding to the [Code of Conduct](CODE_OF_CONDUCT.md).
 
 Using
 -----


### PR DESCRIPTION
Adds a description of how to install a release version vs development version.
Adds a small section (needs to be expanded) on how to make contributions as well as what the various branches are used for.
Also adds "code of conduct" statement.