### PR TITLE
Update calwebb_tso3.cfg to match pipeline

### DIFF
--- a/jwst/pipeline/calwebb_tso3.cfg
+++ b/jwst/pipeline/calwebb_tso3.cfg
@@ -5,9 +5,7 @@ scale_detection = False
 
     [steps]
       [[outlier_detection]]
-        config_file = outlier_detection_stack.cfg
-      [[outlier_detection_scaled]]
-        config_file = outlier_detection_scaled.cfg
+        config_file = outlier_detection_tso.cfg
       [[tso_photometry]]
       [[extract_1d]]
         config_file = extract_1d.cfg


### PR DESCRIPTION
The calwebb_tso3 pipeline was updated in the final B7.1 delivery to no longer use separate outlier_detection_scaled and outlier_detection_stacked steps, but the default .cfg file was not updated to reflect this change. The calwebb_tso3 pipeline then fails, when executed using the default .cfg file, because the step outlier_detection_scaled is no longer defined in the pipeline.

This update brings the default calwebb_tso3.cfg file in synch with the latest calwebb_tso3.py pipeline module.

This error wasn't discovered via the calwebb_tso3 regression tests, because the tests were still using an old version of the calwebb_tso3.cfg file that didn't have this problem. Mike Swam discovered the problem during DMS testing of the B7.1 delivery.