### PR TITLE
Modify datamodels test to not check for ASDF tree in ImageHDU

### DIFF
--- a/jwst/datamodels/tests/test_fits.py
+++ b/jwst/datamodels/tests/test_fits.py
@@ -320,7 +320,6 @@ def test_table_with_metadata():
     assert len(hdulist) == 3
     assert isinstance(hdulist[1], fits.BinTableHDU)
     assert hdulist[1].name == 'FLUX'
-    assert isinstance(hdulist[2], fits.ImageHDU)
     assert hdulist[2].name == 'ASDF'
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,6 @@ all_files = 1
 upload-dir = docs/_build/html
 show-response = 1
 
-
 [pep8]
 # E101 - mix of tabs and spaces
 # W191 - use of tabs
@@ -35,7 +34,7 @@ exclude = extern,sphinx,*parsetab.py
 [tool:pytest]
 minversion = 3
 addopts = --ignore=build
-norecursedirs = build docs/_build relic
+norecursedirs = build docs/_build relic .eggs
 
 [bdist_wheel]
 # This flag says that the code is written to work on both Python 2 and Python


### PR DESCRIPTION
The storage of the ASDF tree in either an `ImageHDU` or another type of HDU is an ASDF implementation detail, and should not be tested here.  This allows for the proposed change in [ASDF PR 412](https://github.com/spacetelescope/asdf/pull/412) to put the ASDF tree in a `NonstandardExtHDU` instead of an `ImageHDU`.