### PR TITLE
Fix blendheaders output datamodel value

### DIFF
--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -168,9 +168,11 @@ class ResampleData:
             group_exptime):
             output_model = self.blank_output.copy()
             output_model.meta.filename = obs_product
+            saved_model_type = output_model.meta.model_type
 
             if self.drizpars['blendheaders']:
                 self.blend_output_metadata(output_model)
+                output_model.meta.model_type = saved_model_type
 
             # Following 2 lines can probably be removed once ASN dicts
             # are handled properly


### PR DESCRIPTION
This is a quick-n-dirty fix (till @stsci-hack can fix it properly in blendheaders) that gives the proper model_type value to the data model returned from blendheaders, when it's called from the resample step. The resampled output model starts out with the proper model_type, but it appears that blendheaders is replacing it with the model_type of the input image(s) that it's blending. This workaround just saves the output model_type before calling blendheaders and then restores that original value after blendheaders is finished. This has been affecting the resampled output product from the calwebb_image3 and calwebb_coron3 pipelines.