### PR TITLE
Adding populate_meta to WCS RegionsModel

### DIFF
--- a/jwst/datamodels/wcs_ref_models.py
+++ b/jwst/datamodels/wcs_ref_models.py
@@ -274,6 +274,10 @@ class RegionsModel(ReferenceFileModel):
     def on_save(self, path=None):
         self.meta.reftype = self.reftype
 
+    def populate_meta(self):
+        self.meta.instrument.name = "MIRI"
+        self.meta.exposure.type = "MIR_MRS"
+
     def to_fits(self):
         raise NotImplementedError("FITS format is not supported for this file.")
 


### PR DESCRIPTION
The MIRI MRS code to create CRDS reference files is crashing using the latest version of the pipeline.  On further investigation, this seems to be because there is no 'populate_meta' function for the RegionsModel MIRI-only reference file within the datamodel.  Since this function exists for all other reference file types I've added it for the Regions files as well, which seems to fix the problem so that MRS reference files can be created again.