### PR TITLE
Make sure ASDF's built-in url mapping is used when loading schemas

### DIFF
--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -102,9 +102,10 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         # Load the schema files
         if schema is None:
             schema_path = os.path.join(base_url, self.schema_url)
-            extension_list = asdf_extension.AsdfExtensionList(self._extensions)
+            # Create an AsdfFile so we can use its resolver for loading schemas
+            asdf_file = AsdfFile(extensions=self._extensions)
             schema = asdf_schema.load_schema(schema_path,
-                resolver=extension_list.url_mapping, resolve_references=True)
+                resolver=asdf_file.resolver, resolve_references=True)
 
         self._schema = mschema.flatten_combiners(schema)
         # Determine what kind of input we have (init) and execute the


### PR DESCRIPTION
Right now, when loading schemas in `datamodels`, the ASDF built-in url mapping is not actually being used. Instead, JWST is inadvertently making use of the `GWCSExtension`, which currently has the same url mapping as ASDF's built-in extension.

The `GWCSExtension` url mapping is about to change, and so JWST needs to actually make sure that ASDF's built-in url mapping is being used when loading schemas. The easiest way to do this is to create an `AsdfFile` object using JWST's list of extensions, and use that object's resolver when loading schemas.