### PR TITLE
Fix msaflagopen for missing v2v3 ref file

### DIFF
--- a/jwst/msaflagopen/msaflagopen_step.py
+++ b/jwst/msaflagopen/msaflagopen_step.py
@@ -52,7 +52,8 @@ def create_reference_filename_dictionary(input_model):
     reffiles['specwcs'] = input_model.meta.ref_file.filteroffset.name
     reffiles['regions'] = input_model.meta.ref_file.regions.name
     reffiles['wavelengthrange'] = input_model.meta.ref_file.wavelengthrange.name
-    reffiles['v2v3'] = input_model.meta.ref_file.v2v3.name
+    if input_model.meta.ref_file.v2v3.name is not None:
+        reffiles['v2v3'] = input_model.meta.ref_file.v2v3.name
     reffiles['camera'] = input_model.meta.ref_file.camera.name
     reffiles['collimator'] = input_model.meta.ref_file.collimator.name
     reffiles['disperser'] = input_model.meta.ref_file.disperser.name


### PR DESCRIPTION
Quick fix to get regression tests running, while @stscirij works on a permanent fix. This handles the fact that the v2v3 reference file was recently retired from use, but the step was still trying to find a name for it, which is now None.