### PR TITLE
Add support for tweaking *groups* of images that "move" together

### DIFF
--- a/jwst/transforms/tpcorr.py
+++ b/jwst/transforms/tpcorr.py
@@ -178,6 +178,11 @@ class TPCorr(Model):
         (xt, yt), format_info = self.prepare_inputs(xt, yt)
         zt = np.full_like(xt, self.__class__.r0)
 
+        # undo corrections:
+        xt, yt = np.dot(np.linalg.inv(self.matrix[0]), (xt, yt))
+        xt += self.shift[0][0]
+        yt += self.shift[0][1]
+
         # build Euler rotation matrices:
         rotm = [
             rot_mat3D(np.deg2rad(alpha), axis)

--- a/jwst/tweakreg/imalign.py
+++ b/jwst/tweakreg/imalign.py
@@ -217,7 +217,6 @@ def align(imcat, refcat=None, enforce_user_order=True,
             nclip=nclip,
             sigma=sigma
         )
-
         aligned_imcat.append(current_imcat)
 
         # add unmatched sources to the reference catalog:

--- a/jwst/tweakreg/tweakreg_step.py
+++ b/jwst/tweakreg/tweakreg_step.py
@@ -49,12 +49,12 @@ class TweakRegStep(Step):
 
         # Object matching parameters:
         minobj = integer(default=15) # Minimum number of objects acceptable for matching
-        searchrad = float(default=1.0) # The search radius for a match
+        searchrad = float(default=1.0) # The search radius in arcsec for a match
         use2dhist = boolean(default=True) # Use 2d histogram to find initial offset?
-        separation = float(default=0.5) # Minimum object separation in pixels
-        tolerance = float(default=1.0) # Matching tolerance for xyxymatch in pixels
-        xoffset = float(default=0.0), # Initial guess for X offset in pixels
-        yoffset = float(default=0.0) # Initial guess for Y offset in pixels
+        separation = float(default=0.5) # Minimum object separation in arcsec
+        tolerance = float(default=1.0) # Matching tolerance for xyxymatch in arcsec
+        xoffset = float(default=0.0), # Initial guess for X offset in arcsec
+        yoffset = float(default=0.0) # Initial guess for Y offset in arcsec
 
         # Catalog fitting parameters:
         fitgeometry = option('shift', 'rscale', 'general', default='general') # Fitting geometry
@@ -103,7 +103,7 @@ class TweakRegStep(Step):
             raise ValueError("Input must contain at least one image model.")
 
         # group images by their "group id":
-        grp_img = [[i] for i in images] #images.models_grouped
+        grp_img = images.models_grouped
 
         if len(grp_img) == 1:
             # we need at least two exposures to perform image alignment

--- a/jwst/tweakreg/wcsutils.py
+++ b/jwst/tweakreg/wcsutils.py
@@ -122,6 +122,5 @@ def apply_affine_to_wcs(imwcs, rot=0.0, scale=1.0, xsh=0.0, ysh=0.0,
         matrix = linearfit.build_fit_matrix(rot, scale)
 
     matrix = matrix.T
-    shift = -np.array([xsh, ysh], dtype=np.float)
-
+    shift = -np.dot(np.linalg.inv(matrix), [xsh, ysh])
     imwcs.set_correction(matrix, shift)


### PR DESCRIPTION
This PR adds support for "tweaking" the WCS of groups of images: sets of images that must be adjusted together as one large image. This PR addresses https://github.com/STScI-JWST/jwst/issues/1520 and also adds a couple of bug fixes.

CC @hbushouse 