### PR TITLE
Set srctype to extended for NRS_IFU background exposures

### DIFF
--- a/jwst/srctype/srctype.py
+++ b/jwst/srctype/srctype.py
@@ -41,6 +41,16 @@ def set_source_type(input_model):
                 src_type = 'EXTENDED'
             else:
                 src_type = 'POINT'
+
+            # Check for background target status
+            if input_model.meta.observation.bkgdtarg:
+
+                # If it's NIRSpec IFU background target exposure, set
+                # the default type to Extended
+                if input_model.meta.exposure.type == 'NRS_IFU':
+                    src_type = 'EXTENDED'
+
+            # Report the type
             log.info('Input SRCTYPE is unknown. Setting to default ' +
                      'value of %s' % src_type)
 


### PR DESCRIPTION
Updated the source_type step to check the setting of the BKGDTARG (background target) keyword and if it's set to True, then set the source type to EXTENDED for NIRSpec IFU exposures.

Fixes #1151.