### PR TITLE
Test setup and minor rule constraint simplification

### DIFF
--- a/jwst/associations/__init__.py
+++ b/jwst/associations/__init__.py
@@ -4,7 +4,7 @@ from os.path import (
     join
 )
 
-__version__ = '0.9.5'
+__version__ = '0.9.6'
 
 
 # Utility

--- a/jwst/associations/association.py
+++ b/jwst/associations/association.py
@@ -414,6 +414,12 @@ class Association(MutableMapping):
             self.force_reprocess = conditions.get('force_reprocess', False)
             return (True, reprocess)
 
+        # Get whether condition is require to exist and be true.
+        required = conditions.get(
+            'required',
+            self.DEFAULT_REQUIRE_CONSTRAINT
+        )
+
         # Get the condition information.
         try:
             input, value = self.item_getattr(
@@ -421,11 +427,7 @@ class Association(MutableMapping):
                 conditions['inputs'],
             )
         except KeyError:
-            if not conditions.get('force_undefined', False) and \
-               conditions.get(
-                   'required',
-                   self.DEFAULT_REQUIRE_CONSTRAINT
-               ):
+            if required and not conditions.get('force_undefined', False):
                 return False, reprocess
             else:
                 return True, reprocess

--- a/jwst/associations/lib/dms_base.py
+++ b/jwst/associations/lib/dms_base.py
@@ -16,7 +16,7 @@ _ASN_NAME_TEMPLATE_STAMP = 'jw{program}-{acid}_{stamp}_{type}_{sequence:03d}_asn
 _ASN_NAME_TEMPLATE = 'jw{program}-{acid}_{type}_{sequence:03d}_asn'
 
 # Exposure EXP_TYPE to Association EXPTYPE mapping
-_EXPTYPE_MAP = {
+EXPTYPE_MAP = {
     'mir_dark':      'dark',
     'mir_flatimage': 'flat',
     'mir_flatmrs':   'flat',
@@ -357,7 +357,7 @@ class DMSBaseMixin(ACIDMixin):
         except KeyError:
             raise LookupError('Exposure type cannot be determined')
 
-        result = _EXPTYPE_MAP.get(exp_type, default)
+        result = EXPTYPE_MAP.get(exp_type, default)
 
         if result is None:
             raise LookupError('Cannot determine exposure type')

--- a/jwst/associations/tests/test_level3_basics.py
+++ b/jwst/associations/tests/test_level3_basics.py
@@ -1,4 +1,6 @@
 """Test general Level 3 rules environment"""
+import pytest
+
 from .helpers import (
     combine_pools,
     registry_level3_only,
@@ -24,3 +26,32 @@ def test_meta():
     assert data['degraded_status'] == 'No known degraded exposures in association.'
     assert data['version_id'] is None
     assert data['constraints'] is not None
+
+
+@pytest.mark.parametrize(
+    'pool_file',
+    [
+        'data/pool_005_spec_niriss.csv',
+        'data/pool_006_spec_nirspec.csv',
+        'data/pool_007_spec_miri.csv',
+        'data/pool_009_spec_miri_lv2bkg.csv',
+        'data/pool_010_spec_nirspec_lv2bkg.csv',
+        'data/pool_015_spec_nirspec_lv2bkg_reversed.csv',
+        'data/pool_016_spec_nirspec_lv2bkg_double.csv',
+        'data/pool_017_spec_nirspec_lv2imprint.csv',
+        'data/pool_018_all_exptypes.csv',
+    ]
+)
+def test_targacq(pool_file):
+    """Test for existence of target acquisitions in associatons"""
+    rules = registry_level3_only()
+    pool = combine_pools(t_path(pool_file))
+    asns = generate(pool, rules)
+    assert len(asns) > 1
+    for asn in asns:
+        for product in asn['products']:
+            exptypes = [
+                member['exptype'].lower()
+                for member in product['members']
+            ]
+            assert 'target_acquistion' in exptypes

--- a/jwst/associations/tests/test_level3_basics.py
+++ b/jwst/associations/tests/test_level3_basics.py
@@ -28,6 +28,10 @@ def test_meta():
     assert data['constraints'] is not None
 
 
+@pytest.mark.xfail(
+    reason='Issue #1442',
+    run=False
+)
 @pytest.mark.parametrize(
     'pool_file',
     [


### PR DESCRIPTION
Preparation for work on issue #1442.

Test setup for ensuring that target acquisitions are included in all associations. However, actual implementation will require a refactor of constraint handling. This will appear later.