### PR TITLE
Updates to populate BUNIT in spectral products

### DIFF
--- a/jwst/datamodels/schemas/drizproduct.schema.yaml
+++ b/jwst/datamodels/schemas/drizproduct.schema.yaml
@@ -4,6 +4,16 @@ allOf:
 - $ref: lev3_prod.schema.yaml
 - type: object
   properties:
+    meta:
+      type: object
+      properties:
+        bunit_data:
+          title: physical units of the array values
+          type: string
+          fits_hdu: SCI
+          fits_keyword: BUNIT
+- type: object
+  properties:
     data:
       title: The science data
       fits_hdu: SCI

--- a/jwst/datamodels/schemas/multiproduct.schema.yaml
+++ b/jwst/datamodels/schemas/multiproduct.schema.yaml
@@ -28,6 +28,11 @@ allOf:
               datatype: int32
             relsens:
               $ref: relsens.schema.yaml
+            bunit_data:
+              title: physical units of the array values
+              type: string
+              fits_hdu: SCI
+              fits_keyword: BUNIT
             name:
               title: Name of the slit
               type: string

--- a/jwst/datamodels/schemas/multislit.schema.yaml
+++ b/jwst/datamodels/schemas/multislit.schema.yaml
@@ -1,6 +1,5 @@
 allOf:
 - $ref: core.schema.yaml
-- $ref: bunit.schema.yaml
 - type: object
   properties:
     slits:
@@ -49,6 +48,16 @@ allOf:
               fits_hdu: WAVELENGTH_UNIFORMSOURCE
               ndim: 1
               datatype: float32
+            bunit_data:
+              title: physical units of the array values
+              type: string
+              fits_hdu: SCI
+              fits_keyword: BUNIT
+            bunit_err:
+              title: physical units of the array values
+              type: string
+              fits_hdu: ERR
+              fits_keyword: BUNIT
             name:
               title: Name of the slit
               type: string

--- a/jwst/extract_2d/grisms.py
+++ b/jwst/extract_2d/grisms.py
@@ -151,6 +151,8 @@ def extract_grism_objects(input_model, grism_objects=[], reference_files={}):
             output_model.slits[-1].source_xpos = obj.xcenter
             output_model.slits[-1].source_ypos = obj.ycenter
             output_model.slits[-1].source_id = obj.sid
+            output_model.slits[-1].bunit_data = input_model.meta.bunit_data
+            output_model.slits[-1].bunit_err = input_model.meta.bunit_err
 
     del subwcs
     return output_model

--- a/jwst/extract_2d/nirspec.py
+++ b/jwst/extract_2d/nirspec.py
@@ -60,6 +60,10 @@ def nrs_extract2d(input_model, which_subarray=None, apply_wavecorr=False, refere
             nslit = len(output_model.slits) - 1
             set_slit_attributes(output_model, nslit, slit, xlo, xhi, ylo, yhi)
 
+            # Copy BUNIT values to output slit
+            output_model.slits[nslit].bunit_data = input_model.meta.bunit_data
+            output_model.slits[nslit].bunit_err = input_model.meta.bunit_err
+
     return output_model
 
 

--- a/jwst/resample/resample_spec_step.py
+++ b/jwst/resample/resample_spec_step.py
@@ -58,6 +58,7 @@ class ResampleSpecStep(Step):
                 if len(resamp.output_models) == 1:
                     out_slit = resamp.output_models[0]
                     output_product.products.append(out_slit)
+                    output_product.products[-1].bunit_data = input_models[0].meta.bunit_data
                 else:
                     out_slit = resamp.output_models
             result = output_product


### PR DESCRIPTION
Several updates to allow propagation of the BUNIT keyword in the SCI and ERR (where it exists) extensions of spectral _cal and _s2d products. Some steps were already setup to copy the value from the input model, but it wasn't showing up because BUNIT wasn't defined in the output model schema, so those schemas have been updated to include it. Others needed updates to the steps to copy over the input values, especially those that create MultiXXXX products as output.

This seems to now cover all cases mentioned in #63. Any spectral mode that produces a regular ImageModel or CubeModel as output was already copying the values via a call to output_model.update(). Those that produce a MultiSlit or MultiProduct model now work via these updates.

The DrizProduct schema was also updated to include the definition of BUNIT, so that the output.update() call already present in the resample step now results in propagated BUNIT values in the output resampled (_i2d) product.