### PR TITLE
guider_cds updates for BUNIT and python2 dependencies

### DIFF
--- a/jwst/guider_cds/guider_cds.py
+++ b/jwst/guider_cds/guider_cds.py
@@ -2,7 +2,6 @@
 # 
 #  guider_cds.py
 
-from __future__ import division
 import time
 import numpy as np
 import logging
@@ -75,6 +74,9 @@ def guider_cds(model):
 
     # copy all meta data from input to output model
     new_model.update(model)
+
+    # Update BUNIT to reflect count rate
+    new_model.meta.bunit_data = 'DN/s'
 
     # Add all table extensions to be carried over to output
     if len(model.planned_star_table):

--- a/jwst/guider_cds/guider_cds_step.py
+++ b/jwst/guider_cds/guider_cds_step.py
@@ -1,7 +1,5 @@
 #! /usr/bin/env python
 
-from __future__ import division
-
 from ..stpipe import Step, cmdline
 from .. import datamodels
 from . import guider_cds


### PR DESCRIPTION
Removed python2 dependencies and added a line to update the value of BUNIT in the output product, to reflect the fact that the output data are in count rates (DN/s).