### PR TITLE
Close the input model.  See GitHub issue #1636.

### DIFF
--- a/jwst/extract_1d/extract_1d_step.py
+++ b/jwst/extract_1d/extract_1d_step.py
@@ -108,6 +108,8 @@ class Extract1dStep(Step):
             # Set the step flag to complete
             result.meta.cal_step.extract_1d = 'COMPLETE'
 
+        input_model.close()
+
         return result
 
 def extract_1d_correction(input):


### PR DESCRIPTION
Under some conditions (errors), the input model can be returned, and in those cases it is the open model that will be returned.  Otherwise, the input model will be closed before the newly created output model is returned.