### PR TITLE
Modify error handling for schema validation errors

### DIFF
--- a/jwst/datamodels/fits_support.py
+++ b/jwst/datamodels/fits_support.py
@@ -438,32 +438,11 @@ def _schema_has_fits_hdu(schema):
     return has_fits_hdu[0]
 
 
-def _load_from_schema(hdulist, schema, tree, pass_invalid_values):
+def _load_from_schema(hdulist, schema, tree, context):
     known_keywords = {}
     known_datas = set()
     invalid_values = set()
     missing_values = set()
-
-    def build_errmsg():
-        # Prefix filename to error message where it can be found
-        errmsg = ""
-        if len(invalid_values) > 0:
-            values = ', '.join(list(invalid_values))
-            errmsg += "  Invalid values: {0}\n".format(values)
-
-        if len(missing_values) > 0:
-            values = ', '.join(list(missing_values))
-            errmsg += "  Missing values: {0}\n".format(values)
-
-        if errmsg:
-            try:
-                filename = hdulist._file.name
-            except AttributeError:
-                filename = None
-            if filename is not None:
-                errmsg = "In {0}\n{1}".format(filename, errmsg)
-
-        return errmsg
 
     def callback(schema, path, combiner, ctx, recurse):
         result = None
@@ -472,42 +451,30 @@ def _load_from_schema(hdulist, schema, tree, pass_invalid_values):
             result = _fits_keyword_loader(
                 hdulist, fits_keyword, schema,
                 ctx.get('hdu_index'), known_keywords)
+
             if result is None:
-                if schema.get('fits_required'):
-                    missing_values.add(fits_keyword)
+                util.validate_schema(result, schema,
+                                     context._pass_invalid_values,
+                                     context._strict_validation)
             else:
-                temp_schema = {
-                    '$schema':
-                    'http://stsci.edu/schemas/asdf-schema/0.1.0/asdf-schema'}
-                temp_schema.update(schema)
-                try:
-                    asdf_schema.validate(result, schema=temp_schema)
-                except jsonschema.ValidationError as errmsg:
-                    warnings.warn(str(errmsg), properties.ValidationWarning)
-                    invalid_values.add(fits_keyword)
-                else:
+                if util.validate_schema(result, schema,
+                                        context._pass_invalid_values,
+                                        context._strict_validation):
                     properties.put_value(path, result, tree)
 
         elif 'fits_hdu' in schema and (
                 'max_ndim' in schema or 'ndim' in schema or 'datatype' in schema):
             result = _fits_array_loader(
                 hdulist, schema, ctx.get('hdu_index'), known_datas)
+
             if result is None:
-                if schema.get('fits_required'):
-                   hdu_name = _get_hdu_name(schema)
-                   missing_values.add(hdu_name)
+                util.validate_schema(result, schema,
+                                     context._pass_invalid_values,
+                                     context._strict_validation)
             else:
-                temp_schema = {
-                    '$schema':
-                    'http://stsci.edu/schemas/asdf-schema/0.1.0/asdf-schema'}
-                temp_schema.update(schema)
-                try:
-                    asdf_schema.validate(result, schema=temp_schema)
-                except jsonschema.ValidationError as errmsg:
-                    fits_hdu = schema['fits_hdu']
-                    warnings.warn(str(errmsg), properties.ValidationWarning)
-                    invalid_values.add(fits_hdu)
-                else:
+                if util.validate_schema(result, schema,
+                                        context._pass_invalid_values,
+                                        context._strict_validation):
                     properties.put_value(path, result, tree)
 
         if schema.get('type') == 'array':
@@ -521,13 +488,6 @@ def _load_from_schema(hdulist, schema, tree, pass_invalid_values):
                 return True
 
     mschema.walk_schema(schema, callback)
-    errmsg = build_errmsg()
-    if errmsg:
-        if pass_invalid_values:
-            warnings.warn(errmsg, properties.ValidationWarning)
-        else:
-            raise jsonschema.ValidationError(errmsg)
-
     return known_keywords, known_datas
 
 
@@ -573,11 +533,11 @@ def _load_history(hdulist, tree):
         history.append(HistoryEntry({'description': entry}))
 
 
-def from_fits(hdulist, schema, extensions, pass_invalid_values):
+def from_fits(hdulist, schema, extensions, context):
     ff = fits_embed.AsdfInFits.open(hdulist, extensions=extensions)
 
-    known_keywords, known_datas = _load_from_schema(
-        hdulist, schema, ff.tree, pass_invalid_values)
+    known_keywords, known_datas = _load_from_schema(hdulist, schema,
+                                                    ff.tree, context)
     _load_extra_fits(hdulist, known_keywords, known_datas, ff.tree)
     _load_history(hdulist, ff.tree)
 

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -89,9 +89,9 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
 
         # Override value of validation parameters
         # if environment value set
-        self._pass_invalid_values = self.get_envar("pass_invalid_values",
+        self._pass_invalid_values = self.get_envar("PASS_INVALID_VALUES",
                                                     pass_invalid_values)
-        self._strict_validation = self.get_envar("strict_validation",
+        self._strict_validation = self.get_envar("STRICT_VALIDATION",
                                                  strict_validation)
 
         # Construct the path to the schema files
@@ -237,13 +237,12 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
             self._asdf.close()
 
     def get_envar(self, name, value):
-        env_name = name.upper()
-        if env_name in os.environ:
-            value = os.environ[env_name]
+        if name in os.environ:
+            value = os.environ[name]
             try:
                 value = bool(int(value))
             except ValueError:
-                value = False
+                value = True
         return value
 
     def get_resolver(self, asdf_file):

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -43,7 +43,7 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
     schema_url = "core.schema.yaml"
 
     def __init__(self, init=None, schema=None, extensions=None,
-                 pass_invalid_values=False):
+                 pass_invalid_values=False, strict_validation=False):
         """
         Parameters
         ----------
@@ -74,8 +74,11 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         extensions: classes extending the standard set of extensions, optional.
             If an extension is defined, the prefix used should be 'url'.
 
-        pass_invalid_values: If true, values that do not validate the schema can
-            be read and written and only a warning will be generated
+        pass_invalid_values: If true, values that do not validate the schema
+            will be added to the metadata. If false, they will be set to None
+
+        strict_validation: if true, an schema validation errors will generate
+            an excption. If false, they will generate a warning.
         """
         # Set the extensions
         if extensions is None:
@@ -84,15 +87,12 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
             extensions.extend(jwst_extensions)
         self._extensions = extensions
 
-        # Override value of pass_invalid value if environment value set
-        if "PASS_INVALID_VALUES" in os.environ:
-            pass_invalid_values = os.environ["PASS_INVALID_VALUES"]
-            try:
-                pass_invalid_values = bool(int(pass_invalid_values))
-            except ValueError:
-                pass_invalid_values = False
-
-        self._pass_invalid_values = pass_invalid_values
+        # Override value of validation parameters
+        # if environment value set
+        self._pass_invalid_values = self.get_envar("pass_invalid_values",
+                                                    pass_invalid_values)
+        self._strict_validation = self.get_envar("strict_validation",
+                                                 strict_validation)
 
         # Construct the path to the schema files
         filename = os.path.abspath(inspect.getfile(self.__class__))
@@ -113,6 +113,10 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
                                              resolve_references=True)
 
         self._schema = mschema.flatten_combiners(schema)
+
+        # Provide the object as context to other classes and functions
+        self._ctx = self
+
         # Determine what kind of input we have (init) and execute the
         # proper code to intiailize the model
         self._files_to_close = []
@@ -147,8 +151,8 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
             asdf = AsdfFile()
             is_shape = True
         elif isinstance(init, fits.HDUList):
-            asdf = fits_support.from_fits(init, self._schema, extensions,
-                                          pass_invalid_values)
+            asdf = fits_support.from_fits(init, self._schema,
+                                          extensions, self._ctx)
 
         elif isinstance(init, (str, bytes)):
             if isinstance(init, bytes):
@@ -158,7 +162,8 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
             if file_type == "fits":
                 hdulist = fits.open(init)
                 asdf = fits_support.from_fits(hdulist, self._schema,
-                                              extensions, pass_invalid_values)
+                                              extensions, self._ctx)
+
                 self._files_to_close.append(hdulist)
 
             elif file_type == "asdf":
@@ -178,7 +183,6 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         self._shape = shape
         self._instance = asdf.tree
         self._asdf = asdf
-        self._ctx = self
 
         # if the input is from a file, set the filename attribute
         if isinstance(init, str):
@@ -232,6 +236,16 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         if not self._iscopy and self._asdf is not None:
             self._asdf.close()
 
+    def get_envar(self, name, value):
+        env_name = name.upper()
+        if env_name in os.environ:
+            value = os.environ(env_name)
+            try:
+                value = bool(int(value))
+            except ValueError:
+                value = False
+        return value
+
     def get_resolver(self, asdf_file):
         extensions = asdf_file._extensions
         def asdf_file_resolver(uri):
@@ -261,7 +275,8 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         """
         result = self.__class__(init=None,
                                 extensions=self._extensions,
-                                pass_invalid_values=self._pass_invalid_values)
+                                pass_invalid_values=self._pass_invalid_values,
+                                strict_validation=self._strict_validation)
         self.clone(result, self, deepcopy=True, memo=memo)
         return result
 
@@ -853,8 +868,8 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
             hdu = fits.ImageHDU(name=hdu_name, header=header)
         hdulist = fits.HDUList([hdu])
 
-        ff = fits_support.from_fits(hdulist, self._schema, extensions=extensions,
-            pass_invalid_values=self._pass_invalid_values)
+        ff = fits_support.from_fits(hdulist, self._schema,
+                                    self._extensions, self._ctx)
 
         self._instance = properties.merge_tree(self._instance, ff.tree)
 

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -239,7 +239,7 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
     def get_envar(self, name, value):
         env_name = name.upper()
         if env_name in os.environ:
-            value = os.environ(env_name)
+            value = os.environ[env_name]
             try:
                 value = bool(int(value))
             except ValueError:

--- a/jwst/datamodels/properties.py
+++ b/jwst/datamodels/properties.py
@@ -3,7 +3,6 @@
 import copy
 import numpy as np
 import jsonschema
-import warnings
 
 from astropy.utils.compat.misc import override__dir__
 
@@ -138,7 +137,6 @@ def _get_schema_for_index(schema, i):
     else:
         return items
 
-
 def _find_property(schema, attr):
     subschema = _get_schema_for_property(schema, attr)
     if subschema == {}:
@@ -147,11 +145,6 @@ def _find_property(schema, attr):
         find = 'default' in subschema
     return find
 
-
-class ValidationWarning(Warning):
-    pass
-
-
 class Node(object):
     def __init__(self, instance, schema, ctx):
         self._instance = instance
@@ -159,34 +152,15 @@ class Node(object):
         self._schema['$schema'] = 'http://stsci.edu/schemas/asdf-schema/0.1.0/asdf-schema'
         self._ctx = ctx
 
-    def _report(self, errmsg):
-        try:
-            filename = self._ctx.meta.filename
-            errmsg = "In {0} {1}".format(filename, errmsg)
-        except AttributeError:
-            pass
-
-        if self._ctx._pass_invalid_values:
-            warnings.warn(errmsg, ValidationWarning)
-        else:
-            raise jsonschema.ValidationError(errmsg)
-
-
     def _validate(self):
-        instance = yamlutil.custom_tree_to_tagged_tree(
-            self._instance, self._ctx._asdf)
-        try:
-            schema.validate(instance, schema=self._schema)
-            valid = True
-        except jsonschema.ValidationError as errmsg:
-            self._report(str(errmsg))
-            valid = False
-        return valid
+        instance = yamlutil.custom_tree_to_tagged_tree(self._instance,
+                                                       self._ctx._asdf)
+        return util.validate_schema(instance, self._schema, False,
+                                    self._ctx._strict_validation)
 
     @property
     def instance(self):
         return self._instance
-
 
 class ObjectNode(Node):
     @override__dir__
@@ -234,34 +208,26 @@ class ObjectNode(Node):
             schema = _get_schema_for_property(self._schema, attr)
             if val is None:
                 val = _make_default(attr, schema, self._ctx)
-            val = _cast(val, schema)
-            old_val = self._instance.get(attr, None)
 
-            self._instance[attr] = val
-            try:
-                if not self._validate():
-                    self._revert(attr, old_val)
-            except jsonschema.ValidationError:
-                self._revert(attr, old_val)
-                raise
+            val = _cast(val, schema)
+            if util.validate_schema(val, schema, False,
+                                    self._ctx._strict_validation):
+                self._instance[attr] = val
 
     def __delattr__(self, attr):
         if attr.startswith('_'):
             del self.__dict__[attr]
         else:
-            old_val = self._instance.get(attr, None)
+            schema = _get_schema_for_property(self._schema, attr)
+            if not util.validate_schema(None, schema, False,
+                                        self._ctx._strict_validation):
+                return
 
             try:
                 del self._instance[attr]
             except KeyError:
                 raise AttributeError(
                     "Attribute '{0}' missing".format(attr))
-            try:
-                if not self._validate():
-                    self._revert(attr, old_val)
-            except jsonschema.ValidationError:
-                self._revert(attr, old_val)
-                raise
 
     def __hasattr__(self, attr):
         return (attr in self._instance or
@@ -270,13 +236,6 @@ class ObjectNode(Node):
     def __iter__(self):
         return NodeIterator(self)
 
-    def _revert(self, attr, old_val):
-        # Revert the change
-        if old_val is None:
-            del self._instance[attr]
-        else:
-            self._instance[attr] = old_val
-
     def items(self):
         # Return a (key, value) tuple for the node
         for key in self:
@@ -284,7 +243,6 @@ class ObjectNode(Node):
             for field in key.split('.'):
                 val = getattr(val, field)
             yield (key, val)
-
 
 class ListNode(Node):
     def __cast(self, other):
@@ -313,8 +271,10 @@ class ListNode(Node):
 
     def __setitem__(self, i, val):
         schema = _get_schema_for_index(self._schema, i)
-        self._instance[i] = _cast(val, schema)
-        self._validate()
+        val =  _cast(val, schema)
+        if util.validate_schema(val, schema, False,
+                                self._ctx._strict_validation):
+            self._instance[i] = val
 
     def __delitem__(self, i):
         del self._instance[i]
@@ -344,19 +304,25 @@ class ListNode(Node):
 
     def append(self, item):
         schema = _get_schema_for_index(self._schema, len(self._instance))
-        self._instance.append(_cast(item, schema))
-        self._validate()
+        item = _cast(item, schema)
+        if util.validate_schema(item, schema, False,
+                                self._ctx._strict_validation):
+            self._instance.append(item)
 
     def insert(self, i, item):
         schema = _get_schema_for_index(self._schema, i)
-        self._instance.insert(i, _cast(item, schema))
-        self._validate()
+        item = _cast(item, schema)
+        if util.validate_schema(item, schema, False,
+                                self._ctx._strict_validation):
+            self._instance.insert(i, item)
 
     def pop(self, i=-1):
         schema = _get_schema_for_index(self._schema, 0)
         x = self._instance.pop(i)
-        self._validate()
-        return _make_node(x, schema, self._ctx)
+        obj = _make_node(x, schema, self._ctx)
+        if not obj._validate():
+            obj = None
+        return obj
 
     def remove(self, item):
         self._instance.remove(item)
@@ -370,11 +336,9 @@ class ListNode(Node):
 
     def reverse(self):
         self._instance.reverse()
-        self._validate()
 
     def sort(self, *args, **kwargs):
         self._instance.sort(*args, **kwargs)
-        self._validate()
 
     def extend(self, other):
         for part in _unmake_node(other):
@@ -384,9 +348,9 @@ class ListNode(Node):
     def item(self, **kwargs):
         assert isinstance(self._schema['items'], dict)
         obj = ObjectNode(kwargs, self._schema['items'], self._ctx)
-        obj._validate()
+        if not obj._validate():
+            obj = None
         return obj
-
 
 class NodeIterator:
     """

--- a/jwst/datamodels/tests/test_schema.py
+++ b/jwst/datamodels/tests/test_schema.py
@@ -4,13 +4,16 @@ import datetime
 import os
 import shutil
 import tempfile
+import warnings
 
 import pytest
 import numpy as np
 from numpy.testing import assert_array_equal, assert_array_almost_equal
 
 import jsonschema
+from astropy.io import fits
 
+from .. import util
 from .. import DataModel, ImageModel, RampModel, MaskModel, MultiSlitModel, AsnModel
 
 from asdf import schema as mschema
@@ -42,28 +45,28 @@ def teardown():
 
 def test_choice():
     with pytest.raises(jsonschema.ValidationError):
-        with DataModel(FITS_FILE) as dm:
+        with DataModel(FITS_FILE, strict_validation=True) as dm:
             assert dm.meta.instrument.name == 'MIRI'
             dm.meta.instrument.name = 'FOO'
 
 
 def test_set_na_ra():
     with pytest.raises(jsonschema.ValidationError):
-        with DataModel(FITS_FILE) as dm:
+        with DataModel(FITS_FILE, strict_validation=True) as dm:
             # Setting an invalid value should raise a ValueError
             dm.meta.target.ra = "FOO"
 
 '''
 def test_date():
     with pytest.raises(jsonschema.ValidationError):
-        with ImageModel((50, 50)) as dm:
+        with ImageModel((50, 50), strict_validation=True) as dm:
             dm.meta.date = 'Not an acceptable date'
 
 
 def test_date2():
     from astropy import time
 
-    with ImageModel((50, 50)) as dm:
+    with ImageModel((50, 50), strict_validation=True) as dm:
         assert isinstance(dm.meta.date, (time.Time, datetime.datetime))
 '''
 
@@ -108,7 +111,8 @@ transformation_schema = {
 
 def test_list():
     with pytest.raises(jsonschema.ValidationError):
-        with ImageModel((50, 50), schema=transformation_schema) as dm:
+        with ImageModel((50, 50), schema=transformation_schema,
+                        strict_validation=True) as dm:
             dm.meta.transformations = []
             object = dm.meta.transformations.item(
                 transformation="SIN",
@@ -119,12 +123,57 @@ def test_list2():
     with pytest.raises(jsonschema.ValidationError):
         with ImageModel(
             (50, 50),
-            schema=transformation_schema) as dm:
+            schema=transformation_schema,
+            strict_validation=True) as dm:
             dm.meta.transformations = []
             object = dm.meta.transformations.append(
                 {'transformation': 'FOO',
                  'coeff': 2.0})
 '''
+
+def test_invalid_fits():
+    hdulist = fits.open(FITS_FILE)
+    header = hdulist[0].header
+    header['INSTRUME'] = 'FOO'
+
+    if os.path.exists(TMP_FITS):
+        os.remove(TMP_FITS)
+
+    hdulist.writeto(TMP_FITS)
+    hdulist.close()
+
+    with pytest.raises(util.ValidationWarning):
+        with warnings.catch_warnings():
+            warnings.simplefilter('error')
+            model = util.open(TMP_FITS,
+                              pass_invalid_values=False,
+                              strict_validation=False)
+            model.close()
+
+    with pytest.raises(jsonschema.ValidationError):
+        model = util.open(TMP_FITS,
+                          pass_invalid_values=False,
+                          strict_validation=True)
+        model.close()
+
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        model = util.open(TMP_FITS,
+                          pass_invalid_values=False,
+                          strict_validation=False)
+        assert model.meta.instrument.name is None
+        model.close()
+
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        model = util.open(TMP_FITS,
+                          pass_invalid_values=True,
+                          strict_validation=False)
+        assert model.meta.instrument.name == 'FOO'
+        model.close()
+
+    if os.path.exists(TMP_FITS):
+        os.remove(TMP_FITS)
 
 def test_ad_hoc_json():
     with DataModel() as dm:
@@ -212,7 +261,7 @@ schema_extra = {
 
 
 def test_dictionary_like():
-    with DataModel() as x:
+    with DataModel(strict_validation=True) as x:
         x.meta.origin = 'FOO'
         assert x['meta.origin'] == 'FOO'
 
@@ -478,7 +527,7 @@ def test_implicit_creation_lower_dimensionality():
 
 
 def test_add_schema_entry():
-    with DataModel() as dm:
+    with DataModel(strict_validation=True) as dm:
         dm.add_schema_entry('meta.foo.bar', {'enum': ['foo', 'bar', 'baz']})
         dm.meta.foo.bar
         dm.meta.foo.bar = 'bar'
@@ -540,6 +589,6 @@ def test_multislit_move_from_fits():
 '''
 def test_multislit_garbage():
     with pytest.raises(jsonschema.ValidationError):
-        m = MultiSlitModel()
+        m = MultiSlitModel(strict_validation=True)
         m.slits.append('junk')
 '''

--- a/jwst/datamodels/tests/test_schema.py
+++ b/jwst/datamodels/tests/test_schema.py
@@ -144,6 +144,37 @@ def test_invalid_fits():
 
     with pytest.raises(util.ValidationWarning):
         with warnings.catch_warnings():
+            os.environ['PASS_INVALID_VALUES'] = '0'
+            os.environ['STRICT_VALIDATION'] = '0'
+            warnings.simplefilter('error')
+            model = util.open(TMP_FITS)
+            model.close()
+
+    with pytest.raises(jsonschema.ValidationError):
+        os.environ['STRICT_VALIDATION'] = '1'
+        model = util.open(TMP_FITS)
+        model.close()
+
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        os.environ['PASS_INVALID_VALUES'] = '0'
+        os.environ['STRICT_VALIDATION'] = '0'
+        model = util.open(TMP_FITS)
+        assert model.meta.instrument.name is None
+        model.close()
+
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        os.environ['PASS_INVALID_VALUES'] = '1'
+        model = util.open(TMP_FITS)
+        assert model.meta.instrument.name == 'FOO'
+        model.close()
+
+    del os.environ['PASS_INVALID_VALUES']
+    del os.environ['STRICT_VALIDATION']
+
+    with pytest.raises(util.ValidationWarning):
+        with warnings.catch_warnings():
             warnings.simplefilter('error')
             model = util.open(TMP_FITS,
                               pass_invalid_values=False,

--- a/jwst/datamodels/util.py
+++ b/jwst/datamodels/util.py
@@ -2,16 +2,23 @@
 Various utility functions and data types
 """
 
+import re
 import sys
+import warnings
+import jsonschema
 from os.path import basename
+
 import numpy as np
 from astropy.io import fits
+from asdf import schema as asdf_schema
 
 import logging
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 log.addHandler(logging.NullHandler())
 
+class ValidationWarning(Warning):
+    pass
 
 def open(init=None, extensions=None, **kwargs):
     """
@@ -147,11 +154,11 @@ def open(init=None, extensions=None, **kwargs):
     model = new_class(init, extensions=extensions, **kwargs)
     if not has_model_type:
         model.meta.model_type = None
-    
+
     # Close the hdulist if we opened it
     if file_to_close is not None:
         model._files_to_close.append(file_to_close)
-        
+
     return model
 
 
@@ -403,3 +410,38 @@ def create_history_entry(description, software=None):
     if software is not None:
         entry['software'] = software
     return entry
+
+
+def validate_schema(value, schema, pass_invalid_values,
+                    strict_validation):
+    """
+    Validate a change in value against a schema and
+    """
+    try:
+        _validate_value(value, schema)
+        update = True
+
+    except jsonschema.ValidationError as errmsg:
+        update = False
+        if pass_invalid_values:
+            update = True
+        if strict_validation:
+            raise
+        else:
+            warnings.warn(str(errmsg), ValidationWarning)
+    return update
+
+
+def _validate_value(value, schema):
+    if value is None:
+        if schema.get('fits_required'):
+            name = schema.get("fits_keyword") or schema.get("fits_hdu")
+            raise jsonschema.ValidationError("%s is a required value"
+                                              % name)
+    else:
+        temp_schema = {
+            '$schema':
+            'http://stsci.edu/schemas/asdf-schema/0.1.0/asdf-schema'}
+        temp_schema.update(schema)
+        asdf_schema.validate(value, schema=temp_schema)
+


### PR DESCRIPTION
This update modifies the interface for creating new datamodels and the generic open function. The new interface has two optional parameters, pass_invalid_values and strict_validation, which control the handling of schema errors. There are also two environment variables PASS_INVALID_VALUES and STRICT_VALIDATION, which if set, override the values of the parameters. The default values of both parameters are False. When the metadata values are read from a FITS file or modified in a script, the value is checked against the schema for that model. If the value does not agree with the schem an exception is thrown if strict_validation is set to True or a warning is issued if strict_validation is set to False. If the value does not match the schema, the metadata is set to that value if pass_invalid_values is True or it is set to None if pass_invalid_values is False.

Please note that the default behavior of datamodels differs from previous behavior. Schema errors now generate warnings instead of exceptions.

Because the error handling is more complex, the code has been centralized into a new function in util.py, validate_schema. All schema checking calls this code directly or indirectly.

Where practical, the schema checking code in properties.py has been modified to only check the value being modified. Previously it would check the entire metadata tree. This change should lead to a significant speed improvement when many metadata items are set, deleted, or appended to a list.

Several tests have been modified to correctly test the modified code. One new test has been added.