### PR TITLE
Additional log info for jump and photom

### DIFF
--- a/jwst/jump/twopoint_difference.py
+++ b/jwst/jump/twopoint_difference.py
@@ -46,6 +46,8 @@ def find_CRs(data, gdq, read_noise, rej_threshold, nframes):
     # Loop over multiple integrations
     for integration in range(nints):
 
+        log.info(' working on integration %d' % (integration+1))
+
         # Roll the ngroups axis of data arrays to the end, to make
         # memory access to the values for a given pixel faster
         rdata = np.rollaxis(data[integration], 0, 3)

--- a/jwst/photom/photom.py
+++ b/jwst/photom/photom.py
@@ -292,14 +292,15 @@ class DataSet(object):
             # data for each of the slits/orders in the input
             for slit in self.input.slits:
 
-                log.info('Working on slit %s' % slit.name)
+                # Initialize the output conversion factor and
+                # increment slit number
                 conv_factor = None
                 self.slitnum += 1
 
-                # Set the input data order number.
-                # This is a hack for now; eventually the order number
-                # should be specified in the input data model
-                order = self.slitnum + 1
+                # Get the spectral order number for this slit
+                order = slit.meta.wcsinfo.spectral_order
+
+                log.info("Working on slit: {} order: {}:".format(slit.name, order))
 
                 # Locate matching row in reference file
                 for tabdata in ftab.phot_table:


### PR DESCRIPTION
Added a log message to jump/twopoint_difference to indicate loop over integrations and updated a log message in photom to include spectral order number along with the slit.