### PR TITLE
Fix caltso3 level-2c file names

### DIFF
--- a/jwst/pipeline/calwebb_tso3.py
+++ b/jwst/pipeline/calwebb_tso3.py
@@ -50,7 +50,6 @@ class Tso3Pipeline(Pipeline):
 
         self.log.info('Starting calwebb_tso3...')
         input_models = datamodels.open(input)
-        self.output_basename = input_models.meta.asn_table.products[0].name
 
         input_exptype = None
         # Input may consist of multiple exposures, so loop over each of them
@@ -91,11 +90,13 @@ class Tso3Pipeline(Pipeline):
             for cube in input_models:
                 # preserve output filename
                 original_filename = cube.meta.filename
-                self.save_model(cube, suffix='crfints')
+                suffix_2c = '{}_{}'.format(input_models.meta.asn_table.asn_id, 'crfints')
+                self.save_model(cube, suffix=suffix_2c)
                 cube.meta.filename = original_filename
 
         # Create final photometry results as a single output
         # regardless of how many members there may be...
+        self.output_basename = input_models.meta.asn_table.products[0].name
         phot_result_list = []
         if input_exptype in self.image_exptypes:
             # Create name for extracted photometry (Level 3) product


### PR DESCRIPTION
The calwebb_tso3 pipeline had a couple of problems with the naming of the level-2c (outlier_detection results) products. First, it was using the level-3 product name from the ASN file as the base name. This was due to having self.output_basename populated at the very beginning of the pipeline, which means save_model was using that instead of the value of model.meta.filename in the model that was passed to it. I moved the population of self.output_basename later in the pipeline flow (after outlier_detection), so that save_model now uses the model filename, which is the original level-2b input file name.  Second, we then need to add the association-id from the ASN file as part of the level-2c filename suffix. We now get proper exposure-based level-2c file names for the results of the outlier_detection step.