### PR TITLE
move check for negative ra to footprint calculation

### DIFF
--- a/jwst/assign_wcs/util.py
+++ b/jwst/assign_wcs/util.py
@@ -548,7 +548,14 @@ def update_s_region(model):
     if bbox is None:
         bbox = _bbox_from_shape(model)
 
-    footprint = model.meta.wcs.footprint(bbox, center=True).T
+    #footprint = model.meta.wcs.footprint(bbox, center=True).T
+    ra, dec = model.meta.wcs.footprint(bbox, center=True)
+    negative_ind = ra < 360
+    if negative_ind.any():
+        ra[negative_ind] = 360 + ra[negative_ind]
+
+    footprint = np.array([ra, dec]).T
+
     s_region = (
         "POLYGON ICRS "
         " {0} {1}"

--- a/jwst/transforms/models.py
+++ b/jwst/transforms/models.py
@@ -842,9 +842,6 @@ class V23ToSky(Rotation3D):
         x1, y1, z1 = super(V23ToSky, self).evaluate(x, y, z, angles)
         ra, dec = self.cartesian2spherical(x1, y1, z1)
 
-        negative_ind = ra < 0
-        if negative_ind.any():
-            ra[negative_ind] = 360 + ra[negative_ind]
         return ra, dec
 
     def __call__(self, v2, v3):


### PR DESCRIPTION
#1659 implemented a change which makes sure that sky footprints always report RA as a positive number .
However it change was implemented in the wrong place. The `V2V3ToSky` model is used also for its inverse and the positive RA (or first coordinate) was enforced also for V2 values when the inverse transforms is run.

This PR moves the positive RA enforcement to the footprint calculation and reverses #1659.
sigh...