### PR TITLE
Make skymatch quietly report lack of data

### DIFF
--- a/jwst/pipeline/skymatch.cfg
+++ b/jwst/pipeline/skymatch.cfg
@@ -5,6 +5,7 @@ skymethod = 'global+match'
 match_down =True
 subtract = False
 skystat = 'mode'
+dqbits = 0
 nclip = 5
 lsigma = 4.0
 usigma = 4.0

--- a/jwst/skymatch/skymatch.py
+++ b/jwst/skymatch/skymatch.py
@@ -543,7 +543,14 @@ def _find_optimum_sky_deltas(images, apply_sky=True):
                 invalid[j] = False
                 ieq += 1
 
-    rank = np.linalg.matrix_rank(K, 1.0e-12)
+    try:
+        rank = np.linalg.matrix_rank(K, 1.0e-12)
+    except np.linalg.LinAlgError:
+        log.warning("Unable to compute sky: No valid data in common "
+                    "image areas")
+        deltas = np.full(ns, np.nan, dtype=np.float)
+        return deltas
+
     if rank < ns - 1:
         log.warning("There are more unknown sky values ({}) to be solved for"
                     .format(ns))

--- a/jwst/skymatch/skymatch_step.py
+++ b/jwst/skymatch/skymatch_step.py
@@ -48,7 +48,7 @@ class SkyMatchStep(Step):
 
         # Sky statistics parameters:
         skystat = option('median', 'midpt', 'mean', 'mode', default='mode') # sky statistics
-        dqbits = string(default=None) # "good" DQ bits
+        dqbits = string(default=0) # "good" DQ bits
         lower = float(default=None) # Lower limit of "good" pixel values
         upper = float(default=None) # Upper limit of "good" pixel values
         nclip = integer(min=0, default=5) # number of sky clipping iterations

--- a/jwst/skymatch/skymatch_step.py
+++ b/jwst/skymatch/skymatch_step.py
@@ -132,7 +132,7 @@ class SkyMatchStep(Step):
 
         # create
         if self._dqbits is None:
-            dqmask = None
+            dqmask = np.isfinite(image_model.data).astype(dtype=np.uint8)
         else:
             dqmask = bitfield_to_boolean_mask(
                 image_model.dq,

--- a/jwst/skymatch/skymatch_step.py
+++ b/jwst/skymatch/skymatch_step.py
@@ -139,7 +139,7 @@ class SkyMatchStep(Step):
                 self._dqbits,
                 good_mask_value=1,
                 dtype=np.uint8
-            )
+            ) * np.isfinite(image_model.data)
 
         # see if 'skymatch' was previously run and raise an exception
         # if 'subtract' mode has changed compared to the previous pass:


### PR DESCRIPTION
This PR should address https://github.com/STScI-JWST/jwst/issues/1715 in that now `skymatch` will no longer throw an exception when either images do not intersect at all or when there are no valid (=non-flagged) data in the overlap regions. Instead, `skymatch` will print a warning message and will set sky values to `0.0`.