### PR TITLE
some steps need to work with SlitModel instead of ImageModel

### DIFF
--- a/jwst/datamodels/multiexposure.py
+++ b/jwst/datamodels/multiexposure.py
@@ -7,7 +7,7 @@ from asdf import treeutil
 
 from . import model_base
 from .image import ImageModel
-
+from .slit import SlitModel, SlitDataModel
 
 __all__ = ['MultiExposureModel']
 
@@ -42,7 +42,7 @@ class MultiExposureModel(model_base.DataModel):
         # Lets create a schema
         schema = self._build_schema()
 
-        if isinstance(init, ImageModel):
+        if isinstance(init, (SlitModel, SlitDataModel, ImageModel)):
             super(MultiExposureModel, self).__init__(
                 init=None,
                 schema=schema,

--- a/jwst/datamodels/slit.py
+++ b/jwst/datamodels/slit.py
@@ -33,9 +33,9 @@ class SlitDataModel(model_base.DataModel):
 
     def __init__(self, init=None, data=None, dq=None, err=None,
                  wavelength=None, var_poisson=None, var_rnoise=None,
-                 relsens=None, area=None, 
+                 relsens=None, area=None,
                  wavelength_pointsource=None, pathloss_pointsource=None,
-                 wavelength_uniformsource=None, pathloss_uniformsource=None, 
+                 wavelength_uniformsource=None, pathloss_uniformsource=None,
                  **kwargs):
         if isinstance(init, (SlitModel, ImageModel)):
             super(SlitDataModel, self).__init__(init=None, **kwargs)
@@ -141,6 +141,7 @@ class SlitModel(model_base.DataModel):
             self.err = init.err
             self.relsens = init.relsens
             self.area = init.area
+            self.wavelength = init.wavelength
             if hasattr(init, 'var_poisson'):
                 self.var_poisson = init.var_poisson
             if hasattr(init, 'var_rnoise'):
@@ -170,7 +171,7 @@ class SlitModel(model_base.DataModel):
 
         if var_rnoise is not None:
             self.var_rnoise = var_rnoise
-        
+
         if dq is not None:
             self.dq = dq
         if err is not None:

--- a/jwst/datamodels/slit.py
+++ b/jwst/datamodels/slit.py
@@ -141,7 +141,8 @@ class SlitModel(model_base.DataModel):
             self.err = init.err
             self.relsens = init.relsens
             self.area = init.area
-            self.wavelength = init.wavelength
+            if hasattr(init, 'wavelength'):
+                self.wavelength = init.wavelength
             if hasattr(init, 'var_poisson'):
                 self.var_poisson = init.var_poisson
             if hasattr(init, 'var_rnoise'):

--- a/jwst/datamodels/slit.py
+++ b/jwst/datamodels/slit.py
@@ -33,7 +33,10 @@ class SlitDataModel(model_base.DataModel):
 
     def __init__(self, init=None, data=None, dq=None, err=None,
                  wavelength=None, var_poisson=None, var_rnoise=None,
-                 relsens=None, area=None, **kwargs):
+                 relsens=None, area=None, 
+                 wavelength_pointsource=None, pathloss_pointsource=None,
+                 wavelength_uniformsource=None, pathloss_uniformsource=None, 
+                 **kwargs):
         if isinstance(init, (SlitModel, ImageModel)):
             super(SlitDataModel, self).__init__(init=None, **kwargs)
             self.data = init.data
@@ -81,9 +84,18 @@ class SlitDataModel(model_base.DataModel):
         if area is not None:
             self.area = area
 
-        # Implicitly create arrays
-        self.dq = self.dq
-        self.err = self.err
+        if dq is not None:
+            self.dq = dq
+        if err is not None:
+            self.err = err
+        if wavelength_pointsource is not None:
+            self.wavelength_poointsource = wavelength_pointsource
+        if pathloss_pointsource is not None:
+            self.pathloss_pointsource = pathloss_pointsource
+        if wavelength_uniformsource is not None:
+            self.wavelength_uniformsource = wavelength_uniformsource
+        if pathloss_uniformsource is not None:
+            self.pathloss_uniform_source = pathloss_uniformsource
 
 
 class SlitModel(model_base.DataModel):
@@ -116,7 +128,10 @@ class SlitModel(model_base.DataModel):
                  xsize=None, ystart=None, ysize=None, slitlet_id=None,
                  source_id=None, source_name=None, source_alias=None,
                  stellarity=None, source_type=None, source_xpos=None, source_ypos=None,
-                 shutter_state=None, area=None, relsens=None, barshadow=None, **kwargs):
+                 shutter_state=None, area=None, relsens=None, barshadow=None,
+                 wavelength_pointsource=None, pathloss_pointsource=None,
+                 wavelength_uniformsource=None, pathloss_uniformsource=None,
+                 **kwargs):
 
         if isinstance(init, (SlitModel, ImageModel)):
             super(SlitModel, self).__init__(init=None, **kwargs)
@@ -155,10 +170,23 @@ class SlitModel(model_base.DataModel):
 
         if var_rnoise is not None:
             self.var_rnoise = var_rnoise
-        # Implicitly create arrays
-        self.dq = self.dq
-        self.err = self.err
-
+        
+        if dq is not None:
+            self.dq = dq
+        if err is not None:
+            self.err = err
+        if bunit_data is not None:
+            self.meta.bunit_data = bunit_data
+        if bunit_err is not None:
+            self.meta.bunit_err = bunit_err
         if name is not None:
             self.name = name
 
+        if wavelength_pointsource is not None:
+            self.wavelength_poointsource = wavelength_pointsource
+        if pathloss_pointsource is not None:
+            self.pathloss_pointsource = pathloss_pointsource
+        if wavelength_uniformsource is not None:
+            self.wavelength_uniformsource = wavelength_uniformsource
+        if pathloss_uniformsource is not None:
+            self.pathloss_uniform_source = pathloss_uniformsource

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -1316,8 +1316,9 @@ def do_extract1d(input_model, refname, smoothing_length, bkg_order):
                     spec.name = slitname
                 output_model.spec.append(spec)
 
-        elif isinstance(input_model, datamodels.CubeModel):
+        elif isinstance(input_model, (datamodels.CubeModel, datamodels.SlitModel)):
 
+            # NRS_BRIGHTOBJ exposures are instances of SlitModel.
             for sp_order in spectral_order_list:
                 if sp_order == "not set yet":
                     sp_order = get_spectral_order(input_model)

--- a/jwst/extract_1d/extract_1d_step.py
+++ b/jwst/extract_1d/extract_1d_step.py
@@ -42,6 +42,9 @@ class Extract1dStep(Step):
         elif isinstance(input_model, datamodels.DrizProductModel):
             # Resampled 2-D data
             self.log.debug('Input is a DrizProductModel')
+        elif isinstance(input_model, datamodels.SlitModel):
+            # NRS_BRIGHTOBJ mode
+            self.log.debug('Input is a SlitModel')
         else:
             self.log.error('Input is a %s,', str(type(input_model)))
             self.log.error('which was not expected for extract_1d.')

--- a/jwst/extract_2d/extract_2d.py
+++ b/jwst/extract_2d/extract_2d.py
@@ -36,5 +36,4 @@ def extract2d(input_model, slit_name=None, apply_wavecorr=False, reference_files
     # Set the step status to COMPLETE
     output_model.meta.cal_step.extract_2d = 'COMPLETE'
     del input_model
-    log.info('extract_2d completed.')
     return output_model

--- a/jwst/extract_2d/extract_2d.py
+++ b/jwst/extract_2d/extract_2d.py
@@ -21,7 +21,8 @@ def extract2d(input_model, slit_name=None, apply_wavecorr=False, reference_files
 
     if exp_type in nrs_modes:
         output_model = nrs_extract2d(input_model, slit_name=slit_name,
-                              apply_wavecorr=apply_wavecorr, reference_files=reference_files)
+                                     apply_wavecorr=apply_wavecorr,
+                                     reference_files=reference_files)
 
     elif exp_type in grism_modes:
         output_model = extract_grism_objects(input_model, grism_objects=grism_objects, reference_files=reference_files)
@@ -35,4 +36,5 @@ def extract2d(input_model, slit_name=None, apply_wavecorr=False, reference_files
     # Set the step status to COMPLETE
     output_model.meta.cal_step.extract_2d = 'COMPLETE'
     del input_model
+    log.info('extract_2d completed.')
     return output_model

--- a/jwst/extract_2d/nirspec.py
+++ b/jwst/extract_2d/nirspec.py
@@ -196,7 +196,7 @@ def extract_slit(input_model, slit, exp_type):
     lam = lam.astype(np.float32)
     new_model = datamodels.SlitModel(data=ext_data, err=ext_err, dq=ext_dq, wavelength=lam,
                                          var_rnoise=ext_var_rnoise, var_poisson=ext_var_poisson)
-    log.info('input model type is {}'.format(input_model.__class__.__name__))
+    log.info('Input model type is {}'.format(input_model.__class__.__name__))
     new_model.update(input_model)
     new_model.meta.wcs = slit_wcs
     return new_model, xlo, xhi, ylo, yhi

--- a/jwst/extract_2d/nirspec.py
+++ b/jwst/extract_2d/nirspec.py
@@ -30,7 +30,7 @@ def nrs_extract2d(input_model, slit_name=None, apply_wavecorr=False, reference_f
     else:
         apply_wavecorr = False
         log.info("Skipping wavecorr correction for EXP_TYPE {0}".format(exp_type))
-    
+
     if hasattr(input_model.meta.cal_step, 'assign_wcs') and input_model.meta.cal_step.assign_wcs == 'SKIPPED':
         log.info("assign_wcs was skipped")
         log.warning("extract_2d: SKIPPED")
@@ -70,9 +70,11 @@ def nrs_extract2d(input_model, slit_name=None, apply_wavecorr=False, reference_f
             set_slit_attributes(new_model, slit, xlo, xhi, ylo, yhi)
 
             # Copy BUNIT values to output slit
-            new_model.bunit_data = input_model.meta.bunit_data
-            new_model.bunit_err = input_model.meta.bunit_err
+            new_model.meta.bunit_data = input_model.meta.bunit_data
+            new_model.meta.bunit_err = input_model.meta.bunit_err
+        log.info('before slits extend')
         output_model.slits.extend(slits)
+        log.info('after slits extend')
     return output_model
 
 
@@ -116,6 +118,7 @@ def set_slit_attributes(output_model, slit, xlo, xhi, ylo, yhi):
         output_model.slitlet_id = int(slit.name)
         # for pathloss correction
         output_model.shutter_state = slit.shutter_state
+    log.info('set slit_attributes completed')
 
 
 def offset_wcs(slit_wcs, slit_name):
@@ -192,7 +195,7 @@ def extract_slit(input_model, slit, exp_type):
     ra, dec, lam = slit_wcs(x, y)
     lam = lam.astype(np.float32)
     new_model = datamodels.SlitModel(data=ext_data, err=ext_err, dq=ext_dq, wavelength=lam,
-                                     var_rnoise=ext_var_rnoise, var_poisson=ext_var_poisson)
+                                         var_rnoise=ext_var_rnoise, var_poisson=ext_var_poisson)
     log.info('input model type is {}'.format(input_model.__class__.__name__))
     new_model.update(input_model)
     new_model.meta.wcs = slit_wcs

--- a/jwst/photom/photom_step.py
+++ b/jwst/photom/photom_step.py
@@ -24,7 +24,7 @@ class PhotomStep(Step):
         # Report the detected type of input model
         model_type = dm.__class__.__name__
         self.log.debug("Input is {}".format(model_type))
-        if model_type not in ('CubeModel', 'ImageModel',
+        if model_type not in ('CubeModel', 'ImageModel', 'SlitModel',
                               'IFUImageModel', 'MultiSlitModel'):
             self.log.warning("Input is not one of the supported model types: "
                              "CubeModel, ImageModel IFUImageModel or MultiSlitModel.")


### PR DESCRIPTION
more #1070 related changes

Because the items in `MultiSlitModel.slits`  are now instances of `SlitModel` and not `ImageModel` some models need to check for `SlitModel` as input. 
In addition there are some minor changes in other packages.

This is the result of debugging a problem with resample_spec_step when run on NRS Fs data. The error as seen in the reg tests is:

```
/data4/iraf_conda/bldtmp/pF3k/p/envs/dev/lib/python3.5/site-packages/jwst-0.9.1a0.dev108-py3.5-linux-x86_64.egg/jwst/resample/resample_spec_step.py", line 61, in process
    output_product.products[-1].bunit_data = input_models[0].meta.bunit_data
  File "/data4/iraf_conda/bldtmp/pF3k/p/envs/dev/lib/python3.5/site-packages/jwst-0.9.1a0.dev108-py3.5-linux-x86_64.egg/jwst/datamodels/properties.py", line 274, in __getitem__
    return _make_node(self._instance[i], schema, self._ctx)
```

However, this does not resolve the above problem. I think some of the schemas used by resample_spec_step may need to be updated to include the `slit` schema instead of individual items from it. @stscieisenhamer may know more about these schemas and how they are used, specifically the `product` schemas.