### PR TITLE
Add association candidate to asn_from_list

### DIFF
--- a/jwst/associations/__init__.py
+++ b/jwst/associations/__init__.py
@@ -4,7 +4,7 @@ from os.path import (
     join
 )
 
-__version__ = '0.9.9'
+__version__ = '0.9.10'
 
 
 # Utility

--- a/jwst/associations/asn_from_list.py
+++ b/jwst/associations/asn_from_list.py
@@ -99,6 +99,13 @@ class Main():
                 ' If not specified, the default rules will be searched.'
             )
         )
+        parser.add_argument(
+            '-i', '--id',
+            type=str,
+            default='o999',
+            help='The association candidate id to use. Default: "%(default)s"',
+            dest='acid'
+        )
 
         parser.add_argument(
             'filelist',
@@ -116,7 +123,8 @@ class Main():
             asn = asn_from_list(
                 parsed.filelist,
                 rule=rule,
-                product_name=parsed.product_name
+                product_name=parsed.product_name,
+                acid=parsed.acid
             )
             name, serialized = asn.dump(format=parsed.format)
             outfile.write(serialized)

--- a/jwst/associations/lib/dms_base.py
+++ b/jwst/associations/lib/dms_base.py
@@ -154,6 +154,7 @@ class DMSBaseMixin(ACIDMixin):
     def __init__(self, *args, **kwargs):
         super(DMSBaseMixin, self).__init__(*args, **kwargs)
 
+        self._acid = None
         self.from_items = []
         self.sequence = None
         if 'degraded_status' not in self.data:
@@ -191,7 +192,10 @@ class DMSBaseMixin(ACIDMixin):
     @property
     def acid(self):
         """Association ID"""
-        return self.acid_from_constraints()
+        acid = self._acid
+        if self._acid is None:
+            acid =  self.acid_from_constraints()
+        return acid
 
     @property
     def asn_name(self):

--- a/jwst/associations/lib/rules_level3_base.py
+++ b/jwst/associations/lib/rules_level3_base.py
@@ -321,7 +321,11 @@ class DMS_Level3_Base(DMSBaseMixin, Association):
         # Update meta info
         self.update_asn(item=item, member=member)
 
-    def _add_items(self, items, product_name=None, with_exptype=False):
+    def _add_items(self,
+                   items,
+                   product_name=None,
+                   with_exptype=False,
+                   **kwargs):
         """ Force adding items to the association
 
         Parameters
@@ -339,6 +343,9 @@ class DMS_Level3_Base(DMSBaseMixin, Association):
             If True, each item is expected to be a 2-tuple with
             the first element being the item to add as `expname`
             and the second items is the `exptype`
+
+        kwargs: dict
+            Allows other keyword arguments used by other subclasses.
 
         Notes
         -----

--- a/jwst/associations/tests/test_asn_from_list.py
+++ b/jwst/associations/tests/test_asn_from_list.py
@@ -23,12 +23,11 @@ def test_level2():
         member = members[0]
         assert member['expname'] == product['name']
         assert member['exptype'] == 'science'
+    name, serialized = asn.dump()
+    assert name.startswith('jwnoprogram-o999_none')
+    assert isinstance(serialized, str)
 
 
-@pytest.mark.xfail(
-    reason='See issue #1725',
-    run=False
-)
 def test_level2_from_cmdline(tmpdir):
     """Create a level2 assocaition from the command line"""
     rule = 'DMSLevel2bBase'


### PR DESCRIPTION
When force creating associations with `asn_from_list`, add ability to specify the association candidate. Necessary since Level2 associations only validate with `OBSERVATION` or `BACKGROUND` candidates.

Resolves #1725 