### PR TITLE
Modify a few model blender rules

### DIFF
--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -134,11 +134,13 @@ properties:
             title: (yyyy-mm-dd) UTC date at start of exposure
             fits_keyword: DATE-OBS
             blend_table: True
+            blend_rule: first
           time:
             title: (hh:mm:ss.ssssss) UTC time at start of exposure
             type: string
             fits_keyword: TIME-OBS
             blend_table: True
+            blend_rule: first
           date_end:
             title: UTC date at end of exposure
             type: string
@@ -542,6 +544,7 @@ properties:
               - fits_keyword: EXPSTART
                 title: UTC exposure start time
                 blend_table: True
+                blend_rule: first
           mid_time:
             allOf:
               - type: number
@@ -633,7 +636,6 @@ properties:
             title: Effective integration time (sec)
             type: number
             fits_keyword: EFFINTTM
-            blend_rule: sum
             blend_table: True
           exposure_time:
             title: Effective exposure time (sec)
@@ -656,7 +658,6 @@ properties:
             title: Number of resets between integrations
             type: integer
             fits_keyword: NRESETS
-            blend_rule: sum
             blend_table: True
           zero_frame:
             title: Zero frame was downlinked separately

--- a/jwst/model_blender/tests/test_blend.py
+++ b/jwst/model_blender/tests/test_blend.py
@@ -13,7 +13,7 @@ from .. import blendmeta
 
 #ROOT_DIR = os.path.join(os.path.dirname(__file__), 'data')
 start_times = [57877.00359994354, 57877.0168373584, 57877.03126958496]
-int_times = [107.3676, 107.3676, 107.3676]
+exp_times = [107.3676, 107.3676, 107.3676]
 end_times = [57877.0048426241, 57877.01808003896, 57877.03251226551]
 filenames = ['image1_cal.fits', 'image2_cal.fits', 'image3_cal.fits']
 dates = ['2017-11-30T13:52:20.367', '2017-11-11T15:14:29.176',
@@ -28,13 +28,13 @@ def setup():
     TMP_FILES = [ImageModel() for i in range(3)]
 
     INPUT_VALUES = {'meta.exposure.start_time': start_times,
-                    'meta.exposure.integration_time': int_times,
+                    'meta.exposure.exposure_time': exp_times,
                     'meta.exposure.end_time': end_times,
                     'meta.filename': filenames,
                     'meta.instrument.name': instrument_names,
                     'meta.date': dates}
     OUTPUT_VALUES = {'meta.exposure.start_time': start_times[0],
-                    'meta.exposure.integration_time': np.sum(int_times),
+                    'meta.exposure.exposure_time': np.sum(exp_times),
                     'meta.exposure.end_time': end_times[-1],
                     'meta.filename': filenames[0],
                     'meta.instrument.name': instrument_names[0],


### PR DESCRIPTION
Regression test results highlighted a couple of model blender rules that aren't correct. In particular, don't sum the EFFINTTIM, because the time per integration is constant across all exposures (it's OK to sum EFFEXPTIM). Also don't sum RESETS. The number of resets is also constant per exposure.