### PR TITLE
Allow catalog to be passed to pipeline from datamodel instead of association

### DIFF
--- a/jwst/assign_wcs/util.py
+++ b/jwst/assign_wcs/util.py
@@ -405,6 +405,8 @@ def create_grism_bbox(input_model, reference_files, mmag_extract=99.0):
     ysize = input_model.meta.subarray.ysize
 
     # extract the catalog objects
+    if input_model.meta.source_catalog.filename is None:
+        raise ValueError("No source catalog listed in datamodel")
     skyobject_list = get_object_info(input_model.meta.source_catalog.filename)
 
     # get the imaging transform to record the center of the object in the image

--- a/jwst/pipeline/calwebb_spec2.py
+++ b/jwst/pipeline/calwebb_spec2.py
@@ -142,7 +142,12 @@ class Spec2Pipeline(Pipeline):
         # a grism image, if so get the catalog
         # name from the asn and record it to the meta
         if exp_type in WFSS_TYPES:
-            input.meta.source_catalog.filename = members_by_type['sourcecat'][0]
+            if input.meta.source_catalog.filename is None:
+                try:
+                    input.meta.source_catalog.filename = members_by_type['sourcecat'][0]
+                except IndexError:
+                    raise IndexError("No source catalog specified in association or datamodel")
+
         input = self.assign_wcs(input)
 
         # Do background processing, if necessary

--- a/jwst/pipeline/calwebb_spec2.py
+++ b/jwst/pipeline/calwebb_spec2.py
@@ -142,10 +142,10 @@ class Spec2Pipeline(Pipeline):
         # a grism image, if so get the catalog
         # name from the asn and record it to the meta
         if exp_type in WFSS_TYPES:
-            if input.meta.source_catalog.filename is None:
-                try:
-                    input.meta.source_catalog.filename = members_by_type['sourcecat'][0]
-                except IndexError:
+            try:
+                input.meta.source_catalog.filename = members_by_type['sourcecat'][0]
+            except IndexError:
+                if input.meta.source_catalog.filename is None:
                     raise IndexError("No source catalog specified in association or datamodel")
 
         input = self.assign_wcs(input)


### PR DESCRIPTION
addresses #1738.

This updates the WFSS section of the Spec2 pipeline to look for the name of the source catalog only if the datamodel is not populated with a value for  datamodel.meta.source_catalog.filename, which is read from the SCATFILE FITS keyword. 

Do the science teams have a preference? What if an association is given that has a catalog name AND the datamodel also specifies a catalog name, which should take precedence? 