### PR TITLE
Straylight2

### DIFF
--- a/jwst/cube_build/coord.py
+++ b/jwst/cube_build/coord.py
@@ -78,6 +78,7 @@ def radec2std(crval1,crval2,ra,dec):
 
 # Compute the standard coordinates xi,eta from CRVAL1,CRVAL2 & ra,dec
 
+
     def check_val(ra):
         ra = np.asarray(ra)
     def check_val(dec):
@@ -91,6 +92,8 @@ def radec2std(crval1,crval2,ra,dec):
     dec0 = crval2*deg2rad
     radiff = ra*deg2rad - ra0;
     decr = dec*deg2rad;
+
+
 
     h = np.sin(decr) *math.sin(dec0) + np.cos(decr)*math.cos(dec0)*np.cos(radiff);
 

--- a/jwst/cube_build/cube_build_wcs_util.py
+++ b/jwst/cube_build/cube_build_wcs_util.py
@@ -21,13 +21,10 @@ log.setLevel(logging.DEBUG)
 
 #********************************************************************************
 # HELPER ROUTINES for IFUCubeData class defined in ifu_cube.py
-<<<<<<< 377992a36064ac6ae614e8f675d6490f0243a5cb
 # these methods relate to wcs type procedures.
 # determine_scale
-=======
 # these methods relate to wcs type procedures.  
 
->>>>>>> fix ra 0/360 issue
 
 #********************************************************************************
 def setup_wcs(self):
@@ -103,15 +100,8 @@ def setup_wcs(self):
 #________________________________________________________________________________
 # Open the input data model
 # Find the footprint of the image
-<<<<<<< 377992a36064ac6ae614e8f675d6490f0243a5cb
 
             with datamodels.IFUImageModel(ifile) as input_model:
-=======
-# amin, amax = ra min and max (0 to 360)
-# bmin, bmax = dec min and max (0 to 90, 0 to -90)
-# 
-            with datamodels.ImageModel(ifile) as input_model:
->>>>>>> fix ra 0/360 issue
                 if self.instrument == 'NIRSPEC':
                     flag_data = 0
                     ch_footprint = find_footprint_NIRSPEC(self,
@@ -322,12 +312,19 @@ def find_footprint_MIRI(self, input, this_channel, instrument_info):
     else:
         # error the coordinate system is not defined
         raise NoCoordSystem(" The output cube coordinate system is not definded")
+#________________________________________________________________________________
+# test for 0/360 wrapping in ra. if exists it makes it difficult to determine
+# ra range of IFU cube. 
 
     coord1_wrap = coord1.copy()
-    median_ra = np.nanmedian(coord1_wrap)
+    median_ra = np.nanmedian(coord1_wrap) # find the median 
+    # using median test if there is any wrapping going on
     wrap_index = np.where( np.fabs(coord1_wrap - median_ra) > 180.0)
     nwrap = wrap_index[0].size
 
+    print('*******',nwrap)
+
+    # get all the ra on the same "side" of 0/360 
     if(nwrap != 0 and median_ra < 180):
         coord1_wrap[wrap_index] = coord1_wrap[wrap_index] - 360.0
 
@@ -400,6 +397,9 @@ def find_footprint_NIRSPEC(self, input,flag_data):
             x,y = wcstools.grid_from_bounding_box(slice_wcs.bounding_box,step=(1,1), center=True)
             ra,dec,lam = slice_wcs(x,y)
 
+#________________________________________________________________________________
+# For each slice  test for 0/360 wrapping in ra. 
+# If exists it makes it difficult to determine  ra range of IFU cube. 
             ra_wrap = ra.copy()
             median_ra = np.nanmedian(ra_wrap)
             wrap_index = np.where( np.fabs(ra_wrap - median_ra) > 180.0)
@@ -425,8 +425,9 @@ def find_footprint_NIRSPEC(self, input,flag_data):
             lambda_slice[k + 1] = np.nanmax(lam)
 
         k = k + 2
-
-    raslice__wrap = a_slice.copy()
+#________________________________________________________________________________
+# now test the ra slices for conistency. Adjust if needed.  
+    raslice_wrap = a_slice.copy()
     median_ra = np.nanmedian(raslice_wrap)
     wrap_index = np.where( np.fabs(raslice_wrap - median_ra) > 180.0)
     nwrap = wrap_index[0].size
@@ -462,28 +463,17 @@ def set_geometry(self, footprint):
         ra_min, ra_max, dec_min, dec_max,lambda_min, lambda_max = footprint # in degrees
         dec_ave = (dec_min + dec_max)/2.0
 
-<<<<<<< 377992a36064ac6ae614e8f675d6490f0243a5cb
-        # actually this is hard due to converenge of hour angle
-        # improve determining ra_ave in the future - do not just average (BAD)
-        ra_ave = ((ra_min + ra_max)/2.0 )#* math.cos(dec_ave*deg2rad)
-=======
         # we can not average ra values because of the convergence of hour angles. 
         ravalues  = np.zeros(2) # we might want to increase the number of ravalues later
                                 # is just taking min and max is not sufficient
         ravalues[0] = ra_min
         ravalues[1] = ra_max
 
-#        ravalues = np.zeros(4)
-#        ravalues[0] = 0.5
-#        ravalues[1] = 359
-#        ravalues[2] = 358.0
-#        ravalues[3] = 1.0
-
 #        ra_ave = ((ra_min + ra_max)/2.0 )#* math.cos(dec_ave*deg2rad) 
 
+        # one more check on ra angles 
         ra_ave = average_ra(ravalues)
 
->>>>>>> fix ra 0/360 issue
 
         self.Crval1 = ra_ave
         self.Crval2 = dec_ave
@@ -496,12 +486,6 @@ def set_geometry(self, footprint):
         # find the CRPIX1 CRPIX2 - xi and eta centered at 0,0
         # to find location of center abs of min values is how many pixels
 
-<<<<<<< 377992a36064ac6ae614e8f675d6490f0243a5cb
-#        print('crval1 crval2',self.Crval1,self.Crval2)
-=======
-        n1a = int(math.ceil(math.fabs(xi_min) / self.Cdelt1)) 
-        n2a = int(math.ceil(math.fabs(eta_min) / self.Cdelt2)) 
->>>>>>> fix ra 0/360 issue
 
         n1a = int(math.ceil(math.fabs(xi_min) / self.Cdelt1))
         n2a = int(math.ceil(math.fabs(eta_min) / self.Cdelt2))

--- a/jwst/cube_build/cube_build_wcs_util.py
+++ b/jwst/cube_build/cube_build_wcs_util.py
@@ -21,8 +21,13 @@ log.setLevel(logging.DEBUG)
 
 #********************************************************************************
 # HELPER ROUTINES for IFUCubeData class defined in ifu_cube.py
+<<<<<<< 377992a36064ac6ae614e8f675d6490f0243a5cb
 # these methods relate to wcs type procedures.
 # determine_scale
+=======
+# these methods relate to wcs type procedures.  
+
+>>>>>>> fix ra 0/360 issue
 
 #********************************************************************************
 def setup_wcs(self):
@@ -98,8 +103,15 @@ def setup_wcs(self):
 #________________________________________________________________________________
 # Open the input data model
 # Find the footprint of the image
+<<<<<<< 377992a36064ac6ae614e8f675d6490f0243a5cb
 
             with datamodels.IFUImageModel(ifile) as input_model:
+=======
+# amin, amax = ra min and max (0 to 360)
+# bmin, bmax = dec min and max (0 to 90, 0 to -90)
+# 
+            with datamodels.ImageModel(ifile) as input_model:
+>>>>>>> fix ra 0/360 issue
                 if self.instrument == 'NIRSPEC':
                     flag_data = 0
                     ch_footprint = find_footprint_NIRSPEC(self,
@@ -113,6 +125,7 @@ def setup_wcs(self):
                                                        this_a,
                                                        self.instrument_info)
                     amin, amax, bmin, bmax, lmin, lmax = ch_footprint
+
 
 # If a dither offset list exists then apply the dither offsets (offsets in arc seconds)
 
@@ -137,6 +150,8 @@ def setup_wcs(self):
     final_b_max = max(b_max)
     final_lambda_min = min(lambda_min)
     final_lambda_max = max(lambda_max)
+#    print('final a,b,l',final_a_min,final_a_max,final_b_min,final_b_max,
+#          final_lambda_min,final_lambda_max)
 
     if(self.wavemin != None and self.wavemin > final_lambda_min):
         final_lambda_min = self.wavemin
@@ -308,8 +323,20 @@ def find_footprint_MIRI(self, input, this_channel, instrument_info):
         # error the coordinate system is not defined
         raise NoCoordSystem(" The output cube coordinate system is not definded")
 
-    a_min = np.nanmin(coord1)
-    a_max = np.nanmax(coord1)
+    coord1_wrap = coord1.copy()
+    median_ra = np.nanmedian(coord1_wrap)
+    wrap_index = np.where( np.fabs(coord1_wrap - median_ra) > 180.0)
+    nwrap = wrap_index[0].size
+
+    if(nwrap != 0 and median_ra < 180):
+        coord1_wrap[wrap_index] = coord1_wrap[wrap_index] - 360.0
+
+    if(nwrap != 0 and median_ra > 180):
+        coord1_wrap[wrap_index] = coord1_wrap[wrap_index] + 360.0
+
+                          
+    a_min = np.nanmin(coord1_wrap)
+    a_max = np.nanmax(coord1_wrap)
 
     b_min = np.nanmin(coord2)
     b_max = np.nanmax(coord2)
@@ -373,8 +400,23 @@ def find_footprint_NIRSPEC(self, input,flag_data):
             x,y = wcstools.grid_from_bounding_box(slice_wcs.bounding_box,step=(1,1), center=True)
             ra,dec,lam = slice_wcs(x,y)
 
-            a_slice[k] = np.nanmin(ra)
-            a_slice[k + 1] = np.nanmax(ra)
+            ra_wrap = ra.copy()
+            median_ra = np.nanmedian(ra_wrap)
+            wrap_index = np.where( np.fabs(ra_wrap - median_ra) > 180.0)
+            nwrap = wrap_index[0].size
+
+            if(nwrap != 0 and median_ra < 180):
+                ra_wrap[wrap_index] = ra_wrap[wrap_index] - 360.0
+
+            if(nwrap != 0 and median_ra > 180):
+                ra_wrap[wrap_index] = ra_wrap[wrap_index] + 360.0
+
+                          
+            a_min = np.nanmin(ra_wrap)
+            a_max = np.nanmax(ra_wrap)
+
+            a_slice[k] = a_min
+            a_slice[k + 1] = a_max
 
             b_slice[k] = np.nanmin(dec)
             b_slice[k + 1] = np.nanmax(dec)
@@ -384,8 +426,19 @@ def find_footprint_NIRSPEC(self, input,flag_data):
 
         k = k + 2
 
-    a_min = min(a_slice)
-    a_max = max(a_slice)
+    raslice__wrap = a_slice.copy()
+    median_ra = np.nanmedian(raslice_wrap)
+    wrap_index = np.where( np.fabs(raslice_wrap - median_ra) > 180.0)
+    nwrap = wrap_index[0].size
+
+    if(nwrap != 0 and median_ra < 180):
+        raslice_wrap[wrap_index] = raslice_wrap[wrap_index] - 360.0
+
+    if(nwrap != 0 and median_ra > 180):
+        raslice_wrap[wrap_index] = raslice_wrap[wrap_index] + 360.0
+
+    a_min = np.nanmin(raslice_wrap)
+    a_max = np.nanmax(raslice_wrap)
 
     b_min = min(b_slice)
     b_max = max(b_slice)
@@ -409,9 +462,28 @@ def set_geometry(self, footprint):
         ra_min, ra_max, dec_min, dec_max,lambda_min, lambda_max = footprint # in degrees
         dec_ave = (dec_min + dec_max)/2.0
 
+<<<<<<< 377992a36064ac6ae614e8f675d6490f0243a5cb
         # actually this is hard due to converenge of hour angle
         # improve determining ra_ave in the future - do not just average (BAD)
         ra_ave = ((ra_min + ra_max)/2.0 )#* math.cos(dec_ave*deg2rad)
+=======
+        # we can not average ra values because of the convergence of hour angles. 
+        ravalues  = np.zeros(2) # we might want to increase the number of ravalues later
+                                # is just taking min and max is not sufficient
+        ravalues[0] = ra_min
+        ravalues[1] = ra_max
+
+#        ravalues = np.zeros(4)
+#        ravalues[0] = 0.5
+#        ravalues[1] = 359
+#        ravalues[2] = 358.0
+#        ravalues[3] = 1.0
+
+#        ra_ave = ((ra_min + ra_max)/2.0 )#* math.cos(dec_ave*deg2rad) 
+
+        ra_ave = average_ra(ravalues)
+
+>>>>>>> fix ra 0/360 issue
 
         self.Crval1 = ra_ave
         self.Crval2 = dec_ave
@@ -419,11 +491,17 @@ def set_geometry(self, footprint):
 
         xi_min,eta_min = coord.radec2std(self.Crval1, self.Crval2,ra_min,dec_min)
         xi_max,eta_max = coord.radec2std(self.Crval1, self.Crval2,ra_max,dec_max)
+
 #________________________________________________________________________________
         # find the CRPIX1 CRPIX2 - xi and eta centered at 0,0
         # to find location of center abs of min values is how many pixels
 
+<<<<<<< 377992a36064ac6ae614e8f675d6490f0243a5cb
 #        print('crval1 crval2',self.Crval1,self.Crval2)
+=======
+        n1a = int(math.ceil(math.fabs(xi_min) / self.Cdelt1)) 
+        n2a = int(math.ceil(math.fabs(eta_min) / self.Cdelt2)) 
+>>>>>>> fix ra 0/360 issue
 
         n1a = int(math.ceil(math.fabs(xi_min) / self.Cdelt1))
         n2a = int(math.ceil(math.fabs(eta_min) / self.Cdelt2))
@@ -583,6 +661,81 @@ def set_geometryAB(self, footprint):
 
 
 #_______________________________________________________________________
+# from a set of ra values find the average ra.
+# This is tricky because of the convergence of hour angles
+# this method is taken from the SPITZER SSC MOSAICER tool
+def average_ra(ravalues):
+
+
+# first check that all the values are 0 to 360 degrees
+    num_values = ravalues.size
+
+    alpha = np.zeros(num_values)
+    dist  = np.zeros(num_values)
+    cap = np.zeros((num_values,num_values))
+    ave_ra = 0.0
+    D360 = 360.0
+    ra_sum = 0.0
+    for i in range(num_values):
+        if(ravalues[i] < 0.0):
+            ravalues[i] = ravalues[i] + D360
+        ra_sum = ra_sum + ravalues[i]
+
+
+    alpha[0] = ra_sum/num_values
+
+# Example of problem: average 0, 359, 1, 358
+# since we might need to add 360 to some of the values to average them
+# correctly set up alpha array 
+# to do this correctly need to add 360 to some values  values:
+# 0 + 360, 359, 1 + 360, 358 
+# 
+    for i in range(1,num_values):
+        alpha[i] = alpha[0] + (D360 * float(i)/num_values)
+        
+        if(alpha[i] < 0.0): 
+            alpha[i] = alpha[i] + D360
+        elif(alpha[i] > D360):
+            alpha[i] = alpha[i] - D360
+
+# create the  cap array
+    complement = 0.0
+    for i in range(num_values): #col
+        for j in range(num_values): #row
+            cap[i,j] = np.fabs(alpha[j] - ravalues[i])
+            complement = D360 - cap[i,j]
+            if(complement < cap[i,j]):
+                cap[i,j] = complement
+
+
+# sum cal along the j index 
+# determine which min is the correct average ra value
+    min_dist = 10000.0
+    min_index = -1
+    for j in range(num_values):
+        dist[j] = 0.0
+        for i in range(num_values):
+            dist[j] = dist[j] + np.fabs(cap[i,j])
+
+
+        if(dist[j] < min_dist):
+            min_dist = dist[j]
+            min_index = j
+
+    if(min_index == -1):
+        raise RaAveError(" Can not determine right ascension average from list")
+        for i in range(num_values):
+            log.info('Ra values  %d', self.ravalues[i])
+        
+
+    else:
+        ave_ra = alpha[min_index]
+        log.info('Mean ra',ave_ra)
+
+
+# update the ra values so ra_min, ra_max 
+    return ave_ra
+#_______________________________________________________________________
 def print_cube_geometry(self):
         log.info('Cube Geometry:')
         blank = '  '
@@ -613,3 +766,11 @@ def print_cube_geometry(self):
                 this_fwa = self.list_par2[i]
                 this_gwa = self.list_par1[i]
                 log.info('Cube covers grating, filter: %s %s ', this_gwa,this_fwa)
+
+#________________________________________________________________________________
+# Errors 
+class NoCoordSystem(Exception):
+    pass
+
+class RaAveError(Exception):
+    pass

--- a/jwst/cube_build/cube_build_wcs_util.py
+++ b/jwst/cube_build/cube_build_wcs_util.py
@@ -317,17 +317,14 @@ def find_footprint_MIRI(self, input, this_channel, instrument_info):
 # test for 0/360 wrapping in ra. if exists it makes it difficult to determine
 # ra range of IFU cube. 
 
+    valid = np.isfinite(coord1)
+    coord1_wrap = coord1[valid].copy()
     
-    coord1_wrap = coord1.copy()
     median_ra = np.nanmedian(coord1_wrap) # find the median 
     # using median test if there is any wrapping going on
-    print('median ra',median_ra)
-    temp = coord1_wrap - median_ra
-    print(temp)
+
     wrap_index = np.where( np.fabs(coord1_wrap - median_ra) > 180.0)
     nwrap = wrap_index[0].size
-
-    print('*******',nwrap)
 
     # get all the ra on the same "side" of 0/360 
     if(nwrap != 0 and median_ra < 180):
@@ -405,7 +402,8 @@ def find_footprint_NIRSPEC(self, input,flag_data):
 #________________________________________________________________________________
 # For each slice  test for 0/360 wrapping in ra. 
 # If exists it makes it difficult to determine  ra range of IFU cube. 
-            ra_wrap = ra.copy()
+            valid = np.isfinite(ra)
+            ra_wrap = ra[valid].copy()
             median_ra = np.nanmedian(ra_wrap)
             wrap_index = np.where( np.fabs(ra_wrap - median_ra) > 180.0)
             nwrap = wrap_index[0].size
@@ -432,6 +430,7 @@ def find_footprint_NIRSPEC(self, input,flag_data):
         k = k + 2
 #________________________________________________________________________________
 # now test the ra slices for conistency. Adjust if needed.  
+        
     raslice_wrap = a_slice.copy()
     median_ra = np.nanmedian(raslice_wrap)
     wrap_index = np.where( np.fabs(raslice_wrap - median_ra) > 180.0)
@@ -719,7 +718,8 @@ def average_ra(ravalues):
 
     else:
         ave_ra = alpha[min_index]
-        log.info('Mean ra',ave_ra)
+
+        log.info('Mean ra %12.8f',ave_ra)
 
 
 # update the ra values so ra_min, ra_max 

--- a/jwst/cube_build/cube_build_wcs_util.py
+++ b/jwst/cube_build/cube_build_wcs_util.py
@@ -293,6 +293,7 @@ def find_footprint_MIRI(self, input, this_channel, instrument_info):
     xstart, xend = instrument_info.GetMIRISliceEndPts(this_channel)
     y, x = np.mgrid[:1024, xstart:xend]
 
+
     coord1 = np.zeros(y.shape)
     coord2 = np.zeros(y.shape)
     lam = np.zeros(y.shape)
@@ -316,9 +317,13 @@ def find_footprint_MIRI(self, input, this_channel, instrument_info):
 # test for 0/360 wrapping in ra. if exists it makes it difficult to determine
 # ra range of IFU cube. 
 
+    
     coord1_wrap = coord1.copy()
     median_ra = np.nanmedian(coord1_wrap) # find the median 
     # using median test if there is any wrapping going on
+    print('median ra',median_ra)
+    temp = coord1_wrap - median_ra
+    print(temp)
     wrap_index = np.where( np.fabs(coord1_wrap - median_ra) > 180.0)
     nwrap = wrap_index[0].size
 

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -738,6 +738,7 @@ class IFUCubeData(object):
         IFUCube.meta.roi_wave = self.roiw
         IFUCube.meta.weighting = self.weighting
         IFUCube.meta.weight_power = self.weight_power
+        IFUCube.meta.channel = '1'
 
         with datamodels.open(self.input_models[j]) as input:
             IFUCube.meta.bunit_data = input.meta.bunit_data

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -696,10 +696,10 @@ class IFUCubeData(object):
                 self.output_file = None
                 newname  = IFUCubeData.define_cubename(self)
                 IFUCube.meta.filename = newname
-                if(self.instrument == 'MIRI'):
-                    IFUCube.meta.instrument.channel = self.list_par1[0]
-                if(self.instrument == 'NIRSPEC'):
-                    IFUCube.meta.instrument.grating = self.list_par1[0]
+#                if(self.instrument == 'MIRI'):
+#                    IFUCube.meta.instrument.channel = self.list_par1[0]
+#                if(self.instrument == 'NIRSPEC'):
+#                    IFUCube.meta.instrument.grating = self.list_par1[0]
 
         IFUCube.meta.wcsinfo.crval1 = self.Crval1
         IFUCube.meta.wcsinfo.crval2 = self.Crval2
@@ -738,7 +738,7 @@ class IFUCubeData(object):
         IFUCube.meta.roi_wave = self.roiw
         IFUCube.meta.weighting = self.weighting
         IFUCube.meta.weight_power = self.weight_power
-        IFUCube.meta.channel = '1'
+        #IFUCube.meta.channel = '1'
 
         with datamodels.open(self.input_models[j]) as input:
             IFUCube.meta.bunit_data = input.meta.bunit_data

--- a/jwst/datamodels/schemas/ifucube.schema.yaml
+++ b/jwst/datamodels/schemas/ifucube.schema.yaml
@@ -35,6 +35,10 @@ allOf:
           title: Weighting power for Modified Shepard Method
           type: number
           fits_keyword: WPOWER
+        channel:
+          title: MIRI MRS channels represented in the Cube
+          type: string
+          fits_keyword: CHANNEL
 
 - type: object
   properties:

--- a/jwst/datamodels/schemas/ifucube.schema.yaml
+++ b/jwst/datamodels/schemas/ifucube.schema.yaml
@@ -35,10 +35,7 @@ allOf:
           title: Weighting power for Modified Shepard Method
           type: number
           fits_keyword: WPOWER
-        channel:
-          title: MIRI MRS channels represented in the Cube
-          type: string
-          fits_keyword: CHANNEL
+
 
 - type: object
   properties:

--- a/jwst/pipeline/straylight.cfg
+++ b/jwst/pipeline/straylight.cfg
@@ -1,2 +1,5 @@
 name = "straylight"
 class = "jwst.straylight.StraylightStep"
+method = "ModShepard"
+roi = 50
+power = 1

--- a/jwst/straylight/straylight.py
+++ b/jwst/straylight/straylight.py
@@ -64,11 +64,10 @@ def correct_MRS(input_model, straylight_model):
 #    drow = 412
 #    dx1 = 470
 #    dx2 = 480
-#    dxhot = dx1 + 6
 
     output = input_model.copy() # this is used in algorithm to
     # find the straylight correction.
-    output2_data = input_model.data.copy()
+
     #_________________________________________________________________
     # if there are nans remove them because they mess up the correction
     index_inf = np.isinf(output.data).nonzero()
@@ -189,7 +188,8 @@ def correct_MRS(input_model, straylight_model):
     simage[:, 1028:1032] = 0.0
     simage[:, 0:4] = 0.0
 
-    output.data = output2_data - simage
+
+    output.data = output.data - simage
     return output
 
 

--- a/jwst/straylight/straylight_step.py
+++ b/jwst/straylight/straylight_step.py
@@ -3,15 +3,23 @@
 from ..stpipe import Step, cmdline
 from .. import datamodels
 from . import straylight
-
+from ..datamodels import RegionsModel
 
 class StraylightStep (Step):
     """
     StraylightStep: Performs straylight correction image using a Mask file.
     """
-    reference_file_types = ['straymask']
+
+    spec = """
+         method = option('Nearest','ModShepard',default='ModShepard')
+         roi = float(default = 50.0)
+         power = float(default = 1.0)
+
+    """
+    reference_file_types = ['regions','straymask']
 
     def process(self, input):
+
 
         # Open the input data model
         with datamodels.IFUImageModel(input) as input_model:
@@ -20,28 +28,48 @@ class StraylightStep (Step):
             detector = input_model.meta.instrument.detector
             if detector == 'MIRIFUSHORT':
 
+                if self.method == 'Nearest': 
                 # Get the name of the straylight reference file
-                self.straylight_name = self.get_reference_file(input_model,
-                                                               'straymask')
-                self.log.info('Using STRAYLIGHT reference file %s',
-                                                      self.straylight_name)
-
+                    self.straylight_name = self.get_reference_file(input_model,
+                                                                   'straymask')
+                    self.log.info('Using straylight reference file %s',
+                                  self.straylight_name)
                 # Check for a valid reference file
-                if self.straylight_name == 'N/A':
-                    self.log.warning('No STRAYLIGHT reference file found')
-                    self.log.warning('Straylight step will be skipped')
-                    result = input_model.copy()
-                    result.meta.cal_step.straylight = 'SKIPPED'
-                    return result
+                    if self.straylight_name == 'N/A':
+                        self.log.warning('No STRAYLIGHT reference file found')
+                        self.log.warning('Straylight step will be skipped')
+                        result = input_model.copy()
+                        result.meta.cal_step.straylight = 'SKIPPED'
+                        return result
 
                 # Open the straylight mask ref file data model
-                straylight_model = datamodels.StrayLightModel(self.straylight_name)
+                    straylight_model = datamodels.StrayLightModel(self.straylight_name)
+                    result = straylight.correct_MRS(input_model, straylight_model)
+                # Close the reference file and update the step status
+                    straylight_model.close()
+# ________________________________________________________________________________
+                if self.method == 'ModShepard': 
+                    self.regions_name = self.get_reference_file(input_model,
+                                                                'regions')
+                    self.log.info('Using Regions reference file %s',
+                                  self.regions_name)
+                # Check for a valid reference file
+                    if self.regions_name == 'N/A':
+                        self.log.warning('No STRAYLIGHT/REGIONS reference file found')
+                        self.log.warning('Straylight step will be skipped')
+                        result = input_model.copy()
+                        result.meta.cal_step.straylight = 'SKIPPED'
+                        return result
+
+                # Open the straylight mask ref file data model
+                    region_model = datamodels.RegionsModel(self.regions_name)
 
                 # Do the correction
-                result = straylight.correct_MRS(input_model, straylight_model)
-
-                # Close the reference file and update the step status
-                straylight_model.close()
+                    result = straylight.correct_MRS_ModShepard(input_model, 
+                                                               region_model,
+                                                               self.roi,
+                                                               self.power)
+# ________________________________________________________________________________
                 result.meta.cal_step.straylight = 'COMPLETE'
 
             else:

--- a/jwst/straylight/straylight_step.py
+++ b/jwst/straylight/straylight_step.py
@@ -61,6 +61,8 @@ class StraylightStep (Step):
                         result.meta.cal_step.straylight = 'SKIPPED'
                         return result
 
+                    self.log.info(' Region of influence radius (pixels) %62f',self.roi)
+                    self.log.info(' Modified Shepard weighting power %5.2f',self.power)
                 # Open the straylight mask ref file data model
                     region_model = datamodels.RegionsModel(self.regions_name)
 


### PR DESCRIPTION
added straylight removal by using Modified Shepard Method to  find the distances of the pixels in the slice gaps. 
This method is set to be used by default, but the other straylight method was kept and can be used
by --method=Nearest. We can probably remove the old method (nearest) at a later date after INS has tested this method. For now I left it.
