### PR TITLE
Verify individual attributes when getting and setting

### DIFF
--- a/jwst/resample/resample_spec.py
+++ b/jwst/resample/resample_spec.py
@@ -408,8 +408,9 @@ class ResampleSpecData:
                         'slitlet_id', 'source_id', 'source_name', 'source_alias',
                         'stellarity', 'source_type', 'source_xpos', 'source_ypos',
                         'shutter_state', 'relsens']:
-                    if hasattr(img, attr):
-                        setattr(output_model, attr, getattr(img, attr))
+                    val = getattr(img, attr)
+                    if val is not None:
+                        setattr(output_model, attr, val)
             except:
                 pass
 


### PR DESCRIPTION
This update corrects and completes the change to validating attributes when they are set. It creates a new node, validates the node, and if the validation does not fail, it sets the attribute. This update
corrects the previous fix by calling custom_tree_to_tagged_tree on the node's data prior to validation. This function converts asdf types into lists and dictionaries which can be validated by the json/yaml parser.

This update also revises the code in resample_spec which builds the metadata structure appended to the datamodel. Because validation is an all or nothing operation, it is important when building the metadata structure to check the result of getattr for None. That indicates the value was not found in the input. Blindly copying the value from input to output without checking would result in spurious values being copied.

Why not call hasattr before getattr instead of checking the value of getattr for None? In datamodels hasattr indicates the value is either in the model or in the schema. This was not changed as a good bit of code expects that hasattr works this way. So to check if a value is in the data, check the return value of getattr for None. To check if the value is in the schema, call hasattr. Resample_spec has been revised to follow this guideline.