### PR TITLE
Fix resample_spec output model

### DIFF
--- a/jwst/resample/resample_spec.py
+++ b/jwst/resample/resample_spec.py
@@ -408,8 +408,12 @@ class ResampleSpecData:
                         'slitlet_id', 'source_id', 'source_name', 'source_alias',
                         'stellarity', 'source_type', 'source_xpos', 'source_ypos',
                         'shutter_state', 'relsens']:
-                    if hasattr(img, attr):
-                        setattr(output_model, attr, getattr(img, attr))
+                    try:
+                        val = getattr(img, attr)
+                    except:
+                        val = None
+                    if val is not None:
+                        setattr(output_model, attr, val)
             except:
                 pass
 


### PR DESCRIPTION
#1747 fixed a problem in datamodels schema validation that was causing the resample_spec step to crash when appending models to its output product. Testing showed a remaining difference in the output from resample_spec, when compared to s2d products that were created before recent changes to both schema validation and datamodels (SlitModel), which was the fact that the RELSENS extensions from the input model were not appearing in the output, and the output was also missing the 2 header keywords SRCXPOS, SRCYPOS from the SCI extension headers.

It appears that these were missing due to the fact that a `for` loop that was being used to copy over attributes from the input model to the output model was hitting an exception somewhere in the midst of looping and then quietly aborting. Thus not all of the attributes were getting copied. So this is a quick fix that inserts a simple try-except block within the for loop, so that if an exception is encountered on any one attribute, it will still try to process the remaining ones.

Resample_spec output for a NIRSpec fixed-slit exposure is now identical to before all the recent changes (woot!).