### PR TITLE
set attributes and compute s_region on SlitModel

### DIFF
--- a/jwst/flatfield/flat_field.py
+++ b/jwst/flatfield/flat_field.py
@@ -473,7 +473,7 @@ def NIRSpec_brightobj(output_model,
     else:
         interpolated_flats = None
 
-    slit_name = "S1600A1"
+    slit_name = output_model.name
 
     # pixels with respect to the original image
     n_ints, ysize, xsize = output_model.data.shape


### PR DESCRIPTION
Resolves #1332.
Adds slit attributes to SlitModel with NRS_BRIGHTOBJ and "computes"  `s_region`.