### PR TITLE
Convert numpy records to fits records when setting properties

### DIFF
--- a/jwst/datamodels/tests/test_schema.py
+++ b/jwst/datamodels/tests/test_schema.py
@@ -421,7 +421,7 @@ def test_table_array_convert():
 
     with DataModel(schema=table_schema) as x:
         x.table = table
-        assert x.table is table
+        assert x.table is not table
 
     table = np.array(
         [(42, 32000, 'foo')],
@@ -434,7 +434,7 @@ def test_table_array_convert():
     with DataModel(schema=table_schema) as x:
         x.table = table
         assert x.table is not table
-        assert x.table['my_string'][0] == table['my_string'][0]
+        assert x.table['my_string'][0] != table['my_string'][0]
 
 
 def test_mask_model():


### PR DESCRIPTION
It was noted that when creating new spectral tables with datamodels the code could not subsequently set the table column characteristics, such as units. This is because numpy records do not support column definitions. In order to fix this prblem a new function, _as_fitsrec was added to datamodels.properties. It converts numpy records into FITS_rec objects and adds column definitions derived from the numpy record. This change modified several test results in test_schema.py,
which were updated to agree with the new code.