### PR TITLE
New noise model

### DIFF
--- a/jwst/outlier_detection/outlier_detection.py
+++ b/jwst/outlier_detection/outlier_detection.py
@@ -472,14 +472,6 @@ def flag_cr(sci_image, blot_image, **pars):
     np.bitwise_or(sci_image.dq, np.invert(cr_mask) * CRBIT, sci_image.dq)
 
 
-def build_mask(dqarr, bitvalue):
-    """Build a bit-mask from an input DQ array and a bitvalue flag."""
-    bitvalue = bitmask.interpret_bit_flags(bitvalue)
-    if bitvalue is None:
-        return (np.ones(dqarr.shape, dtype=np.uint32))
-    return np.logical_not(np.bitwise_and(dqarr, ~bitvalue)).astype(np.uint32)
-
-
 def abs_deriv(array):
     """Take the absolute derivate of a numpy array."""
     tmp = np.zeros(array.shape, dtype=np.float64)

--- a/jwst/outlier_detection/outlier_detection.py
+++ b/jwst/outlier_detection/outlier_detection.py
@@ -53,9 +53,6 @@ class OutlierDetection:
             list of data models as ModelContainer or ASN file,
             one data model for each input image
 
-        reffiles : dict of `jwst.datamodels.DataModel`
-            Dictionary of datamodels.  Keys are reffile_types.
-
         pars : dict, optional
             Optional user-specified parameters to modify how outlier_detection
             will operate.  Valid parameters include:
@@ -161,12 +158,11 @@ class OutlierDetection:
         """
         # Parse any user-provided filename suffix for resampled products
         self.resample_suffix = '_outlier_{}.fits'.format(
-                                pars.get('resample_suffix',
-                                         self.default_suffix))
+            pars.get('resample_suffix', self.default_suffix))
         if 'resample_suffix' in pars:
             del pars['resample_suffix']
         log.debug("Defined output product suffix as: {}".format(
-                                                        self.resample_suffix))
+            self.resample_suffix))
 
     def do_detection(self):
         """Flag outlier pixels in DQ of input images."""
@@ -192,9 +188,9 @@ class OutlierDetection:
             drizzled_models = self.input_models
             for i in range(len(self.input_models)):
                 drizzled_models[i].wht = build_driz_weight(
-                                        self.input_models[i],
-                                        wht_type='exptime',
-                                        good_bits=pars['good_bits'])
+                    self.input_models[i],
+                    wht_type='exptime',
+                    good_bits=pars['good_bits'])
 
         # Initialize intermediate products used in the outlier detection
         median_model = datamodels.ImageModel(
@@ -263,7 +259,7 @@ class OutlierDetection:
             #   MASKPT percent of the mean weight
             mask = np.less(w, weight_threshold)
             log.debug("Number of pixels with low weight: {}".format(
-                                                                np.sum(mask)))
+                np.sum(mask)))
             badmasks.append(mask)
 
         # Compute median of stack os images using BADMASKS to remove low weight
@@ -287,7 +283,7 @@ class OutlierDetection:
         for model in self.input_models:
             blotted_median = model.copy()
             blot_root = '_'.join(model.meta.filename.replace(
-                                '.fits', '').split('_')[:-1])
+                '.fits', '').split('_')[:-1])
             blotted_median.meta.filename = '{}_blot.fits'.format(blot_root)
 
             # clean out extra data not related to blot result
@@ -317,22 +313,15 @@ class OutlierDetection:
             blotted back to the wcs and frame of the ImageModels in
             input_models
 
-        reffiles : dict
-            Contains JWST ModelContainers for
-            'gain' and 'readnoise' reference files
-
         Returns
         -------
         None
             The dq array in each input model is modified in place
 
         """
-        gain_models = self.reffiles['gain']
-        rn_models = self.reffiles['readnoise']
 
-        for image, blot, gain, rn in zip(self.input_models, blot_models,
-                                         gain_models, rn_models):
-            flag_cr(image, blot, gain, rn, **self.outlierpars)
+        for image, blot in zip(self.input_models, blot_models):
+            flag_cr(image, blot, **self.outlierpars)
 
         if self.converted:
             # Make sure actual input gets updated with new results
@@ -340,7 +329,7 @@ class OutlierDetection:
                 self.inputs.dq[i, :, :] = self.input_models[i].dq
 
 
-def flag_cr(sci_image, blot_image, gain_image, readnoise_image, **pars):
+def flag_cr(sci_image, blot_image, **pars):
     """Masks outliers in science image.
 
     Mask blemishes in dithered data by comparing a science image
@@ -353,12 +342,6 @@ def flag_cr(sci_image, blot_image, gain_image, readnoise_image, **pars):
 
     blot_image : ImageModel
         the blotted median image of the dithered science frames
-
-    gain_image : GainModel
-        the 2-D gain array
-
-    readnoise_image : ReadnoiseModel
-        the 2-D read noise array
 
     pars : dict
         the user parameters for Outlier Detection
@@ -392,49 +375,7 @@ def flag_cr(sci_image, blot_image, gain_image, readnoise_image, **pars):
     blot_data = blot_image.data * exptime
     blot_deriv = abs_deriv(blot_data)
 
-    # This mask can take into account any crbits values
-    # specified by the user to be ignored.
-    # dq_mask = build_mask(sci_image.dq, CRBIT)
-
-    # This logic trims these reference files down to match
-    # input file shape to allow this step to apply to subarray readout
-    # modes such as CORONOGRAPHIC data
-    # logic copied from jwst.jump step...
-    # Get subarray limits from metadata of input model
-    xstart = blot_image.meta.subarray.xstart
-    xsize = blot_image.data.shape[1]
-    xstop = xstart + xsize - 1
-    ystart = blot_image.meta.subarray.ystart
-    ysize = blot_image.data.shape[0]
-    ystop = ystart + ysize - 1
-    if (readnoise_image.meta.subarray.xstart == xstart and
-            readnoise_image.meta.subarray.xsize == xsize and
-            readnoise_image.meta.subarray.ystart == ystart and
-            readnoise_image.meta.subarray.ysize == ysize):
-
-        log.debug('Readnoise and gain subarrays match science data')
-        rn = readnoise_image.data
-        # gain = gain_image.data
-
-    else:
-        log.debug('Extracting readnoise and gain subarrays to \
-                    match science data')
-        rn = readnoise_image.data[ystart - 1:ystop, xstart - 1:xstop]
-        # gain = gain_image.data[ystart - 1:ystop, xstart - 1:xstop]
-
-    # TODO: for JWST, the actual readnoise at a given pixel depends on the
-    # number of reads going into that pixel.  So we need to account for that
-    # using the meta.exposure.nints, ngroups and nframes keywords.
-    """
-    MULTIACCUM noise model (Equation 1, Rauscher et.al., PASP 110:768, 2007)
-    t1 = sigma_read**2 * (12*(ngroups-1))/(ngroups*nframes*(ngroups+1))
-    t2 = exposure_time.group_exptime*flux*(ngroups-1)*6*(ngroups**2+1)/
-            (5*ngroups*(ngroups+1))
-    t3 = exposure_time.frame_exptime*flux*(nframes-1)*2*(2*nframes-1)*(ngroups-1)/
-         (nframes*ngroups*(ngroups+1))
-    sigma_total**2 = t1 + t2 - t3
-
-    """
+    err_data = np.nan_to_num(sci_image.err)
 
     # Define output cosmic ray mask to populate
     cr_mask = np.zeros(sci_image.shape, dtype=np.uint8)
@@ -446,7 +387,8 @@ def flag_cr(sci_image, blot_image, gain_image, readnoise_image, **pars):
     #
     # Model the noise and create a CR mask
     diff_noise = np.abs(sci_data - blot_data)
-    ta = np.sqrt(np.abs(blot_data + subtracted_background) + rn ** 2)
+    # ta = np.sqrt(np.abs(blot_data + subtracted_background) + rn ** 2)
+    ta = np.sqrt(np.abs(blot_data + subtracted_background) + err_data ** 2)
     t2 = scl1 * blot_deriv + snr1 * ta
 
     tmp1 = np.logical_not(np.greater(diff_noise, t2))

--- a/jwst/outlier_detection/outlier_detection.py
+++ b/jwst/outlier_detection/outlier_detection.py
@@ -425,6 +425,16 @@ def flag_cr(sci_image, blot_image, gain_image, readnoise_image, **pars):
     # TODO: for JWST, the actual readnoise at a given pixel depends on the
     # number of reads going into that pixel.  So we need to account for that
     # using the meta.exposure.nints, ngroups and nframes keywords.
+    """
+    MULTIACCUM noise model (Equation 1, Rauscher et.al., PASP 110:768, 2007)
+    t1 = sigma_read**2 * (12*(ngroups-1))/(ngroups*nframes*(ngroups+1))
+    t2 = exposure_time.group_exptime*flux*(ngroups-1)*6*(ngroups**2+1)/
+            (5*ngroups*(ngroups+1))
+    t3 = exposure_time.frame_exptime*flux*(nframes-1)*2*(2*nframes-1)*(ngroups-1)/
+         (nframes*ngroups*(ngroups+1))
+    sigma_total**2 = t1 + t2 - t3
+
+    """
 
     # Define output cosmic ray mask to populate
     cr_mask = np.zeros(sci_image.shape, dtype=np.uint8)

--- a/jwst/outlier_detection/outlier_detection_scaled_step.py
+++ b/jwst/outlier_detection/outlier_detection_scaled_step.py
@@ -33,8 +33,6 @@ class OutlierDetectionScaledStep(Step):
         save_intermediate_results = boolean(default=False)
         good_bits = integer(default=4)
     """
-    reference_file_types = ['gain', 'readnoise']
-    prefetch_references = False
 
     def process(self, input):
         """Step interface to running outlier_detection."""
@@ -50,8 +48,6 @@ class OutlierDetectionScaledStep(Step):
             self.input_models = input_models
 
             reffiles = {}
-            reffiles['gain'] = self._build_reffile_container('gain')
-            reffiles['readnoise'] = self._build_reffile_container('readnoise')
 
             pars = {
                 'wht_type': self.wht_type,

--- a/jwst/outlier_detection/outlier_detection_stack_step.py
+++ b/jwst/outlier_detection/outlier_detection_stack_step.py
@@ -44,9 +44,6 @@ class OutlierDetectionStackStep(Step):
         good_bits = integer(default=4)
     """
 
-    reference_file_types = ['gain', 'readnoise']
-    prefetch_references = False
-
     def process(self, input):
         """Step interface for performing outlier_detection processing."""
         with datamodels.open(input) as input_models:
@@ -63,8 +60,6 @@ class OutlierDetectionStackStep(Step):
                           {} inputs".format(len(input_models)))
             self.input_models = input_models
             reffiles = {}
-            reffiles['gain'] = self._build_reffile_container('gain')
-            reffiles['readnoise'] = self._build_reffile_container('readnoise')
 
             pars = {
                 'wht_type': self.wht_type,

--- a/jwst/outlier_detection/outlier_detection_step.py
+++ b/jwst/outlier_detection/outlier_detection_step.py
@@ -59,8 +59,6 @@ class OutlierDetectionStep(Step):
         good_bits = integer(default=4)
         scale_detection = boolean(default=False)
     """
-    reference_file_types = ['gain', 'readnoise']
-    prefetch_references = False
 
     def process(self, input):
         """Perform outlier detection processing on input data."""
@@ -137,8 +135,6 @@ class OutlierDetectionStep(Step):
                            detection_step.__name__))
 
             reffiles = {}
-            reffiles['gain'] = self._build_reffile_container('gain')
-            reffiles['readnoise'] = self._build_reffile_container('readnoise')
 
             # Set up outlier detection, then do detection
             step = detection_step(self.input_models, reffiles=reffiles, **pars)

--- a/jwst/resample/resample_utils.py
+++ b/jwst/resample/resample_utils.py
@@ -176,7 +176,8 @@ def build_driz_weight(model, wht_type=None, good_bits=None):
     exptime = model.meta.exposure.exposure_time
 
     if wht_type.lower()[:3] == 'err':
-        inwht = (exptime / model.err)**2 * dqmask
+        err_model = np.nan_to_num(model.err)
+        inwht = (exptime / err_model)**2 * dqmask
         log.debug("DEBUG weight mask: {} {}".format(type(inwht), np.sum(inwht)))
     # elif wht_type == 'IVM':
     #     _inwht = img.buildIVMmask(chip._chip,dqarr,pix_ratio)


### PR DESCRIPTION
These changes remove the dependence of the readnoise and gain reference files from the outlier_detection step.  The use of these reference files are replaced with use of the ERR arrays from each of the input files.  This version includes conversion of the ERR arrays to remove NaNs since the current computations still results in NaNs in the ERR array. 

The weighting of the outlier_detection step can eventually be changed to use 'error' instead of 'exptime' to better account (on a pixel-by-pixel basis) for the readout characteristics of each exposure.  However, that will wait until the computation of the error arrays does not include NaNs.  

This PR leaves the reffile interface for the outlier_detection step to support any use of outlier-specific reference files for parameter settings (if that ever gets implemented).  