### PR TITLE
Remove hard-coded dqflag use from resample

### DIFF
--- a/jwst/outlier_detection/outlier_detection.py
+++ b/jwst/outlier_detection/outlier_detection.py
@@ -3,7 +3,6 @@
 import numpy as np
 
 from stsci.image import median
-from stsci.tools import bitmask
 from astropy.stats import sigma_clipped_stats
 from scipy import ndimage
 

--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -8,6 +8,8 @@ from . import gwcs_drizzle
 from . import resample_utils
 from ..model_blender import blendmeta
 
+CRBIT = np.uint32(datamodels.dqflags.pixel['JUMP_DET'])
+
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
@@ -36,7 +38,7 @@ class ResampleData:
     drizpars = {'single': False,
                 'kernel': 'square',
                 'pixfrac': 1.0,
-                'good_bits': 4,
+                'good_bits': CRBIT,
                 'fillval': 'INDEF',
                 'wht_type': 'exptime',
                 'blendheaders': True}

--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -8,8 +8,6 @@ from . import gwcs_drizzle
 from . import resample_utils
 from ..model_blender import blendmeta
 
-CRBIT = np.uint32(datamodels.dqflags.pixel['JUMP_DET'])
-
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
@@ -38,7 +36,7 @@ class ResampleData:
     drizpars = {'single': False,
                 'kernel': 'square',
                 'pixfrac': 1.0,
-                'good_bits': CRBIT,
+                'good_bits': 0,
                 'fillval': 'INDEF',
                 'wht_type': 'exptime',
                 'blendheaders': True}
@@ -192,8 +190,9 @@ class ResampleData:
                 exposure_times['end'].append(img.meta.exposure.end_time)
 
                 # apply sky subtraction
-                if 'skybg' in img.meta._instance:
-                    img.data -= img.meta.skybg
+                blevel = img.meta.background.level
+                if not img.meta.background.subtracted and blevel is not None:
+                    img.data -= blevel
 
                 outwcs_pscale = output_model.meta.wcsinfo.cdelt1
                 wcslin_pscale = img.meta.wcsinfo.cdelt1

--- a/jwst/resample/resample_spec.py
+++ b/jwst/resample/resample_spec.py
@@ -16,6 +16,8 @@ from .. import datamodels
 from . import gwcs_drizzle
 from . import resample_utils
 
+CRBIT = np.uint32(datamodels.dqflags.pixel['JUMP_DET'])
+
 import logging
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
@@ -45,7 +47,7 @@ class ResampleSpecData:
     drizpars = {'single': False,
                 'kernel': 'square',
                 'pixfrac': 1.0,
-                'good_bits': 4,
+                'good_bits': CRBIT,
                 'fillval': 'INDEF',
                 'wht_type': 'exptime'}
 


### PR DESCRIPTION
This addresses #1379 .  See comments in issue regarding the scope of these changes. 

It also includes removal of yet another extraneous import of a stsci package; namely, stsci.tools.bitmask. 