### PR TITLE
Initial corrections for background subtraction

### DIFF
--- a/jwst/outlier_detection/outlier_detection.py
+++ b/jwst/outlier_detection/outlier_detection.py
@@ -361,13 +361,10 @@ def flag_cr(sci_image, blot_image, **pars):
     snr1, snr2 = [float(val) for val in pars.get('snr', '5.0 4.0').split()]
     scl1, scl2 = [float(val) for val in pars.get('scale', '1.2 0.7').split()]
 
-    if sci_image.meta.background.subtracted:
+    if not sci_image.meta.background.subtracted:
+        # Include background back into blotted image for comparison
         subtracted_background = sci_image.meta.background.level
         log.debug("Subtracted background: {}".format(subtracted_background))
-    else:
-        subtracted_background = backg
-        log.debug("No subtracted background found. "
-                  "Using default value from outlierpars: {}".format(backg))
 
     exptime = sci_image.meta.exposure.exposure_time
 

--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -190,8 +190,8 @@ class ResampleData:
                 exposure_times['end'].append(img.meta.exposure.end_time)
 
                 # apply sky subtraction
-                if 'skybg' in img.meta._instance:
-                    img.data -= img.meta.skybg
+                if not img.meta.background.subtracted:
+                    img.data -= img.meta.background.level
 
                 outwcs_pscale = output_model.meta.wcsinfo.cdelt1
                 wcslin_pscale = img.meta.wcsinfo.cdelt1

--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -190,8 +190,9 @@ class ResampleData:
                 exposure_times['end'].append(img.meta.exposure.end_time)
 
                 # apply sky subtraction
-                if not img.meta.background.subtracted:
-                    img.data -= img.meta.background.level
+                blevel = img.meta.background.level
+                if not img.meta.background.subtracted and blevel is not None:
+                    img.data -= blevel
 
                 outwcs_pscale = output_model.meta.wcsinfo.cdelt1
                 wcslin_pscale = img.meta.wcsinfo.cdelt1

--- a/jwst/tweakreg/tweakreg_step.py
+++ b/jwst/tweakreg/tweakreg_step.py
@@ -51,7 +51,7 @@ class TweakRegStep(Step):
 
         # Object matching parameters:
         minobj = integer(default=15) # Minimum number of objects acceptable for matching
-        searchrad = float(default=1.0) # The search radius in arcsec for a match
+        searchrad = float(default=10.0) # The search radius in arcsec for a match
         use2dhist = boolean(default=True) # Use 2d histogram to find initial offset?
         separation = float(default=0.5) # Minimum object separation in arcsec
         tolerance = float(default=1.0) # Matching tolerance for xyxymatch in arcsec
@@ -184,4 +184,3 @@ class TweakRegStep(Step):
         )
 
         return im
-


### PR DESCRIPTION
This set of changes includes:
- updates to resample to correctly apply computed background values
- an update to outlier_detection to recognize when background values are available for use
- an update to tweakreg default parameters to make allow tweakreg to work on a wider range of datasets (including simulated NIRCAM associated images that include uncal files)

 This should mostly address issue #925 .