### PR TITLE
Update module import for build_main docs in setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,9 @@ from setuptools.command.test import test as TestCommand
 from numpy import get_include as np_include
 from glob import glob
 
+# hack building the sphinx docs with C source
+from setuptools.command.build_ext import build_ext
+
 if sys.version_info < (3, 5):
     error = """
     JWST 0.9+ does not support Python 2.x, 3.0, 3.1, 3.2, 3.3 or 3.4.
@@ -19,11 +22,9 @@ if sys.version_info < (3, 5):
     """
     sys.exit(error)
 
-# hack building the sphinx docs with C source
-from setuptools.command.build_ext import build_ext
 
 try:
-    import sphinx
+    from sphinx.cmd.build import build_main
     from sphinx.setup_command import BuildDoc
 
     class BuildSphinx(BuildDoc):
@@ -41,7 +42,7 @@ try:
             build_cmd = self.reinitialize_command('build_ext')
             build_cmd.inplace = 1
             self.run_command('build_ext')
-            sphinx.cmd.build.build_main(['-b', 'html', './docs', './docs/_build/html'])
+            build_main(['-b', 'html', './docs', './docs/_build/html'])
 
 except ImportError:
     class BuildSphinx(Command):
@@ -87,6 +88,7 @@ def get_transforms_data():
     # In the package directory, install to the subdirectory 'schemas'
     transforms_schemas = [os.path.join('schemas', s) for s in transforms_schemas]
     return transforms_schemas
+
 
 transforms_schemas = get_transforms_data()
 PACKAGE_DATA['jwst.transforms'] = transforms_schemas


### PR DESCRIPTION
Minor change to the imports in setup to fix the local build_sphinx command for doc build, without it:
```
File "setup.py", line 176, in <module>
    entry_points=entry_points,
  File "/Users/sosey/miniconda3/envs/jwstdev/lib/python3.5/distutils/core.py", line 148, in setup
    dist.run_commands()
  File "/Users/sosey/miniconda3/envs/jwstdev/lib/python3.5/distutils/dist.py", line 955, in run_commands
    self.run_command(cmd)
  File "/Users/sosey/miniconda3/envs/jwstdev/lib/python3.5/distutils/dist.py", line 974, in run_command
    cmd_obj.run()
  File "setup.py", line 44, in run
    sphinx.cmd.build.build_main(['-b', 'html', './docs', './docs/_build/html'])
AttributeError: module 'sphinx' has no attribute 'cmd'
```