### PR TITLE
Change gain_scale warning to info

### DIFF
--- a/jwst/gain_scale/gain_scale_step.py
+++ b/jwst/gain_scale/gain_scale_step.py
@@ -26,8 +26,8 @@ class GainScaleStep(Step):
 
                 # Try to read the GAINFACT keyword value
                 if gain_model.meta.gain_factor is None:
-                    self.log.warning('GAINFACT not found in gain reference file')
-                    self.log.warning('Step will be skipped')
+                    self.log.info('GAINFACT not found in gain reference file')
+                    self.log.info('Step will be skipped')
                     input_model.meta.cal_step.gain_scale = 'SKIPPED'
                     gain_model.close()
                     return input_model


### PR DESCRIPTION
Changed the log level from warning to info in the gain_scale step, when it can't find a gain factor keyword in the gain reference file. This happens when processing data from instruments/modes that use the nominal gain and so it isn't really a problem that the keyword is missing for those.

Fixes #1657.