### PR TITLE
Revise how to append planes to CON array

### DIFF
--- a/jwst/resample/gwcs_drizzle.py
+++ b/jwst/resample/gwcs_drizzle.py
@@ -268,7 +268,8 @@ class GWCSDrizzle:
 
         if self.outcon.shape[0] == planeid:
             plane = np.zeros_like(self.outcon[0])
-            self.outcon = np.append(self.outcon, plane, axis=0)
+            plane = plane.reshape((1, plane.shape[0], plane.shape[1]))
+            self.outcon = np.concatenate((self.outcon, plane))
 
         # Increment the id
         self.uniqid += 1


### PR DESCRIPTION
This should address issue #1770 .  

This implements the correct numpy operations for adding a new plane to the CON array when needed to account for when previous CON array is full (>N*32).  