### PR TITLE
Raise Exception in make_output_wcs

### DIFF
--- a/jwst/resample/resample_utils.py
+++ b/jwst/resample/resample_utils.py
@@ -47,6 +47,12 @@ def make_output_wcs(input_models):
         output_wcs = wcs_from_footprints(input_models)
         data_size = shape_from_bounding_box(output_wcs.bounding_box)
 
+    # Add check to see whether or not a valid output WCS was computed
+    # based on output dimensions
+    # If either output axis has a length of 0, raise an Exception.
+    if data_size[0]*data_size[1] == 0:
+        raise ValueError("Output array size computed as {}".format(data_size))
+
     output_wcs.data_size = (data_size[1], data_size[0])
     return output_wcs
 


### PR DESCRIPTION
Simple change to throw an Exception should either output axis be computed with zero length (after all, who knows what problems may be introduced with a problematic WCS).  

This should address issue #1717 .