### PR TITLE
Move photometry keywords to SCI header

### DIFF
--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -1030,30 +1030,6 @@ properties:
             type: number
             fits_keyword: HMIDTIME
             blend_table: True
-      photometry:
-        title: Photometry information
-        type: object
-        properties:
-          conversion_megajanskys:
-            title: Flux density (MJy/steradian) producing 1 cps
-            type: number
-            fits_keyword: PHOTMJSR
-            blend_table: True
-          conversion_microjanskys:
-            title: Flux density (uJy/arcsec2) producing 1 cps
-            type: number
-            fits_keyword: PHOTUJA2
-            blend_table: True
-          pixelarea_steradians:
-            title: Nominal pixel area in steradians
-            type: number
-            fits_keyword: PIXAR_SR
-            blend_table: True
-          pixelarea_arcsecsq:
-            title: Nominal pixel area in arcsec^2
-            type: number
-            fits_keyword: PIXAR_A2
-            blend_table: True
       nircam_focus:
         title: NIRCam Focus Adjust Mechanism parameters
         type: object

--- a/jwst/datamodels/schemas/cube.schema.yaml
+++ b/jwst/datamodels/schemas/cube.schema.yaml
@@ -1,7 +1,8 @@
 allOf:
 - $ref: core.schema.yaml
-- $ref: wcsinfo.schema.yaml
 - $ref: bunit.schema.yaml
+- $ref: photometry.schema.yaml
+- $ref: wcsinfo.schema.yaml
 - type: object
   properties:
     data:

--- a/jwst/datamodels/schemas/drizproduct.schema.yaml
+++ b/jwst/datamodels/schemas/drizproduct.schema.yaml
@@ -1,7 +1,8 @@
 allOf:
 - $ref: core.schema.yaml
-- $ref: wcsinfo.schema.yaml
 - $ref: lev3_prod.schema.yaml
+- $ref: photometry.schema.yaml
+- $ref: wcsinfo.schema.yaml
 - type: object
   properties:
     meta:

--- a/jwst/datamodels/schemas/ifucube.schema.yaml
+++ b/jwst/datamodels/schemas/ifucube.schema.yaml
@@ -1,7 +1,8 @@
 allOf:
 - $ref: core.schema.yaml
-- $ref: wcsinfo.schema.yaml
 - $ref: bunit.schema.yaml
+- $ref: photometry.schema.yaml
+- $ref: wcsinfo.schema.yaml
 - type: object
   properties:
     meta:

--- a/jwst/datamodels/schemas/ifuimage.schema.yaml
+++ b/jwst/datamodels/schemas/ifuimage.schema.yaml
@@ -1,7 +1,8 @@
 allOf:
 - $ref: core.schema.yaml
-- $ref: wcsinfo.schema.yaml
 - $ref: bunit.schema.yaml
+- $ref: photometry.schema.yaml
+- $ref: wcsinfo.schema.yaml
 - type: object
   properties:
     data:

--- a/jwst/datamodels/schemas/image.schema.yaml
+++ b/jwst/datamodels/schemas/image.schema.yaml
@@ -1,7 +1,8 @@
 allOf:
 - $ref: core.schema.yaml
-- $ref: wcsinfo.schema.yaml
 - $ref: bunit.schema.yaml
+- $ref: photometry.schema.yaml
+- $ref: wcsinfo.schema.yaml
 - type: object
   properties:
     data:

--- a/jwst/datamodels/schemas/level1b.schema.yaml
+++ b/jwst/datamodels/schemas/level1b.schema.yaml
@@ -1,7 +1,8 @@
 allOf:
 - $ref: core.schema.yaml
-- $ref: wcsinfo.schema.yaml
 - $ref: bunit.schema.yaml
+- $ref: photometry.schema.yaml
+- $ref: wcsinfo.schema.yaml
 - type: object
   properties:
     data:

--- a/jwst/datamodels/schemas/miri_ramp.schema.yaml
+++ b/jwst/datamodels/schemas/miri_ramp.schema.yaml
@@ -1,7 +1,8 @@
 allOf:
 - $ref: core.schema.yaml
-- $ref: wcsinfo.schema.yaml
 - $ref: bunit.schema.yaml
+- $ref: photometry.schema.yaml
+- $ref: wcsinfo.schema.yaml
 - type: object
   properties:
     data:

--- a/jwst/datamodels/schemas/multiexposure.schema.yaml
+++ b/jwst/datamodels/schemas/multiexposure.schema.yaml
@@ -7,6 +7,7 @@ allOf:
       title: An array of slits
       items:
         allOf:
+        - $ref: photometry.schema.yaml
         - $ref: wcsinfo.schema.yaml
         - type: object
           properties:

--- a/jwst/datamodels/schemas/multiproduct.schema.yaml
+++ b/jwst/datamodels/schemas/multiproduct.schema.yaml
@@ -7,6 +7,7 @@ allOf:
       title: An array of DrizProducts
       items:
         allOf:
+        - $ref: photometry.schema.yaml
         - $ref: wcsinfo.schema.yaml
         - type: object
           properties:

--- a/jwst/datamodels/schemas/photometry.schema.yaml
+++ b/jwst/datamodels/schemas/photometry.schema.yaml
@@ -1,0 +1,34 @@
+type: object
+properties:
+  meta:
+    type: object
+    properties:
+      photometry:
+        title: Photometry information
+        type: object
+        properties:
+          conversion_megajanskys:
+            title: Flux density (MJy/steradian) producing 1 cps
+            type: number
+            fits_keyword: PHOTMJSR
+            fits_hdu: SCI
+            blend_table: True
+          conversion_microjanskys:
+            title: Flux density (uJy/arcsec2) producing 1 cps
+            type: number
+            fits_keyword: PHOTUJA2
+            fits_hdu: SCI
+            blend_table: True
+          pixelarea_steradians:
+            title: Nominal pixel area in steradians
+            type: number
+            fits_keyword: PIXAR_SR
+            fits_hdu: SCI
+            blend_table: True
+          pixelarea_arcsecsq:
+            title: Nominal pixel area in arcsec^2
+            type: number
+            fits_keyword: PIXAR_A2
+            fits_hdu: SCI
+            blend_table: True
+$schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/quad.schema.yaml
+++ b/jwst/datamodels/schemas/quad.schema.yaml
@@ -1,7 +1,8 @@
 allOf:
 - $ref: core.schema.yaml
-- $ref: wcsinfo.schema.yaml
 - $ref: bunit.schema.yaml
+- $ref: photometry.schema.yaml
+- $ref: wcsinfo.schema.yaml
 - type: object
   properties:
     data:

--- a/jwst/datamodels/schemas/ramp.schema.yaml
+++ b/jwst/datamodels/schemas/ramp.schema.yaml
@@ -1,7 +1,8 @@
 allOf:
 - $ref: core.schema.yaml
-- $ref: wcsinfo.schema.yaml
 - $ref: bunit.schema.yaml
+- $ref: photometry.schema.yaml
+- $ref: wcsinfo.schema.yaml
 - type: object
   properties:
     data:

--- a/jwst/datamodels/schemas/slitdata.schema.yaml
+++ b/jwst/datamodels/schemas/slitdata.schema.yaml
@@ -122,7 +122,8 @@ allOf:
       fits_hdu: VAR_RNOISE
       default: 0.0
       datatype: float32
-- $ref: bunit.schema.yaml
 - $ref: pathlosscorr.schema.yaml
+- $ref: bunit.schema.yaml
+- $ref: photometry.schema.yaml
 - $ref: wcsinfo.schema.yaml
 $schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/photom/photom.py
+++ b/jwst/photom/photom.py
@@ -12,6 +12,7 @@ log.setLevel(logging.DEBUG)
 
 PHOT_TOL = 0.001  # relative tolerance between PIXAR_* keys
 
+
 class DataSet(object):
     """
     Input dataset to which the photom information will be attached
@@ -20,11 +21,11 @@ class DataSet(object):
     ----------
 
     """
-    def __init__(self, model, phot_file=None, area_file=None):
+    def __init__(self, model):
         """
         Short Summary
         -------------
-        Set file name of input file, photom ref file, area ref file,
+        Store vital params in DataSet object, such as
         instrument, detector, filter, pupil, and exposure type.
 
         Parameters
@@ -32,16 +33,8 @@ class DataSet(object):
         model: data model object
             input Data Model object
 
-        phot_file: string
-           name of photom reference file
-
-        area_file: string
-           name of pixel area reference file
-
         """
         self.input = model
-        self.phot_file = phot_file
-        self.area_file = area_file
 
         self.instrument = model.meta.instrument.name.upper()
         self.detector = model.meta.instrument.detector.upper()
@@ -72,7 +65,6 @@ class DataSet(object):
         if self.band is not None:
             log.info(' band: %s', self.band)
 
-
     def calc_nirspec(self, ftab):
         """
         Extended Summary
@@ -92,11 +84,8 @@ class DataSet(object):
 
         Returns
         -------
-        conv_factor: float
-            photometric conversion factor written as PHOTMJSR
 
         """
-        conv_factor = None
 
         # Get the GRATING value from the input data model
         grating = self.input.meta.instrument.grating.upper()
@@ -109,7 +98,7 @@ class DataSet(object):
             for slit in self.input.slits:
 
                 log.info('Working on slit %s' % slit.name)
-                conv_factor = None
+                match = False
                 self.slitnum += 1
 
                 # Loop through reference table to find matching row
@@ -122,21 +111,18 @@ class DataSet(object):
 
                     # Match on filter, grating, and slit name
                     if (self.filter == ref_filter and
-                        grating == ref_grating and
-                        slit.name == ref_slit):
-                        conv_factor = self.photom_io(tabdata)
+                            grating == ref_grating and slit.name == ref_slit):
+                        self.photom_io(tabdata)
+                        match = True
                         break
 
-                if conv_factor is None:
-                    log.warning('Did not find a match in the ref file')
-
-            if conv_factor is not None:
-                return float(conv_factor)
-            else:
-                return 0.0
+                if not match:
+                    log.warning('No match in reference file')
 
         # Bright object fixed-slit exposures use a CubeModel
         elif self.exptype == 'NRS_BRIGHTOBJ':
+
+            match = False
 
             # Bright object always uses S1600A1 slit
             slit_name = 'S1600A1'
@@ -152,21 +138,18 @@ class DataSet(object):
 
                 # Match on filter, grating, and slit name
                 if (self.filter == ref_filter and
-                    grating == ref_grating and
-                    slit_name == ref_slit):
-                    conv_factor = self.photom_io(tabdata)
+                        grating == ref_grating and slit_name == ref_slit):
+                    self.photom_io(tabdata)
+                    match = True
                     break
 
-            if conv_factor is None:
-                log.warning('Did not find a match in the ref file')
-
-            if conv_factor is not None:
-                return float(conv_factor)
-            else:
-                return 0.0
+            if not match:
+                log.warning('No match in reference file')
 
         # IFU and MSA exposures use one set of flux cal data
         else:
+
+            match = False
 
             # Loop through the reference table to find matching row
             for tabdata in ftab.phot_table:
@@ -177,16 +160,18 @@ class DataSet(object):
                 # Match on filter and grating only
                 if self.filter == ref_filter and grating == ref_grating:
 
+                    match = True
+
                     # MSA data
                     if (isinstance(self.input, datamodels.MultiSlitModel) and
-                        self.exptype == 'NRS_MSASPEC'):
+                            self.exptype == 'NRS_MSASPEC'):
 
                         # Loop over the MSA slits, applying the same photom
                         # ref data to all slits
                         for slit in self.input.slits:
                             log.info('Working on slit %s' % slit.name)
                             self.slitnum += 1
-                            conv_factor = self.photom_io(tabdata)
+                            self.photom_io(tabdata)
 
                     # IFU data
                     else:
@@ -194,28 +179,40 @@ class DataSet(object):
                         # Get the conversion factor from the PHOTMJSR column
                         conv_factor = tabdata['photmjsr']
 
-                        # Get the length of the relative response arrays in this row
+                        # Populate the photometry keywords
+                        self.input.meta.photometry.conversion_megajanskys = \
+                            conv_factor
+                        self.input.meta.photometry.conversion_microjanskys = \
+                            23.50443 * conv_factor
+
+                        # Get the length of the relative response arrays in
+                        # this table row
                         nelem = tabdata['nelem']
 
-                        # If the relative response arrays have length > 0, copy them into the
-                        # relsens table of the data model
+                        # If the relative response arrays have length > 0,
+                        # copy them into the relsens table of the data model
                         if nelem > 0:
                             waves = tabdata['wavelength'][:nelem]
                             relresps = tabdata['relresponse'][:nelem]
 
-                            # Convert wavelengths from meters to microns, if necessary
-                            MICRONS_100 = 1.e-4         # 100 microns, in meters
-                            if waves.max() > 0. and waves.max() < MICRONS_100:
+                            # Convert wavelengths from meters to microns,
+                            # if necessary
+                            microns_100 = 1.e-4    # 100 microns, in meters
+                            if waves.max() > 0. and waves.max() < microns_100:
                                 waves *= 1.e+6
 
                         # Load the pixel area table for the IFU slices
-                        area_model = datamodels.NirspecIfuAreaModel(self.area_file)
+                        area_model = \
+                            datamodels.NirspecIfuAreaModel(self.area_file)
                         area_data = area_model.area_table
 
-                        # Compute 2D wavelength and pixel area arrays for the whole image
-                        wave2d, area2d, dqmap = self.calc_nrs_ifu_sens2d(area_data)
+                        # Compute 2D wavelength and pixel area arrays for the
+                        # whole image
+                        wave2d, area2d, dqmap = \
+                            self.calc_nrs_ifu_sens2d(area_data)
 
-                        # Compute relative sensitivity for each pixel based on wavelength
+                        # Compute relative sensitivity for each pixel based
+                        # on its wavelength
                         sens2d = np.interp(wave2d, waves, relresps)
 
                         # Include the scalar conversion factor
@@ -226,16 +223,13 @@ class DataSet(object):
 
                         # Reset NON_SCIENCE pixels to 1 in sens2d array and in
                         # science data dq array
-                        where_dq = np.bitwise_and(dqmap, dqflags.pixel['NON_SCIENCE'])
+                        where_dq = \
+                            np.bitwise_and(dqmap, dqflags.pixel['NON_SCIENCE'])
                         sens2d[where_dq > 0] = 1.
                         self.input.dq = np.bitwise_or(self.input.dq, dqmap)
 
-                        # FOR DEBUGGING ONLY #
-                        #datamodels.ImageModel(data=wave2d).save('phot_wave2d.fits')
-                        #datamodels.ImageModel(data=area2d).save('phot_area2d.fits')
-                        #datamodels.ImageModel(data=sens2d).save('phot_sens2d2.fits')
-
-                        # Divide the science data and err by the conversion factors
+                        # Divide the science data and err by the
+                        # conversion factors
                         self.input.data /= sens2d
                         self.input.err /= sens2d
 
@@ -250,13 +244,10 @@ class DataSet(object):
 
                     break
 
-            if conv_factor is not None:
-                return float(conv_factor)
-            else:
-                log.warning('Did not find a match in the ref file, so returning'
-                            ' conversion factor 0.0')
-                return 0.0
+            if not match:
+                log.warning('No match in reference file')
 
+        return
 
     def calc_niriss(self, ftab):
         """
@@ -280,10 +271,7 @@ class DataSet(object):
 
         Returns
         -------
-        conv_factor: float
-            photometric conversion factor written as PHOTMJSR
         """
-        conv_factor = None
 
         # Handle MultiSlit models separately
         if isinstance(self.input, datamodels.MultiSlitModel):
@@ -294,13 +282,14 @@ class DataSet(object):
 
                 # Initialize the output conversion factor and
                 # increment slit number
-                conv_factor = None
+                match = False
                 self.slitnum += 1
 
                 # Get the spectral order number for this slit
                 order = slit.meta.wcsinfo.spectral_order
 
-                log.info("Working on slit: {} order: {}:".format(slit.name, order))
+                log.info("Working on slit: {} order: {}".format(slit.name,
+                         order))
 
                 # Locate matching row in reference file
                 for tabdata in ftab.phot_table:
@@ -311,24 +300,20 @@ class DataSet(object):
 
                     # Find matching values of FILTER, PUPIL, ORDER
                     if (self.filter == ref_filter and
-                        self.pupil == ref_pupil and
-                        order == ref_order):
-                        conv_factor = self.photom_io(tabdata)
+                            self.pupil == ref_pupil and order == ref_order):
+                        self.photom_io(tabdata)
+                        match = True
                         break
 
-                if conv_factor is None:
-                    log.warning('Did not find a match in the ref file')
-
-            if conv_factor is not None:
-                return float(conv_factor)
-            else:
-                return 0.0
+                if not match:
+                    log.warning('No match in reference file')
 
         # Simple ImageModels
         else:
 
             # Hardwire the science data order number to 1 for now
             order = 1
+            match = False
 
             # Locate matching row in reference file
             for tabdata in ftab.phot_table:
@@ -340,9 +325,10 @@ class DataSet(object):
                 if self.exptype in ['NIS_SOSS', 'NIS_WFSS']:
 
                     # Find matching values of FILTER, PUPIL, and ORDER
-                    if (self.filter == ref_filter and self.pupil == ref_pupil
-                        and order == ref_order):
-                        conv_factor = self.photom_io(tabdata)
+                    if (self.filter == ref_filter and
+                            self.pupil == ref_pupil and order == ref_order):
+                        self.photom_io(tabdata)
+                        match = True
                         break
 
                 # Imaging mode
@@ -350,16 +336,14 @@ class DataSet(object):
 
                     # Find matching values of FILTER and PUPIL
                     if (self.filter == ref_filter and self.pupil == ref_pupil):
-                        conv_factor = self.photom_io(tabdata)
+                        self.photom_io(tabdata)
+                        match = True
                         break
 
-            if conv_factor is not None:
-                return float(conv_factor)
-            else:
-                log.warning('Did not find a match in the ref file, so returning'
-                            ' conversion factor 0.0')
-                return 0.0
+            if not match:
+                log.warning('No match in reference file')
 
+        return
 
     def calc_miri(self, ftab):
         """
@@ -384,10 +368,9 @@ class DataSet(object):
 
         Returns
         -------
-        conv_factor: float
-            photometric conversion factor written as PHOTMJSR
         """
-        conv_factor = None
+
+        match = False
 
         # Imaging detector
         if self.detector == 'MIRIMAGE':
@@ -409,8 +392,12 @@ class DataSet(object):
 
                 # Find matching FILTER and SUBARRAY values
                 if self.filter == ref_filter and subarray == ref_subarray:
-                    conv_factor = self.photom_io(tabdata)
+                    self.photom_io(tabdata)
+                    match = True
                     break
+
+            if not match:
+                log.warning('No match in reference file')
 
         # MRS detectors
         elif self.detector == 'MIRIFUSHORT' or self.detector == 'MIRIFULONG':
@@ -448,17 +435,17 @@ class DataSet(object):
             # Retrieve the scalar conversion factor from the reference data
             conv_factor = ftab.meta.photometry.conversion_megajanskys
 
+            # Store the conversion factors in the meta data
+            self.input.meta.photometry.conversion_megajanskys = \
+                conv_factor
+            self.input.meta.photometry.conversion_microjanskys = \
+                23.50443 * conv_factor
+
             # Update BUNIT values for the science data and err
             self.input.meta.bunit_data = 'mJy/arcsec^2'
             self.input.meta.bunit_err = 'mJy/arcsec^2'
 
-        if conv_factor is not None:
-            return float(conv_factor)
-        else:
-            log.warning('Did not find a match in the ref file, so returning'
-                        ' conversion factor 0.0')
-            return 0.0
-
+        return
 
     def calc_nircam(self, ftab):
         """
@@ -482,10 +469,9 @@ class DataSet(object):
 
         Returns
         -------
-        conv_factor: float
-            photometric conversion factor written as PHOTMJSR
         """
-        conv_factor = None
+
+        match = False
 
         # Locate relevant information in reference file
         for tabdata in ftab.phot_table:
@@ -495,32 +481,30 @@ class DataSet(object):
 
             # Finding matching FILTER and PUPIL values
             if self.filter == ref_filter and self.pupil == ref_pupil:
+                match = True
 
                 # Handle WFSS data separately from regular imaging
                 if (isinstance(self.input, datamodels.MultiSlitModel) and
-                    self.exptype == 'NRC_GRISM'):
+                        self.exptype == 'NRC_GRISM'):
 
                     # Loop over the WFSS slits, applying the same photom
                     # ref data to all slits
                     for slit in self.input.slits:
                         log.info('Working on slit %s' % slit.name)
                         self.slitnum += 1
-                        conv_factor = self.photom_io(tabdata)
+                        self.photom_io(tabdata)
 
                 else:
 
                     # Regular imaging data only requires 1 call
-                    conv_factor = self.photom_io(tabdata)
+                    self.photom_io(tabdata)
 
                 break
 
-        if conv_factor is not None:
-            return float(conv_factor)
-        else:
-            log.warning('Did not find a match in the ref file, so returning'
-                        ' conversion factor 0.0')
-            return 0.0
+        if not match:
+            log.warning('No match in reference file')
 
+        return
 
     def calc_fgs(self, ftab):
         """
@@ -543,32 +527,22 @@ class DataSet(object):
 
         Returns
         -------
-        conv_factor: float
-            photometric conversion factor written as PHOTMJSR
         """
-        conv_factor = None
 
         # Read the first (and only) row in the reference file
         for tabdata in ftab.phot_table:
-            conv_factor = self.photom_io(tabdata)
+            self.photom_io(tabdata)
             break
 
-        if conv_factor is not None:
-            return float(conv_factor)
-        else:
-            log.warning('Did not find a match in the ref file, so returning'
-                        ' conversion factor 0.0')
-            return 0.0
-
+        return
 
     def calc_nrs_ifu_sens2d(self, area_data):
 
-        import math
         import numpy as np
         from .. assign_wcs import nirspec       # for NIRSpec IFU data
         import gwcs
 
-        MICRONS_100 = 1.e-4                     # 100 microns, in meters
+        microns_100 = 1.e-4                     # 100 microns, in meters
 
         # Create empty 2D arrays for the wavelengths and pixel areas
         wave2d = np.zeros_like(self.input.data)
@@ -587,10 +561,11 @@ class DataSet(object):
 
             # Construct array indexes for pixels in this slice
             x, y = gwcs.wcstools.grid_from_bounding_box(ifu_wcs.bounding_box,
-                    step=(1, 1), center=True)
+                                                        step=(1, 1),
+                                                        center=True)
 
             log.debug("Slice %d: %g %g %g %g" %
-                    (k, x[0][0], x[-1][-1], y[0][0], y[-1][-1]))
+                      (k, x[0][0], x[-1][-1], y[0][0], y[-1][-1]))
 
             # Get the world coords for all pixels in this slice
             coords = ifu_wcs(x, y)
@@ -599,7 +574,7 @@ class DataSet(object):
             wl = coords[2]
             nan_flag = np.isnan(wl)
             good_flag = np.logical_not(nan_flag)
-            if wl[good_flag].max() < MICRONS_100:
+            if wl[good_flag].max() < microns_100:
                 log.info("Wavelengths in WCS table appear to be in meters")
 
             # Set NaNs to a harmless value, but don't modify nan_flag.
@@ -624,7 +599,6 @@ class DataSet(object):
 
         return wave2d, area2d, dqmap
 
-
     def photom_io(self, tabdata):
         """
         Short Summary
@@ -639,12 +613,23 @@ class DataSet(object):
 
         Returns
         -------
-        conv_factor: float
-            photometric conversion factor
 
         """
         # Get the conversion factor from the PHOTMJSR column of the table row
         conv_factor = tabdata['photmjsr']
+
+        # Store the conversion factors in the meta data
+        log.info('PHOTMJSR value: %g', conv_factor)
+        if isinstance(self.input, datamodels.MultiSlitModel):
+            self.input.slits[self.slitnum].meta.photometry.conversion_megajanskys = \
+                conv_factor
+            self.input.slits[self.slitnum].meta.photometry.conversion_microjanskys = \
+                23.50443 * conv_factor
+        else:
+            self.input.meta.photometry.conversion_megajanskys = \
+                conv_factor
+            self.input.meta.photometry.conversion_microjanskys = \
+                23.50443 * conv_factor
 
         # Get the length of the relative response arrays in this row
         nelem = tabdata['nelem']
@@ -656,12 +641,13 @@ class DataSet(object):
             relresps = tabdata['relresponse'][:nelem]
 
             # Convert wavelengths from meters to microns, if necessary
-            MICRONS_100 = 1.e-4         # 100 microns, in meters
-            if waves.max() > 0. and waves.max() < MICRONS_100:
+            microns_100 = 1.e-4         # 100 microns, in meters
+            if waves.max() > 0. and waves.max() < microns_100:
                 waves *= 1.e+6
             wl_unit = 'microns'
 
             # Set the relative sensitivity table for the correct Model type
+            log.info('Storing relative response table')
             if isinstance(self.input, datamodels.MultiSlitModel):
                 otab = np.array(list(zip(waves, relresps)),
                        dtype=self.input.slits[self.slitnum].relsens.dtype)
@@ -672,10 +658,7 @@ class DataSet(object):
                                 dtype=self.input.relsens.dtype)
                 self.input.relsens = otab
 
-            log.info('Relative response table written.')
-
-        return conv_factor
-
+        return
 
     def save_area_info(self, ftab, area_fname):
         """
@@ -683,10 +666,10 @@ class DataSet(object):
         -------------
         Read the pixel area values in the PIXAR_A2 and PIXAR_SR keys from the
         meta data in the photom reference file and the pixel area reference
-        file. Copy the values from the pixel area reference file header keywords
-        to the output product. If the difference between the values of the pixel
-        area (in units of arc seconds) between the two reference files exceeds a
-        defined threshold, issue a warning.
+        file. Copy the values from the pixel area reference file header
+        keywords to the output product. If the difference between the values
+        of the pixel area (in units of arc seconds) between the two reference
+        files exceeds a defined threshold, issue a warning.
 
         Also copy the pixel area data array from the pixel area reference file
         to the area extension of the output product.
@@ -701,7 +684,6 @@ class DataSet(object):
 
         Returns
         -------
-        None
 
         """
 
@@ -724,8 +706,8 @@ class DataSet(object):
             tab_a2 = ftab.meta.photometry.pixelarea_arcsecsq
         except:
             # If one or both of them are missing, issue a warning, but carry on
-            log.warning('At least one of the PIXAR_nn keyword values in missing')
-            log.warning('from the photom reference file')
+            log.warning('At least one of the PIXAR_nn keyword values is')
+            log.warning('missing from the photom reference file')
 
         # Load the average pixel area values from the pixel area reference file
         try:
@@ -735,20 +717,20 @@ class DataSet(object):
             area_a2 = pix_area.meta.photometry.pixelarea_arcsecsq
         except:
             # If one or both of them are missing, issue a warning
-            log.warning('At least one of the PIXAR_nn keyword values is missing')
-            log.warning('from the reference file %s', area_fname)
-            log.warning('Pixel area keyword values will not be set in the output')
+            log.warning('At least one of the PIXAR_nn keyword values is')
+            log.warning('missing from the reference file %s', area_fname)
+            log.warning('Pixel area keyword values will not be set in output')
 
-        # Compute the relative difference between the pixel area values from the
-        # two different sources, if they exist
+        # Compute the relative difference between the pixel area values from
+        # the two different sources, if they exist
         if (tab_a2 is not None) and (area_a2 is not None):
             a2_tol = abs(tab_a2 - area_a2) / (tab_a2 + area_a2)
 
             # If the difference is greater than the defined tolerance,
             # issue a warning
             if (a2_tol > PHOT_TOL):
-                log.warning('The relative difference between the values for the')
-                log.warning('pixel area in sq arcsec (%s)', a2_tol)
+                log.warning('The relative difference between the values for')
+                log.warning('the pixel area in sq arcsec (%s)', a2_tol)
                 log.warning('exceeds the defined tolerance (%s)', PHOT_TOL)
 
         # Copy the pixel area values to the output
@@ -759,8 +741,7 @@ class DataSet(object):
         if area_ster is not None:
             self.input.meta.photometry.pixelarea_steradians = float(area_ster)
 
-        return None
-
+        return
 
     def apply_photom(self, photom_fname, area_fname):
         """
@@ -771,13 +752,14 @@ class DataSet(object):
         for each instrument has its own dependence on detector- and
         observation-specific parameters.  The corresponding conversion factor
         from the reference file is written as PHOTMJSR to the model. The table
-        of relative response vs wavelength will be read from the reference file,
-        and if it contains >0 rows, it will be attached to the model. If this
-        is an imaging mode, there will be a pixel area map file, from which the
-        pixel area array will be copied to the area extension of the output
-        product. The keywords having the pixel area values are read from the
-        map file and compared to their values in the table reference file. If
-        these values agree, these keywords will be written to the output.
+        of relative response vs wavelength will be read from the reference
+        file, and if it contains >0 rows, it will be attached to the model. If
+        this is an imaging mode, there will be a pixel area map file, from
+        which the pixel area array will be copied to the area extension of the
+        output product. The keywords having the pixel area values are read
+        from the map file and compared to their values in the table reference
+        file. If these values agree, these keywords will be written to the
+        output.
 
         Parameters
         ----------
@@ -793,63 +775,34 @@ class DataSet(object):
         """
         if self.instrument == 'NIRISS':
             ftab = datamodels.NirissPhotomModel(photom_fname)
-            conv_factor = self.calc_niriss(ftab)
+            self.calc_niriss(ftab)
 
         if self.instrument == 'NIRSPEC':
             if self.exptype in ['NRS_FIXEDSLIT', 'NRS_BRIGHTOBJ']:
                 ftab = datamodels.NirspecFSPhotomModel(photom_fname)
             else:
                 ftab = datamodels.NirspecPhotomModel(photom_fname)
-            conv_factor = self.calc_nirspec(ftab)
+            self.calc_nirspec(ftab)
 
         if self.instrument == 'NIRCAM':
             ftab = datamodels.NircamPhotomModel(photom_fname)
-            conv_factor = self.calc_nircam(ftab)
+            self.calc_nircam(ftab)
 
         if self.instrument == 'MIRI':
             if self.detector == 'MIRIMAGE':
                 ftab = datamodels.MiriImgPhotomModel(photom_fname)
             else:
                 ftab = datamodels.MiriMrsPhotomModel(photom_fname)
-            conv_factor = self.calc_miri(ftab)
+            self.calc_miri(ftab)
 
         if self.instrument == 'FGS':
             ftab = datamodels.FgsPhotomModel(photom_fname)
-            conv_factor = self.calc_fgs(ftab)
+            self.calc_fgs(ftab)
 
-        if conv_factor is None:
-            log.warning('Scale factor not found in reference file.')
-            conv_factor = 0.0
-
-        if area_fname is not None: # Load and save the pixel area info
+        if area_fname is not None:   # Load and save the pixel area info
             if 'IMAGE' in self.exptype and area_fname != 'N/A':
-                result = self.save_area_info(ftab, area_fname)
-
-        # Store the conversion factors in the meta data
-        log.info('Writing PHOTMJSR with value: %g', conv_factor)
-        self.input.meta.photometry.conversion_megajanskys = conv_factor
-        self.input.meta.photometry.conversion_microjanskys = 23.50443 * conv_factor
+                self.save_area_info(ftab, area_fname)
 
         ftab.close()
-
-
-    def do_all(self):
-        """
-        Short Summary
-        -------------
-        Execute all tasks for Photom Correction
-
-        Parameters
-        ----------
-
-        Returns
-        -------
-        self.input: DM object
-            input DM object with conversion factors attached/applied
-
-        """
-        photom_fname = self.phot_file
-        area_fname = self.area_file
-        self.apply_photom(photom_fname, area_fname)
 
         return self.input

--- a/jwst/photom/photom_step.py
+++ b/jwst/photom/photom_step.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 
-from ..stpipe import Step, cmdline
+from ..stpipe import Step
 from . import photom
 from .. import datamodels
 
@@ -14,39 +14,40 @@ class PhotomStep(Step):
 
     reference_file_types = ['photom', 'area']
 
-    def process(self, input_file):
+    def process(self, input):
 
         try:
-            dm = datamodels.open(input_file)
+            input_model = datamodels.open(input)
         except IOError:
             self.log.error('Input can not be opened as a Model.')
 
         # Report the detected type of input model
-        model_type = dm.__class__.__name__
+        model_type = input_model.__class__.__name__
         self.log.debug("Input is {}".format(model_type))
         if model_type not in ('CubeModel', 'ImageModel', 'SlitModel',
                               'IFUImageModel', 'MultiSlitModel'):
             self.log.warning("Input is not one of the supported model types: "
-                             "CubeModel, ImageModel IFUImageModel or MultiSlitModel.")
+                             "CubeModel, ImageModel, IFUImageModel or "
+                             "MultiSlitModel.")
 
         # Get the reference file names
-        phot_filename = self.get_reference_file(dm, 'photom')
+        phot_filename = self.get_reference_file(input_model, 'photom')
         self.log.info('Using photom reference file: %s', phot_filename)
-        area_filename = self.get_reference_file(dm, 'area')
+        area_filename = self.get_reference_file(input_model, 'area')
         self.log.info('Using area reference file: %s', area_filename)
 
         # Check for a valid photom reference file
         if phot_filename == 'N/A':
             self.log.warning('No PHOTOM reference file found')
             self.log.warning('Photom step will be skipped')
-            result = dm.copy()
+            result = input_model.copy()
             result.meta.cal_step.photom = 'SKIPPED'
             return result
 
         # Do the correction
-        phot = photom.DataSet(dm, phot_filename, area_filename)
-        output_obj = phot.do_all()
+        phot = photom.DataSet(input_model)
+        result = phot.apply_photom(phot_filename, area_filename)
 
-        output_obj.meta.cal_step.photom = 'COMPLETE'
+        result.meta.cal_step.photom = 'COMPLETE'
 
-        return output_obj
+        return result


### PR DESCRIPTION
Modified all applicable data models to move the photometry-related keywords populated by the photom step to the SCI extension header of all products, in order to allow for unique values for data from multiple spectral orders. Updates to the data models were done by creating a new sub-schema `photometry.schema.yaml` for the affected keywords and then including that sub-schema in all science product schemas that need those keywords.

The photom step has also been modified to use the new location of the meta attributes for those keywords. The overall photom step structure and flow has also been modified a bit to make it more generic, now that it has to do different types of operations for different observing modes.

Fixes #1697.