### PR TITLE
updated the nircam specwcs grism mode

### DIFF
--- a/jwst/datamodels/schemas/specwcs_nircam_grism.schema.yaml
+++ b/jwst/datamodels/schemas/specwcs_nircam_grism.schema.yaml
@@ -42,6 +42,12 @@ allOf:
         type: array
         items:
           $ref: http://stsci.edu/schemas/asdf/transform/transform-1.1.0
+    orders:
+        description: |
+          NIRCAM Grism orders, matched to the array locations of the dispersion models
+        type: array
+        items:
+          type: number
     meta:
       type: object
       properties:


### PR DESCRIPTION
while making example notebooks for the team I realized the orders member was missing from the nircam wfss specwcs datamodel schema...that's been added and it validates correctly now. 