### PR TITLE
NIRSpec WCS input coordinates are 1-based (flat_field)

### DIFF
--- a/jwst/flatfield/flat_field.py
+++ b/jwst/flatfield/flat_field.py
@@ -336,6 +336,9 @@ def do_NIRSpec_flat_field(output_model,
                 log.warning("so using wcs instead of the wavelength array.")
                 # Pixels with respect to the cutout
                 grid = np.indices((ysize, xsize), dtype=np.float64)
+                # xxx begin temporary workaround ...
+                grid += 1.              # NIRSpec wcs is one-based
+                # xxx ... end temporary workaround
                 # The arguments are the X and Y pixel coordinates.
                 (ra, dec, wl) = slit.meta.wcs(grid[1], grid[0])
                 del ra, dec, grid
@@ -497,6 +500,9 @@ def NIRSpec_brightobj(output_model,
         if got_wcs:
             log.warning("so using wcs instead of the wavelength array.")
             grid = np.indices((ysize, xsize), dtype=np.float64)
+            # xxx begin temporary workaround ...
+            grid += 1.                  # NIRSpec wcs is one-based
+            # xxx ... end temporary workaround
             (ra, dec, wl) = output_model.meta.wcs(grid[1], grid[0])
             del ra, dec, grid
         else:
@@ -658,6 +664,10 @@ def NIRSpec_IFU(output_model,
         ind = np.indices((dy, dx))
         x = ind[1] + xstart
         y = ind[0] + ystart
+        # xxx begin temporary workaround ...
+        x += 1                  # NIRSpec wcs is one-based
+        y += 1
+        # xxx ... end temporary workaround
         coords = ifu_wcs(x, y)
         wl = coords[2]
         nan_flag = np.isnan(wl)


### PR DESCRIPTION
For data taken with instruments other than NIRSpec, the wavelengths are not used and the wcs function is not called, so no change was needed for those data.

For NIRSpec data, changes were made to three functions:  (1) `NIRSpec_brightobj` for 'NRS_BRIGHTOBJ' data; (2) `NIRSpec_IFU` for 'NRS_IFU' data; and (3) `do_NIRSpec_flat_field` for all other NIRSpec data.  The change was to increment the pixel coordinates by 1 before calling the wcs function.

See issue #1781.