### PR TITLE
NIRSpec WCS input coordinates are 1-based (extract_1d)

### DIFF
--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -754,6 +754,7 @@ class ExtractBase:
 
     def __init__(self):
         self.exp_type = ""
+        self.instrument_name = ""
         self.xstart = None
         self.xstop = None
         self.ystart = None
@@ -808,6 +809,7 @@ class ExtractModel(ExtractBase):
         super().__init__()
 
         self.exp_type = input_model.meta.exposure.type
+        self.instrument_name = input_model.meta.instrument.name
         self.dispaxis = dispaxis
         self.spectral_order = spectral_order
 
@@ -1177,7 +1179,11 @@ class ExtractModel(ExtractBase):
                     dec[:] = -999.
                     wcs_wl[:] = -999.
             else:
-                ra, dec, wcs_wl = self.wcs(x_array, y_array)
+                if self.instrument_name == "NIRSPEC":
+                    # xxx temporary:  NIRSpec wcs is one-based.
+                    ra, dec, wcs_wl = self.wcs(x_array + 1., y_array + 1.)
+                else:
+                    ra, dec, wcs_wl = self.wcs(x_array, y_array)
             # We need one right ascension and one declination, representing
             # the direction of pointing.
             mask = np.isnan(ra)
@@ -1256,6 +1262,7 @@ class ImageExtractModel(ExtractBase):
         super().__init__()
 
         self.exp_type = input_model.meta.exposure.type
+        self.instrument_name = input_model.meta.instrument.name
 
         # ref_model contains one or more images; ref_image is the one that
         # matches the current configuration (slit name and spectral order).
@@ -1449,7 +1456,11 @@ class ImageExtractModel(ExtractBase):
                     dec[:] = -999.
                     wcs_wl[:] = -999.
             else:
-                ra, dec, wcs_wl = self.wcs(x_array, y_array)
+                if self.instrument_name == "NIRSPEC":
+                    # xxx temporary:  NIRSpec wcs is one-based.
+                    ra, dec, wcs_wl = self.wcs(x_array + 1., y_array + 1.)
+                else:
+                    ra, dec, wcs_wl = self.wcs(x_array, y_array)
             # We need one right ascension and one declination, representing
             # the direction of pointing.
             middle = ra.shape[0] // 2           # ra and dec have same shape

--- a/jwst/extract_1d/ifu.py
+++ b/jwst/extract_1d/ifu.py
@@ -271,7 +271,11 @@ def extract_ifu(input_model, source_type, extract_params):
         y_array = np.empty(shape[0], dtype=np.float64)
         y_array.fill(float(shape[1]) / 2.)
         z_array = np.arange(shape[0], dtype=np.float64) # for wavelengths
-        ra, dec, wavelength = wcs(x_array, y_array, z_array)
+        if input_model.meta.instrument.name == "NIRSPEC":
+            # xxx temporary:  NIRSpec wcs expects one-based pixel coordinates.
+            ra, dec, wavelength = wcs(x_array + 1., y_array + 1., z_array + 1.)
+        else:
+            ra, dec, wavelength = wcs(x_array, y_array, z_array)
         nelem = len(wavelength)
         ra = ra[nelem // 2]
         dec = dec[nelem // 2]


### PR DESCRIPTION
For NIRSpec data, the pixel coordinates are incremented by 1 before calling the wcs function.  This is done in ifu.py, and in extract.py for the case that the reference file is a JSON file, and also for the case that the reference file is an image.  See issue #1781.