### PR TITLE
Add TUNIT to table-based products

### DIFF
--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -1668,6 +1668,13 @@ def do_extract1d(input_model, refname, smoothing_length, bkg_order):
                             dtype=spec.spec_table.dtype)
             spec = datamodels.SpecModel(spec_table=otab)
             spec.meta.wcs = spec_wcs.create_spectral_wcs(ra, dec, wavelength)
+            spec.spec_table.columns['wavelength'].unit = 'um'
+            spec.spec_table.columns['flux'].unit = 'mJy'
+            spec.spec_table.columns['error'].unit = 'mJy'
+            spec.spec_table.columns['net'].unit = 'DN/s'
+            spec.spec_table.columns['nerror'].unit = 'DN/s'
+            spec.spec_table.columns['background'].unit = 'DN/s'
+            spec.spec_table.columns['berror'].unit = 'DN/s'
             spec.slit_ra = ra
             spec.slit_dec = dec
             spec.spectral_order = sp_order
@@ -1743,6 +1750,13 @@ def do_extract1d(input_model, refname, smoothing_length, bkg_order):
                 spec = datamodels.SpecModel(spec_table=otab)
                 spec.meta.wcs = spec_wcs.create_spectral_wcs(
                                         ra, dec, wavelength)
+                spec.spec_table.columns['wavelength'].unit = 'um'
+                spec.spec_table.columns['flux'].unit = 'mJy'
+                spec.spec_table.columns['error'].unit = 'mJy'
+                spec.spec_table.columns['net'].unit = 'DN/s'
+                spec.spec_table.columns['nerror'].unit = 'DN/s'
+                spec.spec_table.columns['background'].unit = 'DN/s'
+                spec.spec_table.columns['berror'].unit = 'DN/s'
                 spec.slit_ra = ra
                 spec.slit_dec = dec
                 spec.spectral_order = sp_order
@@ -1813,6 +1827,13 @@ def do_extract1d(input_model, refname, smoothing_length, bkg_order):
                     spec = datamodels.SpecModel(spec_table=otab)
                     spec.meta.wcs = spec_wcs.create_spectral_wcs(
                                         ra, dec, wavelength)
+                    spec.spec_table.columns['wavelength'].unit = 'um'
+                    spec.spec_table.columns['flux'].unit = 'mJy'
+                    spec.spec_table.columns['error'].unit = 'mJy'
+                    spec.spec_table.columns['net'].unit = 'DN/s'
+                    spec.spec_table.columns['nerror'].unit = 'DN/s'
+                    spec.spec_table.columns['background'].unit = 'DN/s'
+                    spec.spec_table.columns['berror'].unit = 'DN/s'
                     spec.slit_ra = ra
                     spec.slit_dec = dec
                     spec.spectral_order = sp_order

--- a/jwst/extract_1d/ifu.py
+++ b/jwst/extract_1d/ifu.py
@@ -81,9 +81,11 @@ def ifu_extract1d(input_model, refname, source_type):
         flux = net.copy()
         net[:] = 0.
         log.info("Data have been flux calibrated; setting net to 0.")
+        data_units = 'mJy'
     else:
         flux = np.zeros_like(net)
         log.info("Data have NOT been flux calibrated; setting flux to 0.")
+        data_units = 'mJy'
 
     fl_error = np.ones_like(net)
     nerror = np.ones_like(net)
@@ -94,6 +96,13 @@ def ifu_extract1d(input_model, refname, source_type):
                     dtype=spec.spec_table.dtype)
     spec = datamodels.SpecModel(spec_table=otab)
     spec.meta.wcs = spec_wcs.create_spectral_wcs(ra, dec, wavelength)
+    spec.spec_table.columns['wavelength'].unit = 'um'
+    spec.spec_table.columns['flux'].unit = data_units
+    spec.spec_table.columns['error'].unit = data_units
+    spec.spec_table.columns['net'].unit = data_units
+    spec.spec_table.columns['nerror'].unit = data_units
+    spec.spec_table.columns['background'].unit = data_units
+    spec.spec_table.columns['berror'].unit = data_units
     spec.slit_ra = ra
     spec.slit_dec = dec
     if slitname is not None and slitname != "ANY":

--- a/jwst/extract_1d/ifu.py
+++ b/jwst/extract_1d/ifu.py
@@ -85,7 +85,7 @@ def ifu_extract1d(input_model, refname, source_type):
     else:
         flux = np.zeros_like(net)
         log.info("Data have NOT been flux calibrated; setting flux to 0.")
-        data_units = 'mJy'
+        data_units = 'DN/s'
 
     fl_error = np.ones_like(net)
     nerror = np.ones_like(net)

--- a/jwst/photom/photom.py
+++ b/jwst/photom/photom.py
@@ -647,7 +647,7 @@ class DataSet(object):
             microns_100 = 1.e-4         # 100 microns, in meters
             if waves.max() > 0. and waves.max() < microns_100:
                 waves *= 1.e+6
-            wl_unit = 'microns'
+            wl_unit = 'um'
 
             # Set the relative sensitivity table for the correct Model type
             log.info('Storing relative response table')
@@ -655,11 +655,13 @@ class DataSet(object):
                 otab = np.array(list(zip(waves, relresps)),
                        dtype=self.input.slits[self.slitnum].relsens.dtype)
                 self.input.slits[self.slitnum].relsens = otab
+                self.input.slits[self.slitnum].relsens.columns['wavelength'].unit = wl_unit
 
             else:
                 otab = np.array(list(zip(waves, relresps)),
                                 dtype=self.input.relsens.dtype)
                 self.input.relsens = otab
+                self.input.relsens.columns['wavelength'].unit= wl_unit
 
         return
 


### PR DESCRIPTION
#1754 provided an update that allows column attributes, like units, to be set for table-based data models that have been created from scratch within software. This takes advantage of that ability by setting column units values for the spec_table's created in the extract_1d step, which are stored in x1d products.

It also includes an update to the photom step to set the units value for wavelength column in the RELSENS tables that are attached to science products.

Those are all the FITS table-based science products that I can think of that should set column units. Can anyone think of any others?  The source catalog, TSO photometry, and TSO white-light tables are all ASDF-based and already specify column units.