### PR TITLE
Initial model_blender sphinx docs

### DIFF
--- a/docs/jwst/datamodels/models.rst
+++ b/docs/jwst/datamodels/models.rst
@@ -1,3 +1,5 @@
+.. _datamodels:
+
 About models
 ============
 

--- a/docs/jwst/model_blender/blender_api.rst
+++ b/docs/jwst/model_blender/blender_api.rst
@@ -1,0 +1,11 @@
+.. _blender_api:
+
+Model Blender
+==============
+These functions serve as the primary interface for blending models.  
+
+.. toctree::
+   :maxdepth: 2
+
+.. automodapi:: jwst.model_blender.blendmeta
+.. automodapi:: jwst.model_blender.blender

--- a/docs/jwst/model_blender/blender_rules.rst
+++ b/docs/jwst/model_blender/blender_rules.rst
@@ -1,0 +1,38 @@
+.. _blender_rules:
+
+Model Blender Rules
+====================
+
+Blending models relies on rules to define how to evaluate all the input values 
+for a model attribute in order to determine the final output value. These rules
+then get specified in the model schema for each attribute.  
+
+The rules get interpreted and applied as list or array operations which work on 
+the set of input values for each attribute.  The full set of pre-defined rules
+includes:
+
+.. code-block:: python
+
+  # translation dictionary for function entries from rules files
+  blender_funcs = {'first': first,
+                 'last': last,
+                 'float_one': float_one,
+                 'int_one': int_one,
+                 'zero': zero,
+                 'multi': multi,
+                 'multi?': multi1,
+                 'mean': np.mean,
+                 'sum': np.sum,
+                 'max': np.max,
+                 'min': np.min,
+                 'stddev': np.std}
+
+The rules which should be referenced in the model schema definition are the 
+keys defined for `jwst.model_blender.blender_rules.blender_funcs` listed 
+above.  This definition illustrates how several rules are simply interfaces for 
+numpy array operations, while others are defined internally to `model_blender`.  
+
+.. toctree::
+   :maxdepth: 2
+
+.. automodapi:: jwst.model_blender.blendrules

--- a/docs/jwst/model_blender/index.rst
+++ b/docs/jwst/model_blender/index.rst
@@ -1,0 +1,12 @@
+================
+Model Blender
+================
+
+.. toctree::
+   :maxdepth: 2
+
+   main.rst
+   blender_api.rst
+   blender_rules.rst
+
+.. automodapi:: jwst.model_blender

--- a/docs/jwst/model_blender/main.rst
+++ b/docs/jwst/model_blender/main.rst
@@ -1,0 +1,105 @@
+.. _blender_handbook:
+
+Role of Model Blender
+======================
+
+One problem with combining data from multiple exposures stems from not being able
+to keep track of what kind of data was used to create the final product.  The 
+final product only reports one value for each of the metadata attributes from the
+model schema used to describe the science data, where each of multiple inputs may
+have had different values for each attribute.  The model_blender package solves
+this problem by allowing the user to define rules that can be used to determine a
+final single value from all the input values for each attribute, using separate 
+rules for each attribute as appropriate.  This package also creates a FITS binary
+table that records the input attribute values for all the input models used to 
+create the final product, allowing the user to select what attributes to keep in 
+this table.
+
+This code works by 
+
+  - reading in all the input datamodels (either already in-memory or from FITS files)
+  - evaluating the rules for each attribute as defined in the model's schema
+  - determining from definitions in the input model's schema what attributes to keep in the table
+  - applying each attributes rule to the set of input values to determine the final output value
+  - updating the output model's metadata with the new values
+  - generating the output table with one row for each input model's values
+  
+  
+Using model_blender
+===================
+The model blender package requires
+
+  - all the input models (or FITS files) be available
+  - the output product has already been generated
+
+.. note::
+
+  The generated output model will be considered to contain a default
+  (or perhaps even empty) set of :ref:`metadata` based on some 
+  model defined in :ref:`DataModels<datamodels>`.  This metadata will be replaced 
+  **in-place** when running :ref:`blender_api`.  
+ 
+The simplest way to run model blender only requires calling a single interface:
+
+.. code-block:: python
+  
+  from jwst.model_blender import blendmeta
+  blendmeta.blendmodels(product, inputs=input_list)
+  
+where 
+
+  - `product`: the datamodel(or FITS filename) for the already combined product
+  - `input_list`: list of input datamodels or FITS filenames for all inputs used
+    to create the `product`
+
+
+The output product will end up with new metadata attribute values and a new HDRTAB 
+FITS binary table extension in the FITS file when the product gets saved to disk.
+
+
+Customizing the behavior
+========================
+By default, `blendmodels` will not write out the updated product model to disk. 
+This allows the user or calling program to revise or apply data-specific logic
+to redefine the output value for any of the ouput product's metadata attributes. 
+For example, when combining multiple images, the WCS information does not represent
+any combination of the input WCS attributes.  Instead, the user can have
+their own processing code replace the *blended* WCS attributes with one that was
+computed separately using a complex, accurate algorithm.  This is, in fact, what
+the resample step does to create the final resampled output product whenever it is
+called by steps in the JWST pipeline. 
+
+Additional control over the behavior of model_blender comes from editing the 
+schema for the input datamodels where the rules for each attribute are defined.
+A sample definition from the core schema demonstrates the basic syntax used for 
+any model blending definitions::
+
+          time_end:
+            title: UTC time at end of exposure
+            type: string
+            fits_keyword: TIME-END
+            blend_rule: last
+            blend_table: True
+
+Any attribute without an entry for `blend_rule` will use the default rule of
+`first` which selects the first value from all inputs in the order provided as the
+final output value.  Any attribute with a `blend_table` rule will insure that 
+the specific attribute will be included in the output HDRTAB binary table appended
+to the product model when it gets written out to disk as a FITS file. 
+
+The full set of rules included in the package are described in 
+:ref:`blender_rules` and include common list/array operations such as 
+(but not limited to):
+
+  - minimum
+  - maximum
+  - first
+  - last
+  - mean
+  - zero
+  
+These can then be used to customize the output value for any given attribute
+should the default value provided by default with the schema installed with the
+JWST environment not be correct for the user's input data.  The user can simply
+edit the schema definition installed in their JWST environment to apply custom
+rules for blending the data being processed.

--- a/docs/jwst/package_index.rst
+++ b/docs/jwst/package_index.rst
@@ -32,6 +32,7 @@ Package Index
    jump/index.rst
    lastframe/index.rst
    linearity/index.rst
+   model_blender/index.rst
    mrs_imatch/index.rst
    outlier_detection/index.rst
    pathloss/index.rst


### PR DESCRIPTION
Initial cut at adding user documentation for the model_blender package.  Adding a label to some datamodels docs made it easy to reference the datamodels documentation from within the model_blender (or any JWST) package.  I also needed to update the package index for JWST pipeline to include the model blender docs.
