### PR TITLE
Truncate arrays where wavelength is NaN.

### DIFF
--- a/jwst/extract_1d/ifu.py
+++ b/jwst/extract_1d/ifu.py
@@ -304,4 +304,27 @@ def extract_ifu(input_model, source_type, extract_params):
             background[k] = float(bkg_table['aperture_sum'][0])
             net[k] = net[k] - background[k] * normalization
 
+    # Check for NaNs in the wavelength array, flag them in the dq array,
+    # and truncate the arrays if NaNs are found at endpoints (unless the
+    # entire array is NaN).
+    nan_mask = np.isnan(wavelength)
+    n_nan = nan_mask.sum(dtype=np.intp)
+    if n_nan > 0:
+        log.warning("%d NaNs in wavelength array.", n_nan)
+        dq[nan_mask] = np.bitwise_or(dq[nan_mask], dqflags.pixel['DO_NOT_USE'])
+        not_nan = np.logical_not(nan_mask)
+        flag = np.where(not_nan)
+        if len(flag[0]) > 0:
+            n_trimmed = flag[0][0] + nelem - (flag[0][-1] + 1)
+            if n_trimmed > 0:
+                log.info("Output arrays have been trimmed by %d elements",
+                         n_trimmed)
+                slc = slice(flag[0][0], flag[0][-1] + 1)
+                wavelength = wavelength[slc]
+                net = net[slc]
+                background = background[slc]
+                dq = dq[slc]
+        else:
+            dq |= dqflags.pixel['DO_NOT_USE']
+
     return (ra, dec, wavelength, net, background, dq)


### PR DESCRIPTION
Function nans_at_endpoints was added.  This flags NaNs in the wavelength array with DO_NOT_USE in the dq array.  If there are NaNs at endpoints of the wavelength array, all the output arrays will be truncated to remove the contiguous NaN elements at either or both endpoints.  If there are any interior points in the wavelength array that are NaN, these will be left as NaN, though still flagged as bad in the dq array.  Prior to this, the output dq array was always zero.  See issue #1803.