### PR TITLE
Fix output path naming

### DIFF
--- a/jwst/outlier_detection/outlier_detection_ifu.py
+++ b/jwst/outlier_detection/outlier_detection_ifu.py
@@ -108,7 +108,8 @@ class OutlierDetectionIFU(OutlierDetection):
 
             for model in single_IFUCube_result:
                 model.meta.filename = self.make_output_path(
-                    model, suffix=self.resample_suffix
+                    basepath=model.meta.filename, 
+                    suffix=self.resample_suffix
                 )
                 if save_intermediate_results:
                     log.info("Writing out resampled IFU cubes...")
@@ -119,7 +120,8 @@ class OutlierDetectionIFU(OutlierDetection):
                             init=single_IFUCube_result[0].data.shape)
             median_model.meta = single_IFUCube_result[0].meta
             median_model.meta.filename = self.make_output_path(
-                self.input_models[0], suffix='ch{}_media'.format(ch)
+                basepath=self.input_models[0].meta.filename, 
+                suffix='ch{}_media'.format(ch)
             )
 
             # Perform median combination on set of drizzled mosaics


### PR DESCRIPTION
This is my interpretation of how to call the 'make_output_path' method for outlier_detection_ifu based on the usage from other modules in the package.  At the very least, this avoids the original error reported in Issue #1814  based on my interactive testing with the original problem dataset.
