### PR TITLE
Updates to calwebb_guider processing

### DIFF
--- a/jwst/datamodels/guidercal.py
+++ b/jwst/datamodels/guidercal.py
@@ -19,6 +19,9 @@ class GuiderCalModel( model_base.DataModel):
     dq: numpy array
         The data quality array. 2-D
 
+    err: numpy array
+        The error array. 3-D
+
     plan_star_table: table
         The planned reference star table
 
@@ -37,7 +40,7 @@ class GuiderCalModel( model_base.DataModel):
 
     schema_url = "guider_cal.schema.yaml"
 
-    def __init__(self, init=None, data=None, dq=None,
+    def __init__(self, init=None, data=None, dq=None, err=None,
                  plan_star_table=None, flight_star_table=None,
                  pointing_table=None, centroid_table=None,
                  track_sub_table=None, **kwargs):
@@ -49,6 +52,9 @@ class GuiderCalModel( model_base.DataModel):
 
         if dq is not None:
             self.dq = dq
+
+        if err is not None:
+            self.err = err
 
         if plan_star_table is not None:
             self.plan_star_table = plan_star_table
@@ -67,5 +73,4 @@ class GuiderCalModel( model_base.DataModel):
 
         # Implicitly create arrays
         self.dq = self.dq
-
-
+        self.err = self.err

--- a/jwst/datamodels/guiderraw.py
+++ b/jwst/datamodels/guiderraw.py
@@ -19,6 +19,9 @@ class GuiderRawModel( model_base.DataModel):
     dq: numpy array
         The data quality array. 2-D.
 
+    err: numpy array
+        The error array. 4-D.
+
     plan_star_table: table
         The planned reference star table
 
@@ -37,7 +40,7 @@ class GuiderRawModel( model_base.DataModel):
 
     schema_url = "guider_raw.schema.yaml"
 
-    def __init__(self, init=None, data=None, dq=None,
+    def __init__(self, init=None, data=None, dq=None, err=None,
                  plan_star_table=None, flight_star_table=None,
                  pointing_table=None, centroid_table=None,
                  track_sub_table=None, **kwargs):
@@ -49,6 +52,9 @@ class GuiderRawModel( model_base.DataModel):
 
         if dq is not None:
             self.dq = dq
+
+        if err is not None:
+            self.err = err
 
         if plan_star_table is not None:
             self.plan_star_table = plan_star_table
@@ -67,5 +73,4 @@ class GuiderRawModel( model_base.DataModel):
 
         # Implicitly create arrays
         self.dq = self.dq
-
-
+        self.err = self.err

--- a/jwst/datamodels/schemas/guider_cal.schema.yaml
+++ b/jwst/datamodels/schemas/guider_cal.schema.yaml
@@ -1,7 +1,7 @@
 allOf:
 - $ref: core.schema.yaml
-- $ref: wcsinfo.schema.yaml
 - $ref: bunit.schema.yaml
+- $ref: wcsinfo.schema.yaml
 - type: object
   properties:
     data:
@@ -9,6 +9,11 @@ allOf:
       fits_hdu: SCI
       default: 0.0
       ndim: 3
+      datatype: float32
+    err:
+      title: Error array
+      fits_hdu: ERR
+      default: 0.0
       datatype: float32
     dq:
       title: Data quality array
@@ -23,7 +28,7 @@ allOf:
       - name: guide_star_order
         datatype: int32
       - name: reference_star_id
-        datatype: [ascii, 10]
+        datatype: [ascii, 12]
       - name: ra
         datatype: float64
       - name: dec

--- a/jwst/datamodels/schemas/guider_raw.schema.yaml
+++ b/jwst/datamodels/schemas/guider_raw.schema.yaml
@@ -1,7 +1,7 @@
 allOf:
 - $ref: core.schema.yaml
-- $ref: wcsinfo.schema.yaml
 - $ref: bunit.schema.yaml
+- $ref: wcsinfo.schema.yaml
 - type: object
   properties:
     data:
@@ -9,6 +9,11 @@ allOf:
       fits_hdu: SCI
       default: 0.0
       ndim: 4
+      datatype: float32
+    err:
+      title: Error array
+      fits_hdu: ERR
+      default: 0.0
       datatype: float32
     dq:
       title: Data quality array
@@ -23,7 +28,7 @@ allOf:
       - name: guide_star_order
         datatype: int32
       - name: reference_star_id
-        datatype: [ascii, 10]
+        datatype: [ascii, 12]
       - name: ra
         datatype: float64
       - name: dec

--- a/jwst/dq_init/dq_init_step.py
+++ b/jwst/dq_init/dq_init_step.py
@@ -27,9 +27,10 @@ class DQInitStep(Step):
                 input_model.close()
                 input_model = datamodels.GuiderRawModel(input)
                 self.log.info("Input opened as GuiderRawModel")
-        
+
         except TypeError:
-            # If the initial open attempt fails, try to open as a GuiderRawModel
+            # If the initial open attempt fails,
+            # try to open as a GuiderRawModel
             try:
                 input_model = datamodels.GuiderRawModel(input)
                 self.log.info("Input opened as GuiderRawModel")
@@ -47,16 +48,25 @@ class DQInitStep(Step):
         xsize_kwd = input_model.meta.subarray.xsize
 
         if nints != nints_kwd:
-            self.log.error("Keyword 'NINTS' value of '{0} does not match data array size of '{1}'".format(nints_kwd, nints))
+            self.log.error("Keyword NINTS value of '{0}' does not match " +
+                           "data array size of '{1}'".format(nints_kwd, nints))
             raise ValueError("Bad data dimensions")
+
         if ngroups != ngroups_kwd:
-            self.log.error("Keyword 'NGROUPS' value of '{0}' does not match data array size of '{1}'".format(ngroups_kwd, ngroups))
+            self.log.error("Keyword NGROUPS value of '{0}' " +
+                           "does not match data array size of " +
+                           "'{1}'".format(ngroups_kwd, ngroups))
             raise ValueError("Bad data dimensions")
-        if ysize != ysize_kwd and 'IRS2' not in input_model.meta.exposure.readpatt.upper():
-            self.log.error("Keyword 'SUBSIZE2' value of '{0}' does not match data array size of '{1}'".format(ysize_kwd, ysize))
+
+        if ((ysize != ysize_kwd) and
+                ('IRS2' not in input_model.meta.exposure.readpatt.upper())):
+            self.log.error("Keyword SUBSIZE2 value of '{0}' does not match " +
+                           "data array size of '{1}'".format(ysize_kwd, ysize))
             raise ValueError("Bad data dimensions")
+
         if xsize != xsize_kwd:
-            self.log.error("Keyword 'SUBSIZE1' value of '{0}' does not match data array size of '{1}'".format(xsize_kwd, xsize))
+            self.log.error("Keyword SUBSIZE1 value of '{0}' does not match " +
+                           "data array size of '{1}'".format(xsize_kwd, xsize))
             raise ValueError("Bad data dimensions")
 
         # Retreive the mask reference file name

--- a/jwst/dq_init/dq_initialization.py
+++ b/jwst/dq_init/dq_initialization.py
@@ -17,8 +17,9 @@ log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
 
-guider_list = ['FGS_ID-IMAGE', 'FGS_ID-STACK', 'FGS_ACQ1', 'FGS_ACQ2',\
-             'FGS_TRACK', 'FGS_FINEGUIDE'] # FGS guider operation modes
+# FGS guide star mode exposure types
+guider_list = ['FGS_ID-IMAGE', 'FGS_ID-STACK', 'FGS_ACQ1', 'FGS_ACQ2',
+               'FGS_TRACK', 'FGS_FINEGUIDE']
 
 
 def correct_model(input_model, mask_model):
@@ -42,7 +43,8 @@ def do_dqinit(input_model, mask_model):
         mask_array = mask_model.dq
     else:
         log.info('Extracting mask subarray to match science data')
-        mask_sub_model = reffile_utils.get_subarray_model(output_model, mask_model)
+        mask_sub_model = reffile_utils.get_subarray_model(output_model,
+                                                          mask_model)
         mask_array = mask_sub_model.dq.copy()
         mask_sub_model.close()
 
@@ -61,38 +63,44 @@ def do_dqinit(input_model, mask_model):
 
 def check_dimensions(input_model):
     #
-    # Check that the input model pixeldq attribute has the same dimensions as the
-    # image plane of the input model science data
-    # If it has dimensions (0,0), create an array of zeros with the same shape as
-    # the image plane of the input model. For the FGS modes, the GuiderRawModel
-    # has a dq array only (no pixeldq or groupdq)
+    # Check that the input model pixeldq attribute has the same dimensions as
+    # the image plane of the input model science data
+    # If it has dimensions (0,0), create an array of zeros with the same shape
+    # as the image plane of the input model. For the FGS modes, the
+    # GuiderRawModel has only a regular dq array (no pixeldq or groupdq)
 
     input_shape = input_model.data.shape
 
     if isinstance(input_model, datamodels.GuiderRawModel):
         if input_model.dq.shape != input_shape[-2:]:
 
-            # If the shape is different, then the mask model should have a shape of (0,0)
+            # If the shape is different, then the mask model should have
+            # a shape of (0,0).
             # If that's the case, create the array
             if input_model.dq.shape == (0, 0):
                 input_model.dq = np.zeros((input_shape[-2:])).astype('uint32')
             else:
-                log.error("DQ array has the wrong shape: (%d, %d)" % input_model.dq.shape)
+                log.error("DQ array has the wrong shape: (%d, %d)" %
+                          input_model.dq.shape)
 
     else:   # RampModel
         if input_model.pixeldq.shape != input_shape[-2:]:
 
-            # If the shape is different, then the mask model should have a shape of (0,0)
+            # If the shape is different, then the mask model should have
+            # a shape of (0,0).
             # If that's the case, create the array
             if input_model.pixeldq.shape == (0, 0):
-                input_model.pixeldq = np.zeros((input_shape[-2:])).astype('uint32')
+                input_model.pixeldq = \
+                    np.zeros((input_shape[-2:])).astype('uint32')
             else:
-                log.error("Pixeldq array has the wrong shape: (%d, %d)" % input_model.pixeldq.shape)
+                log.error("Pixeldq array has the wrong shape: (%d, %d)" %
+                          input_model.pixeldq.shape)
 
         # Perform the same check for the input model groupdq array
         if input_model.groupdq.shape != input_shape:
             if input_model.groupdq.shape == (0, 0, 0, 0):
                 input_model.groupdq = np.zeros((input_shape)).astype('uint8')
             else:
-                log.error("Groupdq array has the wrong shape: (%d, %d, %d, %d)" % input_model.groupdq.shape)
+                log.error("Groupdq array has wrong shape: (%d, %d, %d, %d)" %
+                          input_model.groupdq.shape)
     return

--- a/jwst/flatfield/flat_field.py
+++ b/jwst/flatfield/flat_field.py
@@ -18,6 +18,7 @@ MICRONS_100 = 1.e-4                     # 100 microns, in meters
 # This is for NIRSpec.  These exposure types are all fixed-slit modes.
 FIXED_SLIT_TYPES = ["NRS_LAMP", "NRS_BRIGHTOBJ", "NRS_FIXEDSLIT"]
 
+
 def do_correction(input_model, flat_model,
                   f_flat_model, s_flat_model,
                   d_flat_model, flat_suffix=None):
@@ -80,6 +81,8 @@ def do_correction(input_model, flat_model,
 #
 # These functions are for non-NIRSpec flat fielding, or for NIRSpec imaging.
 #
+
+
 def do_flat_field(output_model, flat_model):
     """
     Short Summary
@@ -104,7 +107,7 @@ def do_flat_field(output_model, flat_model):
     else:
         log.debug("Flat field correction for non-NIRSpec modes.")
 
-    any_updated = False # will set True if any flats applied
+    any_updated = False  # will set True if any flats applied
 
     # Check to see if flat data array is smaller than science data
     if (output_model.data.shape[-1] > flat_model.data.shape[-1]) or \
@@ -183,16 +186,8 @@ def apply_flat_field(science, flat):
     # correction is made
     flat_data[np.where(flat_bad)] = 1.0
 
-    # For GuiderCalModel data, only apply flat to science data array;
-    # there isn't an error array.
-    if isinstance(science, datamodels.GuiderCalModel):
-        # Flatten data array
-        science.data /= flat_data
-        # Combine the science and flat DQ arrays
-        science.dq = np.bitwise_or(science.dq, flat_dq)
-
     # For CubeModel science data, apply flat to each integration
-    elif isinstance(science, datamodels.CubeModel):
+    if isinstance(science, datamodels.CubeModel):
         for integ in range(science.data.shape[0]):
             # Flatten data and error arrays
             science.data[integ] /= flat_data

--- a/jwst/guider_cds/guider_cds.py
+++ b/jwst/guider_cds/guider_cds.py
@@ -1,8 +1,7 @@
 #! /usr/bin/env python
-# 
+#
 #  guider_cds.py
 
-import time
 import numpy as np
 import logging
 
@@ -11,20 +10,21 @@ from .. import datamodels
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
+
 def guider_cds(model):
     """
     Extended Summary
     ----------------
     Calculate the count rate for each pixel in all integrations.
 
-    For each integration in a given FGS guider dataset whose mode is ACQ1, 
-    ACQ2, or TRACK, the count rate is the last group minus the first group, 
-    divided by the effective integration time.  If the mode is ID, the last 
-    group minus the first group is calculated for both integrations; the count 
-    rate is then given by the minimum of these two values for each pixel, 
-    divided by the group time.  For the FINEGUIDE mode, the count rate is the 
-    average of the last 4 groups minus the average of the first 4 groups, 
-    divided by the group time.  
+    For each integration in a given FGS guider dataset whose mode is ACQ1,
+    ACQ2, or TRACK, the count rate is the last group minus the first group,
+    divided by the effective integration time.  If the mode is ID, the last
+    group minus the first group is calculated for both integrations; the count
+    rate is then given by the minimum of these two values for each pixel,
+    divided by the group time.  For the FINEGUIDE mode, the count rate is the
+    average of the last 4 groups minus the average of the first 4 groups,
+    divided by the group time.
 
     Parameters
     ----------
@@ -35,23 +35,28 @@ def guider_cds(model):
     # get needed sizes and shapes
     imshape, n_int, grp_time, exp_type = get_dataset_info(model)
 
-    if exp_type[:6] == 'FGS_ID': # force output to have single slice
-        new_model = datamodels.GuiderCalModel((1,)+imshape)
+    if exp_type[:6] == 'FGS_ID':  # force output to have single slice
+        new_model = datamodels.GuiderCalModel((1,) + imshape)
     else:
         new_model = datamodels.GuiderCalModel()
 
     # set up output data arrays
+    slope_int_cube = np.zeros((n_int,) + imshape, dtype=np.float32)
+    if exp_type[:6] == 'FGS_ID':
+        err = np.zeros((1,) + imshape, dtype=np.float32)
+    else:
+        err = np.zeros((n_int,) + imshape, dtype=np.float32)
+    new_model.err = err
     new_model.dq = model.dq
-    slope_int_cube = np.zeros(( n_int,) + imshape, dtype = np.float32)
 
     # loop over data integrations
     for num_int in range(0, n_int):
-        data_sect = model.data[num_int, :,:,:]
+        data_sect = model.data[num_int, :, :, :]
 
         if exp_type == 'FGS_FINEGUIDE':
-            first_4 = data_sect[:4,:,:].mean(axis=0)
-            last_4  = data_sect[-4:,:,:].mean(axis=0)
-            slope_int_cube[num_int,:,:] = last_4 - first_4
+            first_4 = data_sect[:4, :, :].mean(axis=0)
+            last_4 = data_sect[-4:, :, :].mean(axis=0)
+            slope_int_cube[num_int, :, :] = last_4 - first_4
 
         elif exp_type[:6] == 'FGS_ID':
             grp_last = data_sect[1, :, :]
@@ -65,12 +70,12 @@ def guider_cds(model):
         else:  # ACQ1, ACQ2, or TRACK
             grp_last = data_sect[1, :, :]
             grp_first = data_sect[0, :, :]
-            slope_int_cube[ num_int,:,: ] = grp_last - grp_first
-        
+            slope_int_cube[num_int, :, :] = grp_last - grp_first
+
     if exp_type[:6] == 'FGS_ID':
-        new_model.data[0,:,:] = np.minimum( diff_int1, diff_int0 )/grp_time
+        new_model.data[0, :, :] = np.minimum(diff_int1, diff_int0) / grp_time
     else:  # FINEGUIDE, ACQ1, ACQ2, or TRACK
-        new_model.data = slope_int_cube/grp_time
+        new_model.data = slope_int_cube / grp_time
 
     # copy all meta data from input to output model
     new_model.update(model)
@@ -97,7 +102,7 @@ def get_dataset_info(model):
     """
     Short Summary
     -------------
-    Extract values for the image shape, the number of integrations, 
+    Extract values for the image shape, the number of integrations,
     the group time, and the exposure type.
 
     Parameters
@@ -118,7 +123,7 @@ def get_dataset_info(model):
 
     exp_type: string
         exposure type
-    """ 
+    """
     instrume = model.meta.instrument.name
     frame_time = model.meta.exposure.frame_time
     ngroups = model.meta.exposure.ngroups
@@ -129,7 +134,6 @@ def get_dataset_info(model):
     asize2 = model.data.shape[2]
     asize1 = model.data.shape[3]
 
-    npix = asize2 * asize1  # number of pixels in 2D array
     imshape = (asize2, asize1)
 
     log.info('Instrument: %s' % (instrume))

--- a/jwst/guider_cds/guider_cds_step.py
+++ b/jwst/guider_cds/guider_cds_step.py
@@ -1,12 +1,13 @@
 #! /usr/bin/env python
 
-from ..stpipe import Step, cmdline
+from ..stpipe import Step
 from .. import datamodels
 from . import guider_cds
 
 import logging
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
+
 
 class GuiderCdsStep (Step):
 
@@ -21,4 +22,3 @@ class GuiderCdsStep (Step):
         out_model.meta.cal_step.guider_cds = 'COMPLETE'
 
         return out_model
-

--- a/jwst/pipeline/calwebb_guider.py
+++ b/jwst/pipeline/calwebb_guider.py
@@ -1,24 +1,24 @@
 #!/usr/bin/env python
 from ..stpipe import Pipeline
+import logging
 from .. import datamodels
-import os
 
 # step imports
 from ..dq_init import dq_init_step
 from ..flatfield import flat_field_step
 from ..guider_cds import guider_cds_step
 
-__version__ = '0.8.0'
+__version__ = '0.9.3'
 
 # Define logging
-import logging
 log = logging.getLogger()
 log.setLevel(logging.DEBUG)
 
+
 class GuiderPipeline(Pipeline):
     """
-    GuiderPipeline: For FGS observations, apply all calibration 
-    steps to raw JWST ramps to produce a 3-D slope product. 
+    GuiderPipeline: For FGS observations, apply all calibration
+    steps to raw JWST ramps to produce a 3-D slope product.
     Included steps are: dq_init, guider_cds, and flat_field.
     """
 
@@ -41,12 +41,14 @@ class GuiderPipeline(Pipeline):
         # they've been run before and open the input as a Cal
         # model, appropriate for input to flat_field
         if (self.dq_init.skip and self.guider_cds.skip):
+            log.info("dq_init and guider_cds are set to skip; assume they"
+                     " were run before and load data as GuiderCalModel")
             input = datamodels.GuiderCalModel(input)
         else:
-            input = datamodels.GuiderRawModel(input) 
+            input = datamodels.GuiderRawModel(input)
 
         # Apply the steps
-        input = self.dq_init(input)  
+        input = self.dq_init(input)
         input = self.guider_cds(input)
         input = self.flat_field(input)
 

--- a/jwst/pipeline/calwebb_guider.py
+++ b/jwst/pipeline/calwebb_guider.py
@@ -36,8 +36,14 @@ class GuiderPipeline(Pipeline):
 
         log.info('Starting calwebb_guider ...')
 
-        # Open the input
-        input = datamodels.GuiderRawModel(input) 
+        # Open the input:
+        # If the first two steps are set to be skipped, assume
+        # they've been run before and open the input as a Cal
+        # model, appropriate for input to flat_field
+        if (self.dq_init.skip and self.guider_cds.skip):
+            input = datamodels.GuiderCalModel(input)
+        else:
+            input = datamodels.GuiderRawModel(input) 
 
         # Apply the steps
         input = self.dq_init(input)  


### PR DESCRIPTION
First set of updates to guide star processing for #1612. The two main changes are the addition of an ERR array to the data models and a minor update to the column format of one of the table extensions (in order to match what SDP is generating). The guider_cds step has been updated to create an ERR array in the output model. Note that nothing is done yet with the ERR array at any stage of guider processing. It's just there for future expansion and to make it consistent with the SCI, DQ, ERR contents of science products.

Many other changes were made just for general cleanup and to get pep8/flake8 off my back. All of the changes to dq_init are for this purpose only, with no actual changes to the processing.