### PR TITLE
Add EXP_TYPE to WfssBkgModel schema

### DIFF
--- a/jwst/datamodels/schemas/wfssbkg.schema.yaml
+++ b/jwst/datamodels/schemas/wfssbkg.schema.yaml
@@ -1,8 +1,9 @@
 allOf:
 - $ref: referencefile.schema.yaml
-- $ref: subarray.schema.yaml
+- $ref: keyword_exptype.schema.yaml
 - $ref: keyword_filter.schema.yaml
 - $ref: keyword_pupil.schema.yaml
+- $ref: subarray.schema.yaml
 - $ref: bunit.schema.yaml
 - type: object
   properties:


### PR DESCRIPTION
As noted in https://jira.stsci.edu/browse/CRDS-181 the keyword EXP_TYPE also needs to be used as a selector for WFSSBKG reference files, so we need to add it to the schema for WfssBkgModel.