### PR TITLE
Allow conversion between model types in datamodels

### DIFF
--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -25,6 +25,7 @@ from . import filetype
 from . import fits_support
 from . import properties
 from . import schema as mschema
+from . import util
 
 from .extension import BaseExtension
 from jwst.transforms.jwextension import JWSTExtension
@@ -131,13 +132,14 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
             asdf = AsdfFile(extensions=extensions)
             shape = init.shape
             is_array = True
-        elif isinstance(init, self.__class__):
-            self.clone(self, init)
-            return
+
         elif isinstance(init, DataModel):
-            raise TypeError(
-                "Passed in {0!r} is not of the expected subclass {1!r}".format(
-                    init.__class__.__name__, self.__class__.__name__))
+            self.clone(self, init)
+            if not isinstance(init, self.__class__):
+                util.validate_schema(self._instance, self._schema,
+                                     self._pass_invalid_values,
+                                     self._strict_validation)
+            return
         elif isinstance(init, AsdfFile):
             asdf = init
         elif isinstance(init, tuple):
@@ -262,7 +264,6 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
             target._iscopy = True
 
         target._files_to_close = []
-        target._schema = source._schema
         target._shape = source._shape
         target._ctx = target
 

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -136,9 +136,7 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         elif isinstance(init, DataModel):
             self.clone(self, init)
             if not isinstance(init, self.__class__):
-                util.validate_schema(self._instance, self._schema,
-                                     self._pass_invalid_values,
-                                     self._strict_validation)
+                self.validate()
             return
         elif isinstance(init, AsdfFile):
             asdf = init
@@ -279,6 +277,14 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         return result
 
     __copy__ = __deepcopy__ = copy
+
+    def validate(self):
+        """
+        Re-validate the model instance againsst its schema
+        """
+        util.validate_schema(self._instance, self._schema,
+                             self._pass_invalid_values,
+                             self._strict_validation)
 
     def get_primary_array_name(self):
         """

--- a/jwst/datamodels/tests/test_models.py
+++ b/jwst/datamodels/tests/test_models.py
@@ -471,11 +471,13 @@ def test_slit_from_image():
     assert hasattr(slit, 'pathloss_pointsource')
     assert slit.meta.instrument.name == "MIRI"
 
-    with pytest.raises(TypeError):
-        ImageModel(slit)
+    im = ImageModel(slit)
+    assert type(im) == ImageModel
+    im.close()
 
-    with pytest.raises(TypeError):
-        ImageModel(slit_dm)
+    im = ImageModel(slit_dm)
+    assert type(im) == ImageModel
+    im.close()
 
 
 def test_ifuimage():
@@ -485,5 +487,7 @@ def test_ifuimage():
     assert_allclose(im.data, ifuimage.data)
     assert_allclose(im.err, ifuimage.err)
     assert_allclose(im.dq, ifuimage.dq)
-    with pytest.raises(TypeError):
-        ImageModel(ifuimage)
+
+    im = ImageModel(ifuimage)
+    assert type(im) == ImageModel
+    im.close()


### PR DESCRIPTION
Datamodels has been modified to allow conversion between model types. The method is to open a datamodel of the desired type using a datamodel of another type as its argument. For example,

    im = datamodels.open('reference_file.fits')
    im = FlatModel(im)

The first line opens the image as a generic reference file. The second line converts it to a flat field reference file.