### PR TITLE
Initial replacement of code and docstrings

### DIFF
--- a/jwst/skymatch/skyimage.py
+++ b/jwst/skymatch/skyimage.py
@@ -1,4 +1,4 @@
-"""
+spherical_geometry"""
 The ``skyimage`` module contains algorithms that are used by
 ``skymatch`` to manage all of the information for footprints (image outlines)
 on the sky as well as perform useful operations on these outlines such as
@@ -16,7 +16,7 @@ from __future__ import (absolute_import, division, unicode_literals,
 import numpy as np
 
 # THIRD-PARTY
-from stsci.sphere.polygon import SphericalPolygon
+from spherical_geometry.polygon import SphericalPolygon
 
 #LOCAL
 from . skystatistics import SkyStats
@@ -205,7 +205,7 @@ class SkyImage(object):
         """
         Compute intersection of this `SkyImage` object and another
         `SkyImage`, `SkyGroup`, or
-        :py:class:`~stsci.sphere.polygon.SphericalPolygon`
+        :py:class:`~spherical_geometry.polygon.SphericalPolygon`
         object.
 
         Parameters
@@ -216,7 +216,7 @@ class SkyImage(object):
         Returns
         -------
         polygon : SphericalPolygon
-            A :py:class:`~stsci.sphere.polygon.SphericalPolygon` that is
+            A :py:class:`~spherical_geometry.polygon.SphericalPolygon` that is
             the intersection of this `SkyImage` and `skyimage`.
 
         """
@@ -344,7 +344,7 @@ class SkyImage(object):
         overlap : SkyImage, SkyGroup, SphericalPolygon, list of tuples, \
 None, optional
             Another `SkyImage`, `SkyGroup`,
-            :py:class:`stsci.sphere.polygons.SphericalPolygon`, or
+            :py:class:`spherical_geometry.polygons.SphericalPolygon`, or
             a list of tuples of (RA, DEC) of vertices of a spherical
             polygon. This parameter is used to indicate that sky statistics
             should computed only in the region of intersection of *this*
@@ -467,7 +467,7 @@ None, optional
         overlap : SkyImage, SkyGroup, SphericalPolygon, list of tuples, \
 None, optional
             Another `SkyImage`, `SkyGroup`,
-            :py:class:`stsci.sphere.polygons.SphericalPolygon`, or
+            :py:class:`spherical_geometry.polygons.SphericalPolygon`, or
             a list of tuples of (RA, DEC) of vertices of a spherical
             polygon. This parameter is used to indicate that sky statistics
             should computed only in the region of intersection of *this*
@@ -662,7 +662,7 @@ class SkyGroup(object):
         """
         Compute intersection of this `SkyImage` object and another
         `SkyImage`, `SkyGroup`, or
-        :py:class:`~stsci.sphere.polygon.SphericalPolygon`
+        :py:class:`~spherical_geometry.polygon.SphericalPolygon`
         object.
 
         Parameters
@@ -673,7 +673,7 @@ class SkyGroup(object):
         Returns
         -------
         polygon : SphericalPolygon
-            A :py:class:`~stsci.sphere.polygon.SphericalPolygon` that is
+            A :py:class:`~spherical_geometry.polygon.SphericalPolygon` that is
             the intersection of this `SkyImage` and `skyimage`.
 
         """
@@ -742,7 +742,7 @@ class SkyGroup(object):
         overlap : SkyImage, SkyGroup, SphericalPolygon, list of tuples, \
 None, optional
             Another `SkyImage`, `SkyGroup`,
-            :py:class:`stsci.sphere.polygons.SphericalPolygon`, or
+            :py:class:`spherical_geometry.polygons.SphericalPolygon`, or
             a list of tuples of (RA, DEC) of vertices of a spherical
             polygon. This parameter is used to indicate that sky statistics
             should computed only in the region of intersection of *this*

--- a/jwst/tweakreg/wcsimage.py
+++ b/jwst/tweakreg/wcsimage.py
@@ -20,7 +20,7 @@ from copy import deepcopy
 import numpy as np
 import gwcs
 from astropy import table
-from stsci.sphere.polygon import SphericalPolygon
+from spherical_geometry.polygon import SphericalPolygon
 from stsci.stimage import xyxymatch
 
 # LOCAL
@@ -525,7 +525,7 @@ class WCSImageCatalog(object):
         """
         Compute intersection of this `WCSImageCatalog` object and another
         `WCSImageCatalog`, `WCSGroupCatalog`, or
-        :py:class:`~stsci.sphere.polygon.SphericalPolygon`
+        :py:class:`~spherical_geometry.polygon.SphericalPolygon`
         object.
 
         Parameters
@@ -537,7 +537,7 @@ class WCSImageCatalog(object):
         Returns
         -------
         polygon : SphericalPolygon
-            A :py:class:`~stsci.sphere.polygon.SphericalPolygon` that is
+            A :py:class:`~spherical_geometry.polygon.SphericalPolygon` that is
             the intersection of this `WCSImageCatalog` and `wcsim`.
 
         """
@@ -776,7 +776,7 @@ class WCSGroupCatalog(object):
         """
         Compute intersection of this `WCSGroupCatalog` object and another
         `WCSImageCatalog`, `WCSGroupCatalog`, or
-        :py:class:`~stsci.sphere.polygon.SphericalPolygon`
+        :py:class:`~spherical_geometry.polygon.SphericalPolygon`
         object.
 
         Parameters
@@ -788,7 +788,7 @@ class WCSGroupCatalog(object):
         Returns
         -------
         polygon : SphericalPolygon
-            A :py:class:`~stsci.sphere.polygon.SphericalPolygon` that is
+            A :py:class:`~spherical_geometry.polygon.SphericalPolygon` that is
             the intersection of this `WCSGroupCatalog` and `wcsim`.
 
         """
@@ -1357,7 +1357,7 @@ class RefCatalog(object):
         """
         Compute intersection of this `WCSImageCatalog` object and another
         `WCSImageCatalog`, `WCSGroupCatalog`, `RefCatalog`, or
-        :py:class:`~stsci.sphere.polygon.SphericalPolygon`
+        :py:class:`~spherical_geometry.polygon.SphericalPolygon`
         object.
 
         Parameters
@@ -1369,7 +1369,7 @@ class RefCatalog(object):
         Returns
         -------
         polygon : SphericalPolygon
-            A :py:class:`~stsci.sphere.polygon.SphericalPolygon` that is
+            A :py:class:`~spherical_geometry.polygon.SphericalPolygon` that is
             the intersection of this `WCSImageCatalog` and `wcsim`.
 
         """


### PR DESCRIPTION
All references to 'stsci.sphere' that could be found within the JWST package should have been replaced, with this PR, with references to the newer spherical_geometry package.  This includes the code as well as the docs.  