### PR TITLE
slit PPS to slit DMS coordinate conversion

### DIFF
--- a/jwst/assign_wcs/nirspec.py
+++ b/jwst/assign_wcs/nirspec.py
@@ -457,11 +457,10 @@ def get_open_msa_slits(msa_file, msa_metadata_id):
             columns "estimated_source_in_shutter_x" and "estimated_source_in_shutter_y".
             The source position is in a coordinate system associated with each shutter whose
             origin is the upper left corner of the shutter, positive x is to the right
-            and positive y is downwards. To convert to the coordinate frame associated with the
-            slit, where (0, 0) is in the center of the slit, we subtract 0.5 in both directions.
+            and positive y is downwards.
             """
             source_xpos = source_xpos - 0.5
-            source_ypos = source_ypos - 0.5
+            source_ypos = -source_ypos + 0.5
 
             # Create the shutter_state string
             all_shutters = _shutter_id_to_str(open_shutters, ycen)

--- a/jwst/assign_wcs/tests/test_nirspec.py
+++ b/jwst/assign_wcs/tests/test_nirspec.py
@@ -292,7 +292,7 @@ def test_msa_configuration_normal():
     msaconfl = get_file_path('msa_configuration.fits')
     slitlet_info = nirspec.get_open_msa_slits(msaconfl, msa_meta_id)
     ref_slit = Slit(55, 9376, 251, 26, -5.15, 0.55, 4, 1, '1111x', '95065_1', '2122',
-                      0.13, -0.31716078999999997, -0.18092266)
+                      0.13, -0.31716078999999997, 0.18092266)
     _compare_slits(slitlet_info[0], ref_slit)
 
 
@@ -317,7 +317,7 @@ def test_msa_configuration_all_background():
     msaconfl = get_file_path('msa_configuration.fits')
     slitlet_info = nirspec.get_open_msa_slits(msaconfl, msa_meta_id)
     ref_slit = Slit(57, 8646, 251, 24, -2.85, .55, 4, 1, '11x', '95065_1', '2122',
-                    0.13, -0.5, -0.5)
+                    0.13, -0.5, 0.5)
     _compare_slits(slitlet_info[0], ref_slit)
 
 
@@ -332,7 +332,7 @@ def test_msa_configuration_row_skipped():
     msaconfl = get_file_path('msa_configuration.fits')
     slitlet_info = nirspec.get_open_msa_slits(msaconfl, msa_meta_id)
     ref_slit = Slit(58, 8646, 251, 24, -2.85, 5.15, 4, 1, '11x1011', '95065_1', '2122',
-                      0.130, -0.31716078999999997, -0.18092266)
+                      0.130, -0.31716078999999997, 0.18092266)
     _compare_slits(slitlet_info[0], ref_slit)
 
 
@@ -345,9 +345,9 @@ def test_msa_configuration_multiple_returns():
     msaconfl = get_file_path('msa_configuration.fits')
     slitlet_info = nirspec.get_open_msa_slits(msaconfl, msa_meta_id)
     ref_slit1 = Slit(59, 8651, 256, 24, -2.85, 5.15, 4, 1, '11x1011', '95065_1', '2122',
-                     0.13000000000000003, -0.31716078999999997, -0.18092266)
+                     0.13000000000000003, -0.31716078999999997, 0.18092266)
     ref_slit2 = Slit(60, 11573, 258, 32, -2.85, 4, 4, 2, '11x111', '95065_2', '172',
-                     0.70000000000000007, -0.31716078999999997, -0.18092266)
+                     0.70000000000000007, -0.31716078999999997, 0.18092266)
     _compare_slits(slitlet_info[0], ref_slit1)
     _compare_slits(slitlet_info[1], ref_slit2)
 


### PR DESCRIPTION
Fix an issue with converting between PPS and DMS shutter coordinate systems.
The source position in a shutter is reported in the MSA configuration file in a coordinate system associated with the shutter with origin (0, 0) in the upper left corner (PPS system). `x` increases to the right. `y` increases downwards. The DMS uses a shutter coordinate system with origin  (0, 0) in the center of the shutter, with positive `x` to the right and positive `y` upwards.