### PR TITLE
Redo code that sets meta.model_type

### DIFF
--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -200,14 +200,12 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
 
         # store the data model type, if not already set
         klass = self.__class__.__name__
-        if klass == 'DataModel':
-            klass = None
-
-        if hasattr(self.meta, 'model_type'):
-            if self.meta.model_type is None:
+        if klass != 'DataModel':
+            if hasattr(self.meta, 'model_type'):
+                if self.meta.model_type is None:
+                    self.meta.model_type = klass
+            else:
                 self.meta.model_type = klass
-        else:
-            self.meta.model_type = klass
 
         if is_array:
             primary_array_name = self.get_primary_array_name()


### PR DESCRIPTION
In some circumstances the code that set meta.model_type would set it to None. This triggered a validation warning or error, because it failed the type check for model_type. The code has been reworked so that this doesn't happen.