### PR TITLE
Add exp_type vs pipeline info

### DIFF
--- a/docs/jwst/introduction.rst
+++ b/docs/jwst/introduction.rst
@@ -354,11 +354,22 @@ Background-subtracted image                    bsub
 Per integration background-subtracted image    bsubints
 Calibrated image                               cal
 Calibrated per integration images              calints
+CR-flagged image                               crf
+CR-flagged per integration images              crfints
 1D extracted spectrum                          x1d
 1D extracted spectra per integration           x1dints
 Resampled 2D image                             i2d
 Resampled 2D spectrum                          s2d
 Resampled 3D IFU cube                          s3d
+Source catalog                                 cat
+Time Series photometric catalog                phot
+Time Series white-light catalog                whtlt
+Coronagraphic PSF image stack                  psfstack
+Coronagraphic PSF-aligned images               psfalign
+Coronagraphic PSF-subtracted images            psfsub
+AMI fringe and closure phases                  ami
+AMI averaged fringe and closure phases         amiavg
+AMI normalized fringe and closure phases       aminorm
 =============================================  ========
 
 Individual Step Outputs
@@ -423,8 +434,6 @@ jump detection step is:
     name = "jump"
     class = "jwst.jump.JumpStep"
     rejection_threshold = 4.0
-    do_yintercept = False
-    yint_threshold = 1.0
 
 You can list all of the parameters for this step using:
 ::
@@ -437,9 +446,9 @@ Guide at :ref:`stpipe-user-steps`.
 
 Available Pipelines
 ===================
-There are currently several pre-defined pipelines available for processing
-the data from different instrument observing modes. For all of the details
-see :ref:`pipelines`.
+There are many pre-defined pipeline modules for processing
+data from different instrument observing modes through each of the 3 stages
+of calibration. For all of the details see :ref:`pipelines`.
 
 
 For More Information

--- a/docs/jwst/pipeline/description.rst
+++ b/docs/jwst/pipeline/description.rst
@@ -37,6 +37,107 @@ the instrument modes to which they can be applied.
 | TSO3Pipeline      | calwebb_tso3.cfg      | Stage 3: Time Series mode    |
 +-------------------+-----------------------+------------------------------+
 
+The data from different observing modes needs to be processed with
+different combinations of the pipeline stages listed above. Observing
+modes are usually identifiable via the value of the `EXP_TYPE` keyword in
+the data product. The following table lists the pipeline modules that get
+applied to each `EXP_TYPE` instance.
+
++-------------------+-------------------+------------------+------------------+
+| EXP_TYPE          | Stage 1 Pipeline  | Stage 2 Pipeline | Stage 3 Pipeline |
++===================+===================+==================+==================+
+| FGS_IMAGE         | calwebb_detector1 | calwebb_image2   | calwebb_image3   |
++-------------------+-------------------+------------------+------------------+
+| FGS_FOCUS         | calwebb_detector1 | calwebb_image2   | N/A              |
++-------------------+-------------------+------------------+------------------+
+| FGS_DARK          | calwebb_dark1     | N/A              | N/A              |
++-------------------+-------------------+------------------+------------------+
+| FGS_SKYFLAT       | calwebb_detector1 | N/A              | N/A              |
+| FGS_INTFLAT       |                   |                  |                  |
++-------------------+-------------------+------------------+------------------+
+|                   |                   |                  |                  |
++-------------------+-------------------+------------------+------------------+
+| MIR_IMAGE         | calwebb_detector1 | calwebb_image2   | calwebb_image3   |
++-------------------+-------------------+------------------+------------------+
+| MIR_MRS           | calwebb_detector1 | calwebb_spec2    | calwebb_spec3    |
++-------------------+-------------------+------------------+------------------+
+| MIR_LRS-FIXEDSLIT | calwebb_detector1 | calwebb_spec2    | calwebb_spec3    |
++-------------------+-------------------+------------------+------------------+
+| MIR_LRS-SLITLESS  | calwebb_tso1      | calwebb_spec2    | calwebb_tso3     |
++-------------------+-------------------+------------------+------------------+
+| MIR_LYOT          | calwebb_detector1 | calwebb_image2   | calwebb_coron3   |
+| MIR_4QPM          |                   |                  |                  |
++-------------------+-------------------+------------------+------------------+
+| MIR_TACQ          | calwebb_detector1 | calwebb_image2   | N/A              |
++-------------------+-------------------+------------------+------------------+
+| MIR_DARK          | calwebb_dark1     | N/A              | N/A              |
++-------------------+-------------------+------------------+------------------+
+| MIR_FLATIMAGE     | calwebb_detector1 | N/A              | N/A              |
+| MIR_FLATMRS       |                   |                  |                  |
++-------------------+-------------------+------------------+------------------+
+|                   |                   |                  |                  |
++-------------------+-------------------+------------------+------------------+
+| NRC_IMAGE         | calwebb_detector1 | calwebb_image2   | calwebb_image3   |
++-------------------+-------------------+------------------+------------------+
+| NRC_CORON         | calwebb_detector1 | calwebb_image2   | calwebb_coron3   |
++-------------------+-------------------+------------------+------------------+
+| NRC_GRISM         | calwebb_detector1 | calwebb_spec2    | calwebb_spec3    |
++-------------------+-------------------+------------------+------------------+
+| NRC_TSIMAGE       | calwebb_tso1      | calwebb_image2   | calwebb_tso3     |
++-------------------+-------------------+------------------+------------------+
+| NRC_TSGRISM       | calwebb_tso1      | calwebb_spec2    | calwebb_tso3     |
++-------------------+-------------------+------------------+------------------+
+| NRC_TACQ          | calwebb_detector1 | calwebb_image2   | N/A              |
+| NRC_TACONFIRM     |                   |                  |                  |
+| NRC_FOCUS         |                   |                  |                  |
++-------------------+-------------------+------------------+------------------+
+| NRC_DARK          | calwebb_dark1     | N/A              | N/A              |
++-------------------+-------------------+------------------+------------------+
+| NRC_FLAT          | calwebb_detector1 | N/A              | N/A              |
+| NRC_LED           |                   |                  |                  |
++-------------------+-------------------+------------------+------------------+
+|                   |                   |                  |                  |
++-------------------+-------------------+------------------+------------------+
+| NIS_IMAGE         | calwebb_detector1 | calwebb_image2   | calwebb_image3   |
++-------------------+-------------------+------------------+------------------+
+| NIS_WFSS          | calwebb_detector1 | calwebb_spec2    | calwebb_spec3    |
++-------------------+-------------------+------------------+------------------+
+| NIS_SOSS          | calwebb_tso1      | calwebb_spec2    | calwebb_tso3     |
++-------------------+-------------------+------------------+------------------+
+| NIS_AMI           | calwebb_detector1 | calwebb_image2   | calwebb_ami3     |
++-------------------+-------------------+------------------+------------------+
+| NIS_TACQ          | calwebb_detector1 | calwebb_image2   | N/A              |
+| NIS_TACONFIRM     |                   |                  |                  |
+| NIS_FOCUS         |                   |                  |                  |
++-------------------+-------------------+------------------+------------------+
+| NIS_DARK          | calwebb_dark1     | N/A              | N/A              |
++-------------------+-------------------+------------------+------------------+
+| NIS_LAMP          | calwebb_detector1 | N/A              | N/A              |
++-------------------+-------------------+------------------+------------------+
+|                   |                   |                  |                  |
++-------------------+-------------------+------------------+------------------+
+| NRS_FIXEDSLIT     | calwebb_detector1 | calwebb_spec2    | calwebb_spec3    |
+| NRS_IFU           |                   |                  |                  |
+| NRS_MSASPEC       |                   |                  |                  |
++-------------------+-------------------+------------------+------------------+
+| NRS_BRIGHTOBJ     | calwebb_tso1      | calwebb_spec2    | calwebb_tso3     |
++-------------------+-------------------+------------------+------------------+
+| NRS_IMAGE         | calwebb_detector1 | calwebb_image2   | N/A              |
+| NRS_TACQ          |                   |                  |                  |
+| NRS_TACONFIRM     |                   |                  |                  |
+| NRS_BOTA          |                   |                  |                  |
+| NRS_TASLIT        |                   |                  |                  |
+| NRS_CONFIRM       |                   |                  |                  |
+| NRS_FOCUS         |                   |                  |                  |
+| NRS_MIMF          |                   |                  |                  |
++-------------------+-------------------+------------------+------------------+
+| NRS_DARK          | calwebb_dark1     | N/A              | N/A              |
++-------------------+-------------------+------------------+------------------+
+| NRS_AUTOWAVE      | calwebb_detector1 | N/A              | N/A              |
+| NRS_AUTOFLAT      |                   |                  |                  |
+| NRS_LAMP          |                   |                  |                  |
++-------------------+-------------------+------------------+------------------+
+
 Input Files, Output Files and Data Models
 =========================================
 An important concept used throughout the JWST pipeline is the :py:class:`Data


### PR DESCRIPTION
Adding more detailed information to the pipeline docs that shows which pipeline modules get applied to each EXP_TYPE value. Similar to, but more complete than, the info in JDox (https://jwst-docs.stsci.edu/display/JDAT/Modes+of+Observing)