### PR TITLE
Modify code that clears meta.model_type

### DIFF
--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -325,11 +325,6 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         current_date.format = 'isot'
         self.meta.date = current_date.value
 
-        if not hasattr(self.meta, 'model_type'):
-            klass = self.__class__.__name__
-            if klass != 'DataModel':
-                self.meta.model_type = klass
-
     def save(self, path, dir_path=None, *args, **kwargs):
         """
         Save to either a FITS or ASDF file, depending on the path.

--- a/jwst/datamodels/util.py
+++ b/jwst/datamodels/util.py
@@ -153,7 +153,7 @@ def open(init=None, extensions=None, **kwargs):
     # Actually open the model
     model = new_class(init, extensions=extensions, **kwargs)
     if not has_model_type:
-        model.meta.model_type = None
+        delattr(model.meta, 'model_type')
 
     # Close the hdulist if we opened it
     if file_to_close is not None:

--- a/jwst/datamodels/util.py
+++ b/jwst/datamodels/util.py
@@ -153,7 +153,10 @@ def open(init=None, extensions=None, **kwargs):
     # Actually open the model
     model = new_class(init, extensions=extensions, **kwargs)
     if not has_model_type:
-        delattr(model.meta, 'model_type')
+        try:
+            delattr(model.meta, 'model_type')
+        except AttributeError:
+            pass
 
     # Close the hdulist if we opened it
     if file_to_close is not None:


### PR DESCRIPTION
The generic open function in datamodels does not set the meta.model_type attribute because the class it uses to open an image is only a best guess. Previously the code cleared the model_type by
setting it to None. This is not desirable, because if the metadata is re-validated, a value of None with throw a warning or error. This revision deletes the model_type attribute instead. To keep datamodels
from setting the value again, the code in on_save which sets model_type when not found was removed. It was redundant in any case.