### PR TITLE
For extract_1d, find nod/dither offset from the WCS

### DIFF
--- a/docs/jwst/extract_1d/description.rst
+++ b/docs/jwst/extract_1d/description.rst
@@ -1,4 +1,3 @@
-
 Description
 ===========
 The extract_1d step extracts a 1-d signal from a 2-d or 3-d dataset and
@@ -9,7 +8,9 @@ IFU data and NIRSpec MOS (micro-shutter array) data.
 
 For GRISM data (NIS_WFSS or NRC_GRISM), no reference file is used.
 The extraction region is taken to be the full size of the input subarray
-or cutout, and the dispersion direction is assumed to be the longer axis.
+or cutout, or it could be restricted to the region within which the
+world coordinate system is defined.  The dispersion direction is the one
+along which the wavelengths change more rapidly.
 
 For IFU data, the extraction options differ depending on
 whether the target is a point source or an extended source.  For a point
@@ -27,7 +28,7 @@ subsampled N x N, and the "center" option will be used for each sub-pixel.
 Input
 =====
 Level 2-b countrate data, or level-3 data.  The format should be a
-CubeModel, an IFUCubeModel, an ImageModel, a DrizProductModel,
+CubeModel, a SlitModel, an IFUCubeModel, an ImageModel, a DrizProductModel,
 a MultiSlitModel, a MultiProductModel, or a ModelContainer.
 The SCI extensions should
 have keyword SLTNAME to specify which slit was extracted, though if there

--- a/docs/jwst/extract_1d/reference_files.rst
+++ b/docs/jwst/extract_1d/reference_files.rst
@@ -29,7 +29,9 @@ distinguished by using the secondary selection criterion ``spectral_order``.
 In this case, the various spectral orders would likely have different
 extraction locations within the image, so different elements of ``apertures``
 are needed in order to specify those locations.
-Key ``dispaxis`` is required.
+If key ``dispaxis`` is specified, that value will be used.  If it was
+not specified, the dispersion direction will be taken to be the axis
+along which the wavelengths change more rapidly.
 Key ``region_type`` can be omitted, but if it is specified, its value must
 be "target".  The source extraction region can be specified with ``ystart``,
 ``ystop``, etc., but a more flexible alternative is to use ``src_coeff``.


### PR DESCRIPTION
Function `locn_from_wcs` was added.  For one column in the dispersion direction (the column in the middle of the WCS bounding box), this function determines the cross-dispersion location (i.e. the pixel in that column) of the target spectrum.  (I'll describe the case for dispersion in the horizontal direction.)  The target right ascension and declination are gotten from keywords TARG_RA and TARG_DEC respectively.  For each pixel in the middle column, the right ascension, declination, and wavelength are obtained via the WCS function.  The cross-dispersion location is the pixel along that column for which the distance from the target coordinates to the computed coordinates is closest to zero.  Unless the pixel closest to the target was at an endpoint of the aperture, the nod/dither offset will be set to the difference between this pixel and the nominal (i.e. from the reference file) location of the target spectrum.  Any nod offset amplitude that was specified in the reference file (e.g. using keywords such as "nod2_offset", "nod3_offset", and "nod5_offset") will be ignored.  Applying the shift is now done by method `add_nod_correction`, regardless of whether the reference file is JSON format or an image.

Function `find_dispaxis` was added.  This determines the dispersion direction by comparing the rate at which wavelength changes from pixel to pixel, in the horizontal and vertical directions.  If `dispaxis` was specified in the reference file, that value takes precedence.  If `dispaxis` was not specified, or if there was no reference file, the value found by `find_dispaxis` will be used.  This was necessary for the case that there was no reference file, and for other cases it makes it possible to omit `dispaxis` from the reference file.  If there was not sufficient information in the science file to determine the dispersion direction, a warning will be printed, and no change to `dispaxis` will be made.

See issue #1894.