### PR TITLE
Activate WFSS background subtraction

### DIFF
--- a/jwst/background/background_step.py
+++ b/jwst/background/background_step.py
@@ -14,8 +14,7 @@ class BackgroundStep(Step):
     """
 
     # These reference files are only used for WFSS/GRISM data.
-    # xxx can't be used yet:
-    # xxx reference_file_types = ["wfssbkg", "wavelengthrange"]
+    reference_file_types = ["wfssbkg", "wavelengthrange"]
 
     def process(self, input, bkg_list):
 
@@ -41,21 +40,20 @@ class BackgroundStep(Step):
         with datamodels.open(input) as input_model:
 
             if input_model.meta.exposure.type in ["NIS_WFSS", "NRC_GRISM"]:
-                # Delete these four lines when reference files are available.
-                self.log.info("No 'wfssbkg' reference file available; "
-                              "skipping background subtraction.")
-                result = input_model.copy()
-                result.meta.cal_step.back_sub = 'SKIPPED'
 
-                # Uncomment this block when reference files are available.
-                # bkg_filename = self.get_reference_file(
-                #                 input_model, "wfssbkg")
-                # wl_range_name = self.get_reference_file(
-                #                 input_model, "wavelengthrange")
+                # Get the reference file names
+                bkg_name = self.get_reference_file(input_model, "wfssbkg")
+                wlrange_name = self.get_reference_file(input_model,
+                                                       "wavelengthrange")
+                self.log.info('Using WFSSBKG reference file %s', bkg_name)
+                self.log.info('Using WavelengthRange reference file %s',
+                              wlrange_name)
+
                 # Do the background subtraction for WFSS/GRISM data
-                # result = background_sub.subtract_wfss_bkg(
-                #                 input_model, bkg_filename, wl_range_name)
-                # result.meta.cal_step.back_sub = 'COMPLETE'
+                result = background_sub.subtract_wfss_bkg(
+                                input_model, bkg_name, wlrange_name)
+                result.meta.cal_step.back_sub = 'COMPLETE'
+
             else:
                 # Do the background subtraction
                 result = background_sub.background_sub(input_model, bkg_list)


### PR DESCRIPTION
Update the background_subtraction step to activate the loading and subtracting of WFSSBKG reference images for WFSS exposures. This simply involves uncommenting lines that were already included in the routine, but were waiting for the ref files to become available.

Fixes #1917.