### PR TITLE
Fix bugs in finding location of spectrum from the WCS

### DIFF
--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -903,10 +903,10 @@ class ExtractBase:
             # the bounding box.  This may be smaller than the full width
             # of the image, but it's all we need to consider.
             width = bb[0][1] + 1
+            width = int(round(width))           # must be an int
             # This is the middle of the bounding_box in the dispersion
             # direction.  The zero point is the first pixel of the input data.
             middle = int(bb[0][0] + dx // 2)
-            width = int(round(width))           # must be an int
             x = np.empty(width, dtype=np.float64)
             x[:] = float(middle)
             y = np.arange(width, dtype=np.float64)
@@ -918,16 +918,19 @@ class ExtractBase:
             y = np.empty(width, dtype=np.float64)
             y[:] = float(middle)
 
-        if hasattr(input_model.meta, "target"):
-            ra = input_model.meta.target.ra
-            dec = input_model.meta.target.dec
-        elif slit != DUMMY and hasattr(slit.meta, "target"):
+        if slit != DUMMY and hasattr(slit.meta, "target"):
+            log.debug("Target coordinates were gotten from slit.meta")
             ra = slit.meta.target.ra
             dec = slit.meta.target.dec
+        elif hasattr(input_model.meta, "target"):
+            log.debug("Target coordinates were gotten from input_model.meta")
+            ra = input_model.meta.target.ra
+            dec = input_model.meta.target.dec
         else:
             log.warning("Target RA and Dec are not available, "
                         "so we can't get target location using the WCS.")
             return None, None, None
+        log.debug("Target ra = %.5f dec = %.5f", ra, dec)
 
         if transform.n_inputs > 2:
             stuff = transform(x, y, self.spectral_order)

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -906,6 +906,7 @@ class ExtractBase:
             # This is the middle of the bounding_box in the dispersion
             # direction.  The zero point is the first pixel of the input data.
             middle = int(bb[0][0] + dx // 2)
+            width = int(round(width))           # must be an int
             x = np.empty(width, dtype=np.float64)
             x[:] = float(middle)
             y = np.arange(width, dtype=np.float64)
@@ -917,12 +918,16 @@ class ExtractBase:
             y = np.empty(width, dtype=np.float64)
             y[:] = float(middle)
 
-        if slit == DUMMY:
+        if hasattr(input_model.meta, "target"):
             ra = input_model.meta.target.ra
             dec = input_model.meta.target.dec
-        else:
+        elif slit != DUMMY and hasattr(slit.meta, "target"):
             ra = slit.meta.target.ra
             dec = slit.meta.target.dec
+        else:
+            log.warning("Target RA and Dec are not available, "
+                        "so we can't get target location using the WCS.")
+            return None, None, None
 
         if transform.n_inputs > 2:
             stuff = transform(x, y, self.spectral_order)


### PR DESCRIPTION
Another `int(round(width))` was needed.  Also, a check was needed on whether `slit.meta` had a `target` attribute.