### PR TITLE
Test for existence of filename in __repr__

### DIFF
--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -242,7 +242,10 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         if self.shape:
             buf.append(str(self.shape))
 
-        filename = self.meta.filename
+        try:
+            filename = self.meta.filename
+        except AttributeError:
+            filename = None
         if filename:
             buf.append(" from ")
             buf.append(filename)


### PR DESCRIPTION
Datamodels sometimes, but not always, throws an error when trying to access a non-existent metadata value. I've wrapped the access to meta.filename with a try block to catch the error.