### PR TITLE
Fix history validation error

### DIFF
--- a/jwst/datamodels/fits_support.py
+++ b/jwst/datamodels/fits_support.py
@@ -377,6 +377,7 @@ def _save_history(hdulist, tree):
         history = tree['history']
     else:
         history = tree['history'].get('entries', [])
+        tree['history'] = history
 
     for i in range(len(history)):
         # There is no guarantee the user has added proper HistoryEntry records


### PR DESCRIPTION
Datamodels tests were throwing a validation error when writing new history records. It's not clear why we started seeing the errors, perhaps an update to asdf. But the cause is that there were two
different data structures to hold the history records and only one of them passed validation. The solution is to convert the invalid structure to the valid one before serializing the asdf file to its
extension.