### PR TITLE
fix units by adding a model unit conversion

### DIFF
--- a/jwst/assign_wcs/pointing.py
+++ b/jwst/assign_wcs/pointing.py
@@ -19,7 +19,9 @@ def v23tosky(input_model):
     angles = [-v2_ref, v3_ref, -roll_ref, -dec_ref, ra_ref]
     axes = "zyxyz"
     sky_rotation = V23ToSky(angles, axes_order=axes, name="v23tosky")
-    return sky_rotation
+    # The sky rotation expects values in deg.
+    # This should be removed when models work with quantities.
+    return astmodels.Scale(1/3600) & astmodels.Scale(1/3600) | sky_rotation
 
 
 def compute_roll_ref(v2_ref, v3_ref, roll_ref, ra_ref, dec_ref, new_v2_ref, new_v3_ref):

--- a/jwst/assign_wcs/tests/test_wcs.py
+++ b/jwst/assign_wcs/tests/test_wcs.py
@@ -75,8 +75,8 @@ def test_v23_to_sky():
     v3_ref = -318.742464 / 3600 # in deg
     r0 = 37 # in deg
 
-    v2 = 210 *3600 # in arcsec
-    v3 = -75 *3600 # in arcsec
+    v2 = 210 # in deg
+    v3 = -75 # in deg
     expected_ra_dec = (107.12810484789563, -35.97940247128502) # in deg
     angles = [-v2_ref, v3_ref, -r0, -dec_ref, ra_ref]
     axes = "zyxyz"

--- a/jwst/lib/set_telescope_pointing.py
+++ b/jwst/lib/set_telescope_pointing.py
@@ -384,8 +384,8 @@ def update_s_region(model, prd_db_filepath=None):
     v2, v3 = idltov23(xvert, yvert)  # in arcsec
 
     # Convert to deg
-    v2 = v2 # in arcsec
-    v3 = v3 # in arcsec
+    v2 = v2 / 3600 # in deg
+    v3 = v3 / 3600 # in deg
     angles = [-v2_ref_deg, v3_ref_deg, -roll_ref, -dec_ref, ra_ref]
     axes = "zyxyz"
     v23tosky = V23ToSky(angles, axes_order=axes)

--- a/jwst/transforms/models.py
+++ b/jwst/transforms/models.py
@@ -853,8 +853,6 @@ class V23ToSky(Rotation3D):
         return alpha, delta
 
     def evaluate(self, v2, v3, angles):
-        v2 /= 3600
-        v3 /= 3600
         x, y, z = self.spherical2cartesian(v2, v3)
         x1, y1, z1 = super(V23ToSky, self).evaluate(x, y, z, angles)
         ra, dec = self.cartesian2spherical(x1, y1, z1)


### PR DESCRIPTION
This is a different fix to the unit problem in #1931. The V2V3 to sky transform works with angles in degrees. Since this is a sequence of rotations the inverse is an analytical one and reuses the same class. This means that a unit conversion in `V23ToSky.evaluate` will not work with the inverse.
One option is to writ ea separate inverse class.
Another approach, implemented here, is to prepend a specific  transform for the unit conversion.

Supersedes #1931.