### PR TITLE
Fix MIRI regtests

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -7,7 +7,7 @@ def test_env = [
     "PATH=./miniconda/bin:/bin:/usr/bin",
     "TEST_BIGDATA=/data4/jwst_test_data",
     "CRDS_SERVER_URL=https://jwst-crds.stsci.edu",
-    "CRDS_CONTEXT=jwst_0445.pmap",
+    "CRDS_CONTEXT=jwst_0452.pmap",
     "CRDS_PATH=./test_outputs/crds_cache",
 ]
 

--- a/jwst/tests_nightly/general/miri/test_bias_drift.py
+++ b/jwst/tests_nightly/general/miri/test_bias_drift.py
@@ -28,7 +28,7 @@ def test_refpix_miri(_bigdata):
 
     RefPixStep.call(_bigdata+'/miri/test_bias_drift/jw00001001001_01101_00001_MIRIMAGE_saturation.fits',
                     use_side_ref_pixels=False, side_smoothing_length=10, side_gain=1.0,
-                    output_file=output_file_base)
+                    output_file=output_file_base, name='refpix')
 
     h = pf.open(output_file)
     href = pf.open(_bigdata+'/miri/test_bias_drift/jw00001001001_01101_00001_MIRIMAGE_bias_drift.fits')

--- a/jwst/tests_nightly/general/miri/test_bias_drift2.py
+++ b/jwst/tests_nightly/general/miri/test_bias_drift2.py
@@ -28,7 +28,7 @@ def test_refpix_miri2(_bigdata):
 
     RefPixStep.call(_bigdata+'/miri/test_bias_drift/jw00025001001_01107_00001_MIRIMAGE_saturation.fits',
                     use_side_ref_pixels=False, side_smoothing_length=10, side_gain=1.0,
-                    output_file=output_file_base)
+                    output_file=output_file_base, name='refpix')
     h = pf.open(output_file)
     href = pf.open(_bigdata+'/miri/test_bias_drift/jw00025001001_01107_00001_MIRIMAGE_bias_drift.fits')
     newh = pf.HDUList([h['primary'],h['sci'],h['err'],h['pixeldq'],h['groupdq']])

--- a/jwst/tests_nightly/general/miri/test_dark_step.py
+++ b/jwst/tests_nightly/general/miri/test_dark_step.py
@@ -25,7 +25,7 @@ def test_dark_current_miri(_bigdata):
         pass
 
     DarkCurrentStep.call(_bigdata+'/miri/test_dark_step/jw00001001001_01101_00001_MIRIMAGE_bias_drift.fits',
-                         output_file=output_file_base
+                         output_file=output_file_base, name='dark_current'
                          )
     h = pf.open(output_file)
     href = pf.open(_bigdata+'/miri/test_dark_step/jw00001001001_01101_00001_MIRIMAGE_dark_current.fits')

--- a/jwst/tests_nightly/general/miri/test_dark_step2.py
+++ b/jwst/tests_nightly/general/miri/test_dark_step2.py
@@ -25,7 +25,7 @@ def test_dark_current_miri2(_bigdata):
         pass
 
     DarkCurrentStep.call(_bigdata+'/miri/test_dark_step/jw80600012001_02101_00003_mirimage_lastframe.fits',
-                         output_file=output_file_base
+                         output_file=output_file_base, name='dark_current'
                          )
     h = pf.open(output_file)
     href = pf.open(_bigdata+'/miri/test_dark_step/jw80600012001_02101_00003_mirimage_dark.fits')

--- a/jwst/tests_nightly/general/miri/test_dq_init.py
+++ b/jwst/tests_nightly/general/miri/test_dq_init.py
@@ -25,7 +25,7 @@ def test_dq_init_miri(_bigdata):
         pass
 
     DQInitStep.call(_bigdata+'/miri/test_dq_init/jw00001001001_01101_00001_MIRIMAGE_uncal.fits',
-                    output_file=output_file_base
+                    output_file=output_file_base, name='dq_init'
     )
 
     h = pf.open(output_file)

--- a/jwst/tests_nightly/general/miri/test_dq_init2.py
+++ b/jwst/tests_nightly/general/miri/test_dq_init2.py
@@ -25,7 +25,7 @@ def test_dq_init_miri2(_bigdata):
         pass
 
     DQInitStep.call(_bigdata+'/miri/test_dq_init/jw80600012001_02101_00003_mirimage_uncal.fits',
-                    output_file=output_file_base
+                    output_file=output_file_base, name='dq_init'
     )
 
     h = pf.open(output_file)

--- a/jwst/tests_nightly/general/miri/test_emission_step.py
+++ b/jwst/tests_nightly/general/miri/test_emission_step.py
@@ -27,7 +27,7 @@ def test_emission_miri(_bigdata):
 
 
     EmissionStep.call(_bigdata+'/miri/test_emission/jw00001001001_01101_00001_MIRIMAGE_flat_field.fits',
-                         output_file=output_file_base
+                         output_file=output_file_base, name='emission'
     )
     h = pf.open(output_file)
     href = pf.open(_bigdata+'/miri/test_emission/jw00001001001_01101_00001_MIRIMAGE_emission.fits')

--- a/jwst/tests_nightly/general/miri/test_extract1d.py
+++ b/jwst/tests_nightly/general/miri/test_extract1d.py
@@ -28,7 +28,7 @@ def test_extract1d_miri(_bigdata):
 
     Extract1dStep.call(_bigdata+'/miri/test_extract1d/jw00035001001_01101_00001_mirimage_photom.fits',
                        smoothing_length=0,
-                       output_file=output_file_base
+                       output_file=output_file_base, name='extract_1d'
                        )
     h = pf.open(output_file)
     href = pf.open(_bigdata+'/miri/test_extract1d/jw00035001001_01101_00001_mirimage_x1d.fits')

--- a/jwst/tests_nightly/general/miri/test_extract1d2.py
+++ b/jwst/tests_nightly/general/miri/test_extract1d2.py
@@ -28,7 +28,7 @@ def test_extract1d_miri2(_bigdata):
 
     Extract1dStep.call(_bigdata+'/miri/test_extract1d/jw80600012001_02101_00003_mirimage_photom.fits',
                        smoothing_length=0,
-                       output_file=output_file_base
+                       output_file=output_file_base, name='extract_1d'
                        )
     h = pf.open(output_file)
     href = pf.open(_bigdata+'/miri/test_extract1d/jw80600012001_02101_00003_mirimage_x1d.fits')

--- a/jwst/tests_nightly/general/miri/test_flat_field.py
+++ b/jwst/tests_nightly/general/miri/test_flat_field.py
@@ -27,7 +27,7 @@ def test_flat_field_miri(_bigdata):
 
 
     FlatFieldStep.call(_bigdata+'/miri/test_flat_field/jw00001001001_01101_00001_MIRIMAGE_assign_wcs.fits',
-                       output_file=output_file_base
+                       output_file=output_file_base, name='flat_field'
                        )
     h = pf.open(output_file)
     href = pf.open(_bigdata+'/miri/test_flat_field/jw00001001001_01101_00001_MIRIMAGE_flat_field.fits')

--- a/jwst/tests_nightly/general/miri/test_flat_field2.py
+++ b/jwst/tests_nightly/general/miri/test_flat_field2.py
@@ -27,7 +27,7 @@ def test_flat_field_miri2(_bigdata):
 
 
     FlatFieldStep.call(_bigdata+'/miri/test_flat_field/jw80600012001_02101_00003_mirimage_assign_wcs.fits',
-                       output_file=output_file_base
+                       output_file=output_file_base, name='flat_field'
                        )
     h = pf.open(output_file)
     href = pf.open(_bigdata+'/miri/test_flat_field/jw80600012001_02101_00003_mirimage_flat_field.fits')

--- a/jwst/tests_nightly/general/miri/test_fringe.py
+++ b/jwst/tests_nightly/general/miri/test_fringe.py
@@ -25,7 +25,7 @@ def test_fringe_miri(_bigdata):
         pass
 
     FringeStep.call(_bigdata+'/miri/test_fringe/fringe1_input.fits',
-                    output_file=output_file_base
+                    output_file=output_file_base, name='fringe'
                     )
     h = pf.open(output_file)
     href = pf.open(_bigdata+'/miri/test_fringe/baseline_fringe1.fits')

--- a/jwst/tests_nightly/general/miri/test_fringe2.py
+++ b/jwst/tests_nightly/general/miri/test_fringe2.py
@@ -25,7 +25,7 @@ def test_fringe_miri2(_bigdata):
         pass
 
     FringeStep.call(_bigdata+'/miri/test_fringe/fringe2_input.fits',
-                    output_file=output_file_base
+                    output_file=output_file_base, name='fringe'
                     )
     h = pf.open(output_file)
     href = pf.open(_bigdata+'/miri/test_fringe/baseline_fringe2.fits')

--- a/jwst/tests_nightly/general/miri/test_fringe3.py
+++ b/jwst/tests_nightly/general/miri/test_fringe3.py
@@ -25,7 +25,7 @@ def test_fringe_miri3(_bigdata):
         pass
 
     FringeStep.call(_bigdata+'/miri/test_fringe/fringe3_input.fits',
-                    output_file=output_file_base
+                    output_file=output_file_base, name='fringe'
                     )
     h = pf.open(output_file)
     href = pf.open(_bigdata+'/miri/test_fringe/baseline_fringe3.fits')

--- a/jwst/tests_nightly/general/miri/test_jump.py
+++ b/jwst/tests_nightly/general/miri/test_jump.py
@@ -28,7 +28,7 @@ def test_jump_miri(_bigdata):
 
     JumpStep.call(_bigdata+'/miri/test_jump/jw00001001001_01101_00001_MIRIMAGE_linearity.fits',
                   rejection_threshold=200.0,
-                  output_file=output_file_base
+                  output_file=output_file_base, name='jump'
                   )
     h = pf.open(output_file)
     href = pf.open(_bigdata+'/miri/test_jump/jw00001001001_01101_00001_MIRIMAGE_jump.fits')

--- a/jwst/tests_nightly/general/miri/test_jump2.py
+++ b/jwst/tests_nightly/general/miri/test_jump2.py
@@ -28,7 +28,7 @@ def test_jump_miri2(_bigdata):
 
     JumpStep.call(_bigdata+'/miri/test_jump/jw80600012001_02101_00003_mirimage_dark.fits',
                   rejection_threshold=25.0,
-                  output_file=output_file_base
+                  output_file=output_file_base, name='jump'
                   )
     h = pf.open(output_file)
     href = pf.open(_bigdata+'/miri/test_jump/jw80600012001_02101_00003_mirimage_jump.fits')

--- a/jwst/tests_nightly/general/miri/test_lastframe2.py
+++ b/jwst/tests_nightly/general/miri/test_lastframe2.py
@@ -26,7 +26,7 @@ def test_lastframe_miri2(_bigdata):
 
 
     LastFrameStep.call(_bigdata+'/miri/test_lastframe/jw80600012001_02101_00003_mirimage_rscd.fits',
-                       output_file=output_file_base
+                       output_file=output_file_base, name='lastframe'
                        )
     h = pf.open(output_file)
     href = pf.open(_bigdata+'/miri/test_lastframe/jw80600012001_02101_00003_mirimage_lastframe.fits')

--- a/jwst/tests_nightly/general/miri/test_linearity.py
+++ b/jwst/tests_nightly/general/miri/test_linearity.py
@@ -27,7 +27,7 @@ def test_linearity_miri(_bigdata):
 
 
     LinearityStep.call(_bigdata+'/miri/test_linearity/jw00001001001_01101_00001_MIRIMAGE_dark_current.fits',
-                       output_file=output_file_base
+                       output_file=output_file_base, name='linearity'
                        )
     h = pf.open(output_file)
     href = pf.open(_bigdata+'/miri/test_linearity/jw00001001001_01101_00001_MIRIMAGE_linearity.fits')

--- a/jwst/tests_nightly/general/miri/test_linearity2.py
+++ b/jwst/tests_nightly/general/miri/test_linearity2.py
@@ -27,7 +27,7 @@ def test_linearity_miri2(_bigdata):
 
 
     LinearityStep.call(_bigdata+'/miri/test_linearity/jw80600012001_02101_00003_mirimage_saturation.fits',
-                       output_file=output_file_base
+                       output_file=output_file_base, name='linearity'
                        )
     h = pf.open(output_file)
     href = pf.open(_bigdata+'/miri/test_linearity/jw80600012001_02101_00003_mirimage_linearity.fits')

--- a/jwst/tests_nightly/general/miri/test_linearity3.py
+++ b/jwst/tests_nightly/general/miri/test_linearity3.py
@@ -28,7 +28,7 @@ def test_linearity_miri3(_bigdata):
 
     LinearityStep.call(_bigdata+'/miri/test_linearity/jw00001001001_01109_00001_MIRIMAGE_dark_current.fits',
                        override_linearity=_bigdata+'/miri/test_linearity/lin_nan_flag_miri.fits',
-                       output_file=output_file_base
+                       output_file=output_file_base, name='linearity'
                        )
     h = pf.open(output_file)
     href = pf.open(_bigdata+'/miri/test_linearity/jw00001001001_01109_00001_MIRIMAGE_linearity.fits')
@@ -37,7 +37,7 @@ def test_linearity_miri3(_bigdata):
     newhref = pf.HDUList([href['primary'],href['sci'],href['err'],href['pixeldq'],href['groupdq']])
     result = pf.diff.FITSDiff(newh,
                               newhref,
-                              ignore_keywords = ['DATE','CAL_VER','CAL_VCS','CRDS_VER','CRDS_CTX'],
+                              ignore_keywords = ['DATE','CAL_VER','CAL_VCS','CRDS_VER','CRDS_CTX', 'R_LINEAR'],
                               rtol = 0.00001
     )
     assert result.identical, result.report()

--- a/jwst/tests_nightly/general/miri/test_miri_ifu_wcs.py
+++ b/jwst/tests_nightly/general/miri/test_miri_ifu_wcs.py
@@ -31,14 +31,13 @@ def test_miri_ifu_wcs(_bigdata):
     ref_file = os.path.join(_bigdata, 'miri', 'test_wcs', 'ifu', 'jw00024001001_01101_00001_MIRIFUSHORT_assign_wcs.fits')
 
     AssignWcsStep.call(input_file,
-                       output_file='miri_ifu_wcs_output.fits'
+                       output_file='miri_ifu_wcs', suffix='output'
                        )
     im = ImageModel('miri_ifu_wcs_output.fits')
     imref = ImageModel(ref_file)
 
     # Get the valid region
-    f = fits.open('miri_ifu_wcs_output.fits')
-    region = AsdfFile.open('/grp/crds/cache/references/jwst/{}'.format(f[0].header['R_REGION'].replace('crds://', '')))
+    region = AsdfFile.open('/grp/crds/cache/references/jwst/{}'.format(im.meta.ref_file_regions.name.replace('crds://', '')))
     y, x = np.nonzero(region.tree['regions'])
 
     # Get indices where pixels == 0. These should be NaNs in the output.

--- a/jwst/tests_nightly/general/miri/test_miri_image_wcs.py
+++ b/jwst/tests_nightly/general/miri/test_miri_image_wcs.py
@@ -21,7 +21,8 @@ def test_miri_image_wcs(_bigdata):
     Regression test of creating a WCS object and doing pixel to sky transformation.
 
     """
-    output_file_base, output_file = add_suffix('miri_image_wcs_output.fits', 'assignwcsstep')
+    suffix = 'assignwcsstep'
+    output_file_base, output_file = add_suffix('miri_image_wcs_output.fits', suffix)
 
     try:
         os.remove(output_file)
@@ -32,7 +33,7 @@ def test_miri_image_wcs(_bigdata):
     ref_file = os.path.join(_bigdata, 'miri', 'test_wcs', 'image', 'jw00001001001_01101_00001_MIRIMAGE_assign_wcs.fits')
 
     AssignWcsStep.call(input_file,
-                       output_file=output_file_base
+                       output_file=output_file_base, suffix=suffix
                        )
     im = ImageModel(output_file)
     imref = ImageModel(ref_file)

--- a/jwst/tests_nightly/general/miri/test_miri_slitless_wcs.py
+++ b/jwst/tests_nightly/general/miri/test_miri_slitless_wcs.py
@@ -21,7 +21,8 @@ def test_miri_slitless_wcs(_bigdata):
     Regression test of creating a WCS object and doing pixel to sky transformation.
 
     """
-    output_file_base, output_file = add_suffix('miri_slitless_wcs_output.fits', 'assignwcsstep')
+    suffix = 'assignwcsstep'
+    output_file_base, output_file = add_suffix('miri_slitless_wcs_output.fits', suffix)
 
     try:
         os.remove(output_file)
@@ -32,7 +33,7 @@ def test_miri_slitless_wcs(_bigdata):
     ref_file = os.path.join(_bigdata, 'miri', 'test_wcs', 'slitless', 'jw80600012001_02101_00003_mirimage_assign_wcs.fits')
 
     AssignWcsStep.call(input_file,
-                       output_file=output_file_base
+                       output_file=output_file_base, suffix=suffix
                        )
     im = CubeModel(output_file)
     imref = CubeModel(ref_file)

--- a/jwst/tests_nightly/general/miri/test_photom.py
+++ b/jwst/tests_nightly/general/miri/test_photom.py
@@ -17,7 +17,8 @@ def test_photom_miri(_bigdata):
     Regression test of photom step performed on MIRI imaging data.
 
     """
-    output_file_base, output_file = add_suffix('photom1_output.fits', 'photom')
+    suffix = 'photom'
+    output_file_base, output_file = add_suffix('photom1_output.fits', suffix)
 
     try:
         os.remove(output_file)
@@ -27,7 +28,7 @@ def test_photom_miri(_bigdata):
 
 
     PhotomStep.call(_bigdata+'/miri/test_photom/jw00001001001_01101_00001_MIRIMAGE_emission.fits',
-                    output_file=output_file_base
+                    output_file=output_file_base, suffix=suffix
                     )
     h = pf.open(output_file)
     href = pf.open(_bigdata+'/miri/test_photom/jw00001001001_01101_00001_MIRIMAGE_photom.fits')

--- a/jwst/tests_nightly/general/miri/test_photom2.py
+++ b/jwst/tests_nightly/general/miri/test_photom2.py
@@ -17,7 +17,8 @@ def test_photom_miri2(_bigdata):
     Regression test of photom step performed on MIRI LRS slitless data.
 
     """
-    output_file_base, output_file = add_suffix('photom2_output.fits', 'photom')
+    suffix = 'photom'
+    output_file_base, output_file = add_suffix('photom2_output.fits', suffix)
 
     try:
         os.remove(output_file)
@@ -27,7 +28,7 @@ def test_photom_miri2(_bigdata):
 
 
     PhotomStep.call(_bigdata+'/miri/test_photom/jw80600012001_02101_00003_mirimage_srctype.fits',
-                    output_file=output_file_base
+                    output_file=output_file_base, suffix=suffix
                     )
     h = pf.open(output_file)
     href = pf.open(_bigdata+'/miri/test_photom/jw80600012001_02101_00003_mirimage_photom.fits')

--- a/jwst/tests_nightly/general/miri/test_ramp_fit.py
+++ b/jwst/tests_nightly/general/miri/test_ramp_fit.py
@@ -17,7 +17,8 @@ def test_ramp_fit_miri1(_bigdata):
     Regression test of ramp_fit step performed on MIRI data.
 
     """
-    output_file_base, output_files = add_suffix('rampfit1_output.fits', 'rampfit', list(range(2)))
+    suffix = 'rampfit'
+    output_file_base, output_files = add_suffix('rampfit1_output.fits', suffix, list(range(2)))
 
     try:
         for output_file in output_files:
@@ -29,7 +30,7 @@ def test_ramp_fit_miri1(_bigdata):
     RampFitStep.call(_bigdata+'/miri/test_ramp_fit/jw00001001001_01101_00001_MIRIMAGE_jump.fits',
                      save_opt=True,
                      opt_name='rampfit1_opt_out.fits',
-                     output_file=output_file_base
+                     output_file=output_file_base, suffix=suffix
                      )
 
     # compare primary output

--- a/jwst/tests_nightly/general/miri/test_ramp_fit2.py
+++ b/jwst/tests_nightly/general/miri/test_ramp_fit2.py
@@ -17,7 +17,8 @@ def test_ramp_fit_miri2(_bigdata):
     Regression test of ramp_fit step performed on MIRI data.
 
     """
-    output_file_base, output_files = add_suffix('rampfit2_output.fits', 'rampfit', list(range(2)))
+    suffix = 'rampfit'
+    output_file_base, output_files = add_suffix('rampfit2_output.fits', suffix, list(range(2)))
 
     try:
         for output_file in output_files:
@@ -29,7 +30,7 @@ def test_ramp_fit_miri2(_bigdata):
     RampFitStep.call(_bigdata+'/miri/test_ramp_fit/jw80600012001_02101_00003_mirimage_jump.fits',
                       save_opt=True,
                       opt_name='rampfit2_opt_out.fits',
-                      output_file=output_file_base
+                      output_file=output_file_base, suffix=suffix
                       )
 
     # compare primary output

--- a/jwst/tests_nightly/general/miri/test_rscd2.py
+++ b/jwst/tests_nightly/general/miri/test_rscd2.py
@@ -17,7 +17,8 @@ def test_rscd_miri2(_bigdata):
     Regression test of RSCD step performed on MIRI data.
 
     """
-    output_file_base, output_file = add_suffix('rscd2_output.fits', 'rscd')
+    suffix = 'rcsd'
+    output_file_base, output_file = add_suffix('rscd2_output.fits', suffix)
 
     try:
         os.remove(output_file)
@@ -26,7 +27,7 @@ def test_rscd_miri2(_bigdata):
 
 
     RSCD_Step.call(_bigdata+'/miri/test_rscd/jw80600012001_02101_00003_mirimage_linearity.fits',
-                   output_file=output_file_base
+                   output_file=output_file_base, suffix=suffix
                    )
     h = pf.open(output_file)
     href = pf.open(_bigdata+'/miri/test_rscd/jw80600012001_02101_00003_mirimage_rscd.fits')

--- a/jwst/tests_nightly/general/miri/test_saturation.py
+++ b/jwst/tests_nightly/general/miri/test_saturation.py
@@ -27,7 +27,7 @@ def test_saturation_miri(_bigdata):
 
 
     SaturationStep.call(_bigdata+'/miri/test_saturation/jw00001001001_01101_00001_MIRIMAGE_dq_init.fits',
-                        output_file=output_file_base
+                        output_file=output_file_base, name='saturation'
                         )
     h = pf.open(output_file)
     href = pf.open(_bigdata+'/miri/test_saturation/jw00001001001_01101_00001_MIRIMAGE_saturation.fits')

--- a/jwst/tests_nightly/general/miri/test_saturation2.py
+++ b/jwst/tests_nightly/general/miri/test_saturation2.py
@@ -27,7 +27,7 @@ def test_saturation_miri2(_bigdata):
 
 
     SaturationStep.call(_bigdata+'/miri/test_saturation/jw80600012001_02101_00003_mirimage_dqinit.fits',
-                        output_file=output_file_base
+                        output_file=output_file_base, name='saturation'
                         )
     h = pf.open(output_file)
     href = pf.open(_bigdata+'/miri/test_saturation/jw80600012001_02101_00003_mirimage_saturation.fits')

--- a/jwst/tests_nightly/general/miri/test_sloperpipeline_1.py
+++ b/jwst/tests_nightly/general/miri/test_sloperpipeline_1.py
@@ -25,9 +25,11 @@ def test_detector1pipeline1(_bigdata):
     step.refpix.odd_even_rows = True
     step.jump.rejection_threshold = 250.0
     step.ramp_fit.save_opt = False
+    step.output_file='jw00001001001_01101_00001_MIRIMAGE'
+    step.suffix='rate'
 
-    step.run(_bigdata+'/miri/test_sloperpipeline/jw00001001001_01101_00001_MIRIMAGE_uncal.fits',
-             output_file='jw00001001001_01101_00001_MIRIMAGE_rate.fits')
+    step.run(_bigdata+'/miri/test_sloperpipeline/jw00001001001_01101_00001_MIRIMAGE_uncal.fits'
+             )
 
     # Compare calibrated ramp product
     n_cr = 'jw00001001001_01101_00001_MIRIMAGE_ramp.fits'

--- a/jwst/tests_nightly/general/miri/test_sloperpipeline_2.py
+++ b/jwst/tests_nightly/general/miri/test_sloperpipeline_2.py
@@ -24,9 +24,11 @@ def test_detector1pipeline2(_bigdata):
     step.refpix.odd_even_rows = True
     step.jump.rejection_threshold = 250.0
     step.ramp_fit.save_opt = False
+    step.output_file='jw80600012001_02101_00003_mirimage'
+    step.suffix='rate'
 
-    step.run(_bigdata+'/miri/test_sloperpipeline/jw80600012001_02101_00003_mirimage_uncal.fits',
-             output_file='jw80600012001_02101_00003_mirimage_rate.fits')
+    step.run(_bigdata+'/miri/test_sloperpipeline/jw80600012001_02101_00003_mirimage_uncal.fits'
+             )
 
     # Compare the calibrated ramp product
     n_cr = 'jw80600012001_02101_00003_mirimage_ramp.fits'

--- a/jwst/tests_nightly/general/miri/test_srctype2.py
+++ b/jwst/tests_nightly/general/miri/test_srctype2.py
@@ -27,7 +27,7 @@ def test_srctype2(_bigdata):
 
 
     SourceTypeStep.call(_bigdata+'/miri/test_srctype/jw80600012001_02101_00003_mirimage_flat_field.fits',
-                        output_file=output_file_base
+                        output_file=output_file_base, suffix='sourcetypestep'
                         )
     h = pf.open(output_file)
     href = pf.open(_bigdata+'/miri/test_srctype/jw80600012001_02101_00003_mirimage_srctype.fits')

--- a/jwst/tests_nightly/general/miri/test_straylight.py
+++ b/jwst/tests_nightly/general/miri/test_straylight.py
@@ -25,7 +25,7 @@ def test_straylight1_miri(_bigdata):
         pass
 
     StraylightStep.call(_bigdata+'/miri/test_straylight/jw80500018001_02101_00002_MIRIFUSHORT_flatfield.fits',
-                        output_file=output_file_base
+                        output_file=output_file_base, name='straylight'
                         )
     h = pf.open(output_file)
     href = pf.open(_bigdata+'/miri/test_straylight/jw80500018001_02101_00002_MIRIFUSHORT_straylight.fits')

--- a/jwst/tests_nightly/general/miri/test_straylight2.py
+++ b/jwst/tests_nightly/general/miri/test_straylight2.py
@@ -25,7 +25,7 @@ def test_straylight2_miri(_bigdata):
         pass
 
     StraylightStep.call(_bigdata+'/miri/test_straylight/jw80500018001_02101_00002_MIRIFULONG_flatfield.fits',
-                        output_file=output_file_base
+                        output_file=output_file_base, name='straylight'
                         )
     h = pf.open(output_file)
     href = pf.open(_bigdata+'/miri/test_straylight/jw80500018001_02101_00002_MIRIFULONG_straylight.fits')


### PR DESCRIPTION
We do 2 things here:

- update the CRDS context so it matches what is currently happening on the Pandokia side
- Build the output names correctly so the tests can pass.

There's still a couple tests that are not passing due to them being broken (or evaporating) on the SVN/pandokia side, but these issues are unrelated to output names, so we'll fix these later.