### PR TITLE
Cube build parity

### DIFF
--- a/jwst/cube_build/coord.py
+++ b/jwst/cube_build/coord.py
@@ -7,77 +7,11 @@ import math
 
 
 #_______________________________________________________________________
-def V2V32RADEC(ra_ref,dec_ref,roll_ref,v2_ref,v3_ref,v2, v3):
-
-        # v2_ref,v3_ref given in arc seconds 
-        # v2 and v3 are given in arc seconds
-        # ra_ref,dec_ref, roll_ref given in degrees
-        # it is assumed that the V2,V3 coordinates have the effects of dithering included
-        
-    d2r = math.pi/180.0
-
-    v2deg = v2.copy()/3600.0      # convert to degrees
-    v3deg = v3.copy()/3600.0      # convert to degrees
-
-
-    v2_ref = v2_ref/3600.0 # covert to degrees
-    v3_ref = v3_ref/3600.0 # convert to degrees
-    v3_ref_rad = v3_ref*d2r
-    roll_ref_rad = roll_ref * d2r
-        
-    delta_v2 = (v2deg - v2_ref) * math.cos(v3_ref_rad)
-    delta_v3 = (v3deg - v3_ref)
-    delta_ra = delta_v2 * math.cos(roll_ref_rad) + delta_v3* math.sin(roll_ref_rad)
-    delta_dec = -delta_v2* math.sin(roll_ref_rad) + delta_v3*math.cos(roll_ref_rad)
-
-    ra = ra_ref + delta_ra/math.cos(dec_ref*d2r)
-    dec = delta_dec + dec_ref
-
-    return ra,dec
-#_______________________________________________________________________
-
-#_______________________________________________________________________
-def RADEC2V2V3(ra_ref,dec_ref,roll_ref,v2_ref,v3_ref,ra, dec):
-
-        # v2_ref,v3_ref given in arc seconds
-        # v2 and v3 are given in arc seconds
-        # ra_ref,dec_ref, roll_ref given in degrees
-        # ra,dec are given in degrees
-     
-        
-    d2r = math.pi/180.0
-
-    r2d = 180.0  / math.pi
-
-    v3_ref_rad = (v3_ref)/3600.0* d2r # convert from arc seconds to radians
-    v2_ref_rad = (v2_ref)/3600.0* d2r # convert from arc seconds to radians 
-
-    roll_ref_rad = roll_ref * d2r
-
-    ra_ref_rad = ra_ref*d2r
-    dec_ref_rad = dec_ref*d2r
-    this_ra = ra*d2r
-    this_dec  = dec*d2r
-
-    delta_ra = (this_ra - ra_ref_rad) * math.cos(dec_ref_rad)
-    delta_dec = (this_dec-dec_ref_rad)
-
-    dv2 = delta_ra* math.cos(roll_ref_rad) - delta_dec*math.sin(roll_ref_rad) 
-    dv3 = delta_ra*math.sin(roll_ref_rad) + delta_dec*math.cos(roll_ref_rad)
-
-    v2 = v2_ref_rad + dv2/math.cos(v3_ref_rad)
-    v3 = v3_ref_rad + dv3
-
-    v2 = v2*r2d*3600.0  # convert from radians to arc seconds 
-    v3  = v3*r2d*3600.0 # convert from radians to arc seconds
-
-    return v2,v3
-#_______________________________________________________________________
 
 def radec2std(crval1,crval2,ra,dec):
-
-# Compute the standard coordinates xi,eta from CRVAL1,CRVAL2 & ra,dec
-
+    """
+    Compute the standard coordinates xi,eta from CRVAL1,CRVAL2 & ra,dec
+    """
 
     def check_val(ra):
         ra = np.asarray(ra)
@@ -85,7 +19,6 @@ def radec2std(crval1,crval2,ra,dec):
         dec = np.asarray(dec)
 
     rad2arcsec = (180.0*3600.0)/math.pi
-
     deg2rad = math.pi/180.0
 
     ra0 = crval1*deg2rad
@@ -93,14 +26,15 @@ def radec2std(crval1,crval2,ra,dec):
     radiff = ra*deg2rad - ra0;
     decr = dec*deg2rad;
 
-
-
     h = np.sin(decr) *math.sin(dec0) + np.cos(decr)*math.cos(dec0)*np.cos(radiff);
 
     xi = np.cos(decr)*np.sin(radiff)/h;
     eta = ( np.sin(decr)*math.cos(dec0) - np.cos(decr)*math.sin(dec0)*np.cos(radiff) )/h;
 
     xi = xi * rad2arcsec
+    xi = -xi # xi is made negative so it increase in the opposite direction of ra
+             # to match the images the Parity of the ifu_cue is for ra is PC1_1 = -1
+             
     eta = eta * rad2arcsec
 
 
@@ -161,3 +95,78 @@ def std2radec(crval1,crval2,xi,eta):
 
     return ra,dec
   
+#_______________________________________________________________________
+def V2V32RADEC_ESTIMATE(ra_ref,dec_ref,roll_ref,v2_ref,v3_ref,v2, v3):
+    """
+    This routine is used for debugging purposes. It is not actually used
+    in the cube_build step for routine IFU cube building.
+    The conversion from V2,V3 to Ra,dec  is handled more accuarately by
+    the transforms provided by assign_wcs. 
+    v2_ref,v3_ref given in arc seconds 
+    v2 and v3 are given in arc seconds
+    ra_ref,dec_ref, roll_ref given in degrees
+    it is assumed that the V2,V3 coordinates have the effects of dithering included
+    """
+    d2r = math.pi/180.0
+
+    v2deg = v2.copy()/3600.0      # convert to degrees
+    v3deg = v3.copy()/3600.0      # convert to degrees
+
+
+    v2_ref = v2_ref/3600.0 # covert to degrees
+    v3_ref = v3_ref/3600.0 # convert to degrees
+    v3_ref_rad = v3_ref*d2r
+    roll_ref_rad = roll_ref * d2r
+        
+    delta_v2 = (v2deg - v2_ref) * math.cos(v3_ref_rad)
+    delta_v3 = (v3deg - v3_ref)
+    delta_ra = delta_v2 * math.cos(roll_ref_rad) + delta_v3* math.sin(roll_ref_rad)
+    delta_dec = -delta_v2* math.sin(roll_ref_rad) + delta_v3*math.cos(roll_ref_rad)
+
+    ra = ra_ref + delta_ra/math.cos(dec_ref*d2r)
+    dec = delta_dec + dec_ref
+
+    return ra,dec
+#_______________________________________________________________________
+
+#_______________________________________________________________________
+def RADEC2V2V3_ESTIMATE(ra_ref,dec_ref,roll_ref,v2_ref,v3_ref,ra, dec):
+    """
+    This routine is used for debugging purposes. It is not actually used
+    in the cube_build step for routine IFU cube building.
+    The conversion from Ra,Dec to V2,V3 is handled more accuarately by
+    the transforms provided by assign_wcs. 
+
+        # v2_ref,v3_ref given in arc seconds
+        # v2 and v3 are given in arc seconds
+        # ra_ref,dec_ref, roll_ref given in degrees
+        # ra,dec are given in degrees
+     """
+        
+    d2r = math.pi/180.0
+
+    r2d = 180.0  / math.pi
+
+    v3_ref_rad = (v3_ref)/3600.0* d2r # convert from arc seconds to radians
+    v2_ref_rad = (v2_ref)/3600.0* d2r # convert from arc seconds to radians 
+
+    roll_ref_rad = roll_ref * d2r
+
+    ra_ref_rad = ra_ref*d2r
+    dec_ref_rad = dec_ref*d2r
+    this_ra = ra*d2r
+    this_dec  = dec*d2r
+
+    delta_ra = (this_ra - ra_ref_rad) * math.cos(dec_ref_rad)
+    delta_dec = (this_dec-dec_ref_rad)
+
+    dv2 = delta_ra* math.cos(roll_ref_rad) - delta_dec*math.sin(roll_ref_rad) 
+    dv3 = delta_ra*math.sin(roll_ref_rad) + delta_dec*math.cos(roll_ref_rad)
+
+    v2 = v2_ref_rad + dv2/math.cos(v3_ref_rad)
+    v3 = v3_ref_rad + dv3
+
+    v2 = v2*r2d*3600.0  # convert from radians to arc seconds 
+    v3  = v3*r2d*3600.0 # convert from radians to arc seconds
+
+    return v2,v3

--- a/jwst/cube_build/cube_build_wcs_util.py
+++ b/jwst/cube_build/cube_build_wcs_util.py
@@ -317,6 +317,12 @@ def find_footprint_MIRI(self, input, this_channel, instrument_info):
 # ra range of IFU cube. 
 
 
+    print('coord1',coord1.shape)
+
+    print('v2',v2[500,0:100])
+    print('v3',v3[500,0:100])
+    print('coord1',coord1[500,0:100])
+    print('coord2',coord2[500,0:100])
     coord1_wrap = wrap_ra(coord1)
 
     a_min = np.nanmin(coord1_wrap)
@@ -328,6 +334,7 @@ def find_footprint_MIRI(self, input, this_channel, instrument_info):
     lambda_min = np.nanmin(lam)
     lambda_max = np.nanmax(lam)
 
+    print('find footprint',a_min,a_max,b_min,b_max)
     return a_min, a_max, b_min, b_max, lambda_min, lambda_max
 
 #********************************************************************************
@@ -731,11 +738,11 @@ def wrap_ra(ravalues):
 
     valid = np.isfinite(ravalues)
     index_good = np.where( valid == True)
-##    print('number of non nan ra values',index_good[0].size,index_good[0].size/2048)
+    print('number of non nan ra values',index_good[0].size,index_good[0].size/2048)
     ravalues_wrap = ravalues[index_good].copy()
     
     median_ra = np.nanmedian(ravalues_wrap) # find the median 
-##    print('median_ra',median_ra)
+    print('median_ra',median_ra)
 
     # using median to test if there is any wrapping going on
     wrap_index = np.where( np.fabs(ravalues_wrap - median_ra) > 180.0)

--- a/jwst/cube_build/cube_build_wcs_util.py
+++ b/jwst/cube_build/cube_build_wcs_util.py
@@ -316,15 +316,7 @@ def find_footprint_MIRI(self, input, this_channel, instrument_info):
 # test for 0/360 wrapping in ra. if exists it makes it difficult to determine
 # ra range of IFU cube. 
 
-
-    print('coord1',coord1.shape)
-
-    print('v2',v2[500,0:100])
-    print('v3',v3[500,0:100])
-    print('coord1',coord1[500,0:100])
-    print('coord2',coord2[500,0:100])
     coord1_wrap = wrap_ra(coord1)
-
     a_min = np.nanmin(coord1_wrap)
     a_max = np.nanmax(coord1_wrap)
 
@@ -334,7 +326,7 @@ def find_footprint_MIRI(self, input, this_channel, instrument_info):
     lambda_min = np.nanmin(lam)
     lambda_max = np.nanmax(lam)
 
-    print('find footprint',a_min,a_max,b_min,b_max)
+#    print('find footprint',a_min,a_max,b_min,b_max)
     return a_min, a_max, b_min, b_max, lambda_min, lambda_max
 
 #********************************************************************************
@@ -738,11 +730,11 @@ def wrap_ra(ravalues):
 
     valid = np.isfinite(ravalues)
     index_good = np.where( valid == True)
-    print('number of non nan ra values',index_good[0].size,index_good[0].size/2048)
+#    print('number of non nan ra values',index_good[0].size,index_good[0].size/2048)
     ravalues_wrap = ravalues[index_good].copy()
     
     median_ra = np.nanmedian(ravalues_wrap) # find the median 
-    print('median_ra',median_ra)
+#    print('median_ra',median_ra)
 
     # using median to test if there is any wrapping going on
     wrap_index = np.where( np.fabs(ravalues_wrap - median_ra) > 180.0)

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -155,7 +155,7 @@ class IFUCubeData(object):
                log.info('Increasing spatial region of interest' + \
                             ' default value set for 4 dithers %f', self.rois)
         if self.interpolation == 'pointcloud':
-            log.info('Region of interest  %f %f',self.rois,self.roiw)
+            log.info('Region of interest spatial, wavelength  %f %f',self.rois,self.roiw)
 
 #________________________________________________________________________________
 


### PR DESCRIPTION
Fix the IFU cubes parity that I messed up a few months ago.
PC1_1 = -1 is still used but the naxis1 dimension is constructed opposite what is was. 
The naxis1 dimension now increase in the opposite direction as ra does. 

For regression testing we need to establish a new reference IFU cube.