### PR TITLE
Fix NIRCam regtests

### DIFF
--- a/jwst/tests_nightly/general/miri/test_bias_drift.py
+++ b/jwst/tests_nightly/general/miri/test_bias_drift.py
@@ -17,7 +17,8 @@ def test_refpix_miri(_bigdata):
     Regression test of refpix step performed on MIRI data.
 
     """
-    output_file_base, output_file = add_suffix('refpix1_output.fits', 'refpix')
+    suffix = 'refpix'
+    output_file_base, output_file = add_suffix('refpix1_output.fits', suffix)
 
     try:
         os.remove(output_file)
@@ -28,7 +29,8 @@ def test_refpix_miri(_bigdata):
 
     RefPixStep.call(_bigdata+'/miri/test_bias_drift/jw00001001001_01101_00001_MIRIMAGE_saturation.fits',
                     use_side_ref_pixels=False, side_smoothing_length=10, side_gain=1.0,
-                    output_file=output_file_base, name='refpix')
+                    output_file=output_file_base, suffix=suffix
+                    )
 
     h = pf.open(output_file)
     href = pf.open(_bigdata+'/miri/test_bias_drift/jw00001001001_01101_00001_MIRIMAGE_bias_drift.fits')

--- a/jwst/tests_nightly/general/miri/test_bias_drift2.py
+++ b/jwst/tests_nightly/general/miri/test_bias_drift2.py
@@ -17,7 +17,8 @@ def test_refpix_miri2(_bigdata):
     Regression test of refpix step performed on MIRI data.
 
     """
-    output_file_base, output_file = add_suffix('refpix2_output.fits', 'refpix')
+    suffix = 'refpix'
+    output_file_base, output_file = add_suffix('refpix2_output.fits', suffix)
 
     try:
         os.remove(output_file)
@@ -28,7 +29,8 @@ def test_refpix_miri2(_bigdata):
 
     RefPixStep.call(_bigdata+'/miri/test_bias_drift/jw00025001001_01107_00001_MIRIMAGE_saturation.fits',
                     use_side_ref_pixels=False, side_smoothing_length=10, side_gain=1.0,
-                    output_file=output_file_base, name='refpix')
+                    output_file=output_file_base, suffix=suffix
+                    )
     h = pf.open(output_file)
     href = pf.open(_bigdata+'/miri/test_bias_drift/jw00025001001_01107_00001_MIRIMAGE_bias_drift.fits')
     newh = pf.HDUList([h['primary'],h['sci'],h['err'],h['pixeldq'],h['groupdq']])

--- a/jwst/tests_nightly/general/miri/test_dark_step.py
+++ b/jwst/tests_nightly/general/miri/test_dark_step.py
@@ -17,7 +17,8 @@ def test_dark_current_miri(_bigdata):
     Regression test of dark current step performed on MIRI data.
 
     """
-    output_file_base, output_file = add_suffix('darkcurrent1_output.fits', 'dark_current')
+    suffix = 'dark_current'
+    output_file_base, output_file = add_suffix('darkcurrent1_output.fits', suffix)
 
     try:
         os.remove(output_file)
@@ -25,7 +26,7 @@ def test_dark_current_miri(_bigdata):
         pass
 
     DarkCurrentStep.call(_bigdata+'/miri/test_dark_step/jw00001001001_01101_00001_MIRIMAGE_bias_drift.fits',
-                         output_file=output_file_base, name='dark_current'
+                         output_file=output_file_base, suffix=suffix
                          )
     h = pf.open(output_file)
     href = pf.open(_bigdata+'/miri/test_dark_step/jw00001001001_01101_00001_MIRIMAGE_dark_current.fits')

--- a/jwst/tests_nightly/general/miri/test_dark_step2.py
+++ b/jwst/tests_nightly/general/miri/test_dark_step2.py
@@ -17,7 +17,8 @@ def test_dark_current_miri2(_bigdata):
     Regression test of dark current step performed on MIRI data.
 
     """
-    output_file_base, output_file = add_suffix('darkcurrent2_output.fits', 'dark_current')
+    suffix = 'dark_current'
+    output_file_base, output_file = add_suffix('darkcurrent2_output.fits', suffix)
 
     try:
         os.remove('output_file')
@@ -25,7 +26,7 @@ def test_dark_current_miri2(_bigdata):
         pass
 
     DarkCurrentStep.call(_bigdata+'/miri/test_dark_step/jw80600012001_02101_00003_mirimage_lastframe.fits',
-                         output_file=output_file_base, name='dark_current'
+                         output_file=output_file_base, suffix=suffix
                          )
     h = pf.open(output_file)
     href = pf.open(_bigdata+'/miri/test_dark_step/jw80600012001_02101_00003_mirimage_dark.fits')

--- a/jwst/tests_nightly/general/miri/test_dq_init.py
+++ b/jwst/tests_nightly/general/miri/test_dq_init.py
@@ -17,7 +17,8 @@ def test_dq_init_miri(_bigdata):
     Regression test of dq_init step performed on uncalibrated MIRI data.
 
     """
-    output_file_base, output_file = add_suffix('dqinit1_output.fits', 'dq_init')
+    suffix = 'dq_init'
+    output_file_base, output_file = add_suffix('dqinit1_output.fits', suffix)
 
     try:
         os.remove(output_file)
@@ -25,7 +26,7 @@ def test_dq_init_miri(_bigdata):
         pass
 
     DQInitStep.call(_bigdata+'/miri/test_dq_init/jw00001001001_01101_00001_MIRIMAGE_uncal.fits',
-                    output_file=output_file_base, name='dq_init'
+                    output_file=output_file_base, suffix=suffix
     )
 
     h = pf.open(output_file)

--- a/jwst/tests_nightly/general/miri/test_dq_init2.py
+++ b/jwst/tests_nightly/general/miri/test_dq_init2.py
@@ -17,7 +17,8 @@ def test_dq_init_miri2(_bigdata):
     Regression test of dq_init step performed on uncalibrated MIRI data.
 
     """
-    output_file_base, output_file = add_suffix('dqinit2_output.fits', 'dq_init')
+    suffix = 'dq_init'
+    output_file_base, output_file = add_suffix('dqinit2_output.fits', suffix)
 
     try:
         os.remove(output_file)
@@ -25,7 +26,7 @@ def test_dq_init_miri2(_bigdata):
         pass
 
     DQInitStep.call(_bigdata+'/miri/test_dq_init/jw80600012001_02101_00003_mirimage_uncal.fits',
-                    output_file=output_file_base, name='dq_init'
+                    output_file=output_file_base, suffix=suffix
     )
 
     h = pf.open(output_file)

--- a/jwst/tests_nightly/general/miri/test_emission_step.py
+++ b/jwst/tests_nightly/general/miri/test_emission_step.py
@@ -17,7 +17,8 @@ def test_emission_miri(_bigdata):
     Regression test of emission step performed on calibrated miri data.
 
     """
-    output_file_base, output_file = add_suffix('emission1_output.fits', 'emission')
+    suffix = 'emission'
+    output_file_base, output_file = add_suffix('emission1_output.fits', suffix)
 
     try:
         os.remove(output_file)
@@ -27,7 +28,7 @@ def test_emission_miri(_bigdata):
 
 
     EmissionStep.call(_bigdata+'/miri/test_emission/jw00001001001_01101_00001_MIRIMAGE_flat_field.fits',
-                         output_file=output_file_base, name='emission'
+                         output_file=output_file_base, suffix=suffix
     )
     h = pf.open(output_file)
     href = pf.open(_bigdata+'/miri/test_emission/jw00001001001_01101_00001_MIRIMAGE_emission.fits')

--- a/jwst/tests_nightly/general/miri/test_extract1d.py
+++ b/jwst/tests_nightly/general/miri/test_extract1d.py
@@ -17,7 +17,8 @@ def test_extract1d_miri(_bigdata):
     Regression test of extract_1d step performed on MIRI LRS fixed-slit data.
 
     """
-    output_file_base, output_file = add_suffix('extract1d1_output.fits', 'extract_1d')
+    suffix = 'extract_1d'
+    output_file_base, output_file = add_suffix('extract1d1_output.fits', suffix)
 
     try:
         os.remove(output_file)
@@ -28,7 +29,7 @@ def test_extract1d_miri(_bigdata):
 
     Extract1dStep.call(_bigdata+'/miri/test_extract1d/jw00035001001_01101_00001_mirimage_photom.fits',
                        smoothing_length=0,
-                       output_file=output_file_base, name='extract_1d'
+                       output_file=output_file_base, suffix=suffix
                        )
     h = pf.open(output_file)
     href = pf.open(_bigdata+'/miri/test_extract1d/jw00035001001_01101_00001_mirimage_x1d.fits')

--- a/jwst/tests_nightly/general/miri/test_extract1d2.py
+++ b/jwst/tests_nightly/general/miri/test_extract1d2.py
@@ -17,7 +17,8 @@ def test_extract1d_miri2(_bigdata):
     Regression test of extract_1d step performed on MIRI LRS slitless data.
 
     """
-    output_file_base, output_file = add_suffix('extract1d2_output.fits', 'extract_1d')
+    suffix = 'extract_1d'
+    output_file_base, output_file = add_suffix('extract1d2_output.fits', suffix)
 
     try:
         os.remove(output_file)
@@ -28,7 +29,7 @@ def test_extract1d_miri2(_bigdata):
 
     Extract1dStep.call(_bigdata+'/miri/test_extract1d/jw80600012001_02101_00003_mirimage_photom.fits',
                        smoothing_length=0,
-                       output_file=output_file_base, name='extract_1d'
+                       output_file=output_file_base, suffix=suffix
                        )
     h = pf.open(output_file)
     href = pf.open(_bigdata+'/miri/test_extract1d/jw80600012001_02101_00003_mirimage_x1d.fits')

--- a/jwst/tests_nightly/general/miri/test_flat_field.py
+++ b/jwst/tests_nightly/general/miri/test_flat_field.py
@@ -17,7 +17,8 @@ def test_flat_field_miri(_bigdata):
     Regression test of flat_field step performed on MIRI data.
 
     """
-    output_file_base, output_file = add_suffix('flatfield1_output.fits', 'flat_field')
+    suffix = 'flat_field'
+    output_file_base, output_file = add_suffix('flatfield1_output.fits', suffix)
 
     try:
         os.remove(output_file)
@@ -27,7 +28,7 @@ def test_flat_field_miri(_bigdata):
 
 
     FlatFieldStep.call(_bigdata+'/miri/test_flat_field/jw00001001001_01101_00001_MIRIMAGE_assign_wcs.fits',
-                       output_file=output_file_base, name='flat_field'
+                       output_file=output_file_base, suffix=suffix
                        )
     h = pf.open(output_file)
     href = pf.open(_bigdata+'/miri/test_flat_field/jw00001001001_01101_00001_MIRIMAGE_flat_field.fits')

--- a/jwst/tests_nightly/general/miri/test_flat_field2.py
+++ b/jwst/tests_nightly/general/miri/test_flat_field2.py
@@ -17,7 +17,8 @@ def test_flat_field_miri2(_bigdata):
     Regression test of flat_field step performed on MIRI data.
 
     """
-    output_file_base, output_file = add_suffix('flatfield2_output.fits', 'flat_field')
+    suffix = 'flat_field'
+    output_file_base, output_file = add_suffix('flatfield2_output.fits', suffix)
 
     try:
         os.remove(output_file)
@@ -27,7 +28,7 @@ def test_flat_field_miri2(_bigdata):
 
 
     FlatFieldStep.call(_bigdata+'/miri/test_flat_field/jw80600012001_02101_00003_mirimage_assign_wcs.fits',
-                       output_file=output_file_base, name='flat_field'
+                       output_file=output_file_base, suffix=suffix
                        )
     h = pf.open(output_file)
     href = pf.open(_bigdata+'/miri/test_flat_field/jw80600012001_02101_00003_mirimage_flat_field.fits')

--- a/jwst/tests_nightly/general/miri/test_fringe.py
+++ b/jwst/tests_nightly/general/miri/test_fringe.py
@@ -17,7 +17,8 @@ def test_fringe_miri(_bigdata):
     Regression test of fringe performed on MIRI data.
 
     """
-    output_file_base, output_file = add_suffix('fringe1_output.fits', 'fringe')
+    suffix = 'fringe'
+    output_file_base, output_file = add_suffix('fringe1_output.fits', suffix)
 
     try:
         os.remove(output_file)
@@ -25,7 +26,7 @@ def test_fringe_miri(_bigdata):
         pass
 
     FringeStep.call(_bigdata+'/miri/test_fringe/fringe1_input.fits',
-                    output_file=output_file_base, name='fringe'
+                    output_file=output_file_base, suffix=suffix
                     )
     h = pf.open(output_file)
     href = pf.open(_bigdata+'/miri/test_fringe/baseline_fringe1.fits')

--- a/jwst/tests_nightly/general/miri/test_fringe2.py
+++ b/jwst/tests_nightly/general/miri/test_fringe2.py
@@ -17,7 +17,8 @@ def test_fringe_miri2(_bigdata):
     Regression test of fringe performed on MIRI data.
 
     """
-    output_file_base, output_file = add_suffix('fringe2_output.fits', 'fringe')
+    suffix = 'fringe'
+    output_file_base, output_file = add_suffix('fringe2_output.fits', suffix)
 
     try:
         os.remove(output_file)
@@ -25,7 +26,7 @@ def test_fringe_miri2(_bigdata):
         pass
 
     FringeStep.call(_bigdata+'/miri/test_fringe/fringe2_input.fits',
-                    output_file=output_file_base, name='fringe'
+                    output_file=output_file_base, suffix=suffix
                     )
     h = pf.open(output_file)
     href = pf.open(_bigdata+'/miri/test_fringe/baseline_fringe2.fits')

--- a/jwst/tests_nightly/general/miri/test_fringe3.py
+++ b/jwst/tests_nightly/general/miri/test_fringe3.py
@@ -17,7 +17,8 @@ def test_fringe_miri3(_bigdata):
     Regression test of fringe performed on MIRI data.
 
     """
-    output_file_base, output_file = add_suffix('fringe3_output.fits', 'fringe')
+    suffix = 'fringe'
+    output_file_base, output_file = add_suffix('fringe3_output.fits', suffix)
 
     try:
         os.remove(output_file)
@@ -25,7 +26,7 @@ def test_fringe_miri3(_bigdata):
         pass
 
     FringeStep.call(_bigdata+'/miri/test_fringe/fringe3_input.fits',
-                    output_file=output_file_base, name='fringe'
+                    output_file=output_file_base, suffix=suffix
                     )
     h = pf.open(output_file)
     href = pf.open(_bigdata+'/miri/test_fringe/baseline_fringe3.fits')

--- a/jwst/tests_nightly/general/miri/test_jump.py
+++ b/jwst/tests_nightly/general/miri/test_jump.py
@@ -17,7 +17,8 @@ def test_jump_miri(_bigdata):
     Regression test of jump step performed on MIRI data.
 
     """
-    output_file_base, output_file = add_suffix('jump1_output.fits', 'jump')
+    suffix = 'jump'
+    output_file_base, output_file = add_suffix('jump1_output.fits', suffix)
 
     try:
         os.remove(output_file)
@@ -28,7 +29,7 @@ def test_jump_miri(_bigdata):
 
     JumpStep.call(_bigdata+'/miri/test_jump/jw00001001001_01101_00001_MIRIMAGE_linearity.fits',
                   rejection_threshold=200.0,
-                  output_file=output_file_base, name='jump'
+                  output_file=output_file_base, suffix=suffix
                   )
     h = pf.open(output_file)
     href = pf.open(_bigdata+'/miri/test_jump/jw00001001001_01101_00001_MIRIMAGE_jump.fits')

--- a/jwst/tests_nightly/general/miri/test_jump2.py
+++ b/jwst/tests_nightly/general/miri/test_jump2.py
@@ -17,7 +17,8 @@ def test_jump_miri2(_bigdata):
     Regression test of jump step performed on MIRI data.
 
     """
-    output_file_base, output_file = add_suffix('jump2_output.fits', 'jump')
+    suffix = 'jump'
+    output_file_base, output_file = add_suffix('jump2_output.fits', suffix)
 
     try:
         os.remove(output_file)
@@ -28,7 +29,7 @@ def test_jump_miri2(_bigdata):
 
     JumpStep.call(_bigdata+'/miri/test_jump/jw80600012001_02101_00003_mirimage_dark.fits',
                   rejection_threshold=25.0,
-                  output_file=output_file_base, name='jump'
+                  output_file=output_file_base, suffix=suffix
                   )
     h = pf.open(output_file)
     href = pf.open(_bigdata+'/miri/test_jump/jw80600012001_02101_00003_mirimage_jump.fits')

--- a/jwst/tests_nightly/general/miri/test_lastframe2.py
+++ b/jwst/tests_nightly/general/miri/test_lastframe2.py
@@ -17,7 +17,8 @@ def test_lastframe_miri2(_bigdata):
     Regression test of lastframe step performed on MIRI data.
 
     """
-    output_file_base, output_file = add_suffix('lastframe2_output.fits', 'lastframe')
+    suffix = 'lastframe'
+    output_file_base, output_file = add_suffix('lastframe2_output.fits', suffix)
 
     try:
         os.remove(output_file)
@@ -26,7 +27,7 @@ def test_lastframe_miri2(_bigdata):
 
 
     LastFrameStep.call(_bigdata+'/miri/test_lastframe/jw80600012001_02101_00003_mirimage_rscd.fits',
-                       output_file=output_file_base, name='lastframe'
+                       output_file=output_file_base, suffix=suffix
                        )
     h = pf.open(output_file)
     href = pf.open(_bigdata+'/miri/test_lastframe/jw80600012001_02101_00003_mirimage_lastframe.fits')

--- a/jwst/tests_nightly/general/miri/test_linearity.py
+++ b/jwst/tests_nightly/general/miri/test_linearity.py
@@ -17,7 +17,8 @@ def test_linearity_miri(_bigdata):
     Regression test of linearity step performed on MIRI data.
 
     """
-    output_file_base, output_file = add_suffix('linearity1_output.fits', 'linearity')
+    suffix = 'linearity'
+    output_file_base, output_file = add_suffix('linearity1_output.fits', suffix)
 
     try:
         os.remove(output_file)
@@ -27,7 +28,7 @@ def test_linearity_miri(_bigdata):
 
 
     LinearityStep.call(_bigdata+'/miri/test_linearity/jw00001001001_01101_00001_MIRIMAGE_dark_current.fits',
-                       output_file=output_file_base, name='linearity'
+                       output_file=output_file_base, suffix=suffix
                        )
     h = pf.open(output_file)
     href = pf.open(_bigdata+'/miri/test_linearity/jw00001001001_01101_00001_MIRIMAGE_linearity.fits')

--- a/jwst/tests_nightly/general/miri/test_linearity2.py
+++ b/jwst/tests_nightly/general/miri/test_linearity2.py
@@ -17,7 +17,8 @@ def test_linearity_miri2(_bigdata):
     Regression test of linearity step performed on MIRI data.
 
     """
-    output_file_base, output_file = add_suffix('linearity2_output.fits', 'linearity')
+    suffix = 'linearity'
+    output_file_base, output_file = add_suffix('linearity2_output.fits', suffix)
 
     try:
         os.remove(output_file)
@@ -27,7 +28,7 @@ def test_linearity_miri2(_bigdata):
 
 
     LinearityStep.call(_bigdata+'/miri/test_linearity/jw80600012001_02101_00003_mirimage_saturation.fits',
-                       output_file=output_file_base, name='linearity'
+                       output_file=output_file_base, suffix=suffix
                        )
     h = pf.open(output_file)
     href = pf.open(_bigdata+'/miri/test_linearity/jw80600012001_02101_00003_mirimage_linearity.fits')

--- a/jwst/tests_nightly/general/miri/test_linearity3.py
+++ b/jwst/tests_nightly/general/miri/test_linearity3.py
@@ -17,7 +17,8 @@ def test_linearity_miri3(_bigdata):
     Regression test of linearity step performed on MIRI data.
 
     """
-    output_file_base, output_file = add_suffix('linearity3_output.fits', 'linearity')
+    suffix = 'linearity'
+    output_file_base, output_file = add_suffix('linearity3_output.fits', suffix)
 
     try:
         os.remove(output_file)
@@ -28,7 +29,7 @@ def test_linearity_miri3(_bigdata):
 
     LinearityStep.call(_bigdata+'/miri/test_linearity/jw00001001001_01109_00001_MIRIMAGE_dark_current.fits',
                        override_linearity=_bigdata+'/miri/test_linearity/lin_nan_flag_miri.fits',
-                       output_file=output_file_base, name='linearity'
+                       output_file=output_file_base, suffix=suffix
                        )
     h = pf.open(output_file)
     href = pf.open(_bigdata+'/miri/test_linearity/jw00001001001_01109_00001_MIRIMAGE_linearity.fits')

--- a/jwst/tests_nightly/general/miri/test_linearity3.py
+++ b/jwst/tests_nightly/general/miri/test_linearity3.py
@@ -37,7 +37,7 @@ def test_linearity_miri3(_bigdata):
     newhref = pf.HDUList([href['primary'],href['sci'],href['err'],href['pixeldq'],href['groupdq']])
     result = pf.diff.FITSDiff(newh,
                               newhref,
-                              ignore_keywords = ['DATE','CAL_VER','CAL_VCS','CRDS_VER','CRDS_CTX', 'R_LINEAR'],
+                              ignore_keywords = ['DATE','CAL_VER','CAL_VCS','CRDS_VER','CRDS_CTX'],
                               rtol = 0.00001
     )
     assert result.identical, result.report()

--- a/jwst/tests_nightly/general/miri/test_saturation.py
+++ b/jwst/tests_nightly/general/miri/test_saturation.py
@@ -17,7 +17,8 @@ def test_saturation_miri(_bigdata):
     Regression test of saturation step performed on uncalibrated MIRI data.
 
     """
-    output_file_base, output_file = add_suffix('saturation1_output.fits', 'saturation')
+    suffix = 'saturation'
+    output_file_base, output_file = add_suffix('saturation1_output.fits', suffix)
 
     try:
         os.remove(output_file)
@@ -27,7 +28,7 @@ def test_saturation_miri(_bigdata):
 
 
     SaturationStep.call(_bigdata+'/miri/test_saturation/jw00001001001_01101_00001_MIRIMAGE_dq_init.fits',
-                        output_file=output_file_base, name='saturation'
+                        output_file=output_file_base, suffix=suffix
                         )
     h = pf.open(output_file)
     href = pf.open(_bigdata+'/miri/test_saturation/jw00001001001_01101_00001_MIRIMAGE_saturation.fits')

--- a/jwst/tests_nightly/general/miri/test_saturation2.py
+++ b/jwst/tests_nightly/general/miri/test_saturation2.py
@@ -17,7 +17,8 @@ def test_saturation_miri2(_bigdata):
     Regression test of saturation step performed on uncalibrated MIRI data.
 
     """
-    output_file_base, output_file = add_suffix('saturation2_output.fits', 'saturation')
+    suffix = 'saturation'
+    output_file_base, output_file = add_suffix('saturation2_output.fits', suffix)
 
     try:
         os.remove(output_file)
@@ -27,7 +28,7 @@ def test_saturation_miri2(_bigdata):
 
 
     SaturationStep.call(_bigdata+'/miri/test_saturation/jw80600012001_02101_00003_mirimage_dqinit.fits',
-                        output_file=output_file_base, name='saturation'
+                        output_file=output_file_base, suffix=suffix
                         )
     h = pf.open(output_file)
     href = pf.open(_bigdata+'/miri/test_saturation/jw80600012001_02101_00003_mirimage_saturation.fits')

--- a/jwst/tests_nightly/general/miri/test_srctype2.py
+++ b/jwst/tests_nightly/general/miri/test_srctype2.py
@@ -17,7 +17,8 @@ def test_srctype2(_bigdata):
     Regression test of srctype step performed on MIRI LRS slitless data.
 
     """
-    output_file_base, output_file = add_suffix('srctype2_output.fits', 'sourcetypestep')
+    suffix = 'sourcetypestep'
+    output_file_base, output_file = add_suffix('srctype2_output.fits', suffix)
 
     try:
         os.remove(output_file)
@@ -27,7 +28,7 @@ def test_srctype2(_bigdata):
 
 
     SourceTypeStep.call(_bigdata+'/miri/test_srctype/jw80600012001_02101_00003_mirimage_flat_field.fits',
-                        output_file=output_file_base, suffix='sourcetypestep'
+                        output_file=output_file_base, suffix=suffix
                         )
     h = pf.open(output_file)
     href = pf.open(_bigdata+'/miri/test_srctype/jw80600012001_02101_00003_mirimage_srctype.fits')

--- a/jwst/tests_nightly/general/miri/test_straylight.py
+++ b/jwst/tests_nightly/general/miri/test_straylight.py
@@ -17,7 +17,8 @@ def test_straylight1_miri(_bigdata):
     Regression test of straylight performed on MIRI IFUSHORT data.
 
     """
-    output_file_base, output_file = add_suffix('straylight1_output.fits', 'straylight')
+    suffix = 'straylight'
+    output_file_base, output_file = add_suffix('straylight1_output.fits', suffix)
 
     try:
         os.remove(output_file)
@@ -25,7 +26,7 @@ def test_straylight1_miri(_bigdata):
         pass
 
     StraylightStep.call(_bigdata+'/miri/test_straylight/jw80500018001_02101_00002_MIRIFUSHORT_flatfield.fits',
-                        output_file=output_file_base, name='straylight'
+                        output_file=output_file_base, suffix=suffix
                         )
     h = pf.open(output_file)
     href = pf.open(_bigdata+'/miri/test_straylight/jw80500018001_02101_00002_MIRIFUSHORT_straylight.fits')

--- a/jwst/tests_nightly/general/miri/test_straylight2.py
+++ b/jwst/tests_nightly/general/miri/test_straylight2.py
@@ -17,7 +17,8 @@ def test_straylight2_miri(_bigdata):
     Regression test of straylight performed on MIRI IFULONG data.
 
     """
-    output_file_base, output_file = add_suffix('straylight2_output.fits', 'straylight')
+    suffix = 'straylight'
+    output_file_base, output_file = add_suffix('straylight2_output.fits', suffix)
 
     try:
         os.remove(output_file)
@@ -25,7 +26,7 @@ def test_straylight2_miri(_bigdata):
         pass
 
     StraylightStep.call(_bigdata+'/miri/test_straylight/jw80500018001_02101_00002_MIRIFULONG_flatfield.fits',
-                        output_file=output_file_base, name='straylight'
+                        output_file=output_file_base, suffix=suffix
                         )
     h = pf.open(output_file)
     href = pf.open(_bigdata+'/miri/test_straylight/jw80500018001_02101_00002_MIRIFULONG_straylight.fits')

--- a/jwst/tests_nightly/general/nircam/test_bias_drift.py
+++ b/jwst/tests_nightly/general/nircam/test_bias_drift.py
@@ -18,7 +18,8 @@ def test_refpixt_nircam(_bigdata):
     Regression test of refpix step performed on NIRCam data.
 
     """
-    output_file_base, output_file = add_suffix('refpix1_output.fits', 'refpix')
+    suffix = 'refpix'
+    output_file_base, output_file = add_suffix('refpix1_output.fits', suffix)
 
     try:
         os.remove(output_file)
@@ -29,7 +30,7 @@ def test_refpixt_nircam(_bigdata):
 
     RefPixStep.call(_bigdata+'/nircam/test_bias_drift/jw00017001001_01101_00001_NRCA1_dq_init.fits',
                     odd_even_columns=True, use_side_ref_pixels=False, side_smoothing_length=10,
-                    side_gain=1.0, output_file=output_file_base
+                    side_gain=1.0, output_file=output_file_base, suffix=suffix
                     )
     h = pf.open(output_file)
     href = pf.open(_bigdata+'/nircam/test_bias_drift/jw00017001001_01101_00001_NRCA1_bias_drift.fits')

--- a/jwst/tests_nightly/general/nircam/test_dark_step.py
+++ b/jwst/tests_nightly/general/nircam/test_dark_step.py
@@ -18,7 +18,8 @@ def test_dark_current_nircam(_bigdata):
     Regression test of dark current step performed on NIRCam data.
 
     """
-    output_file_base, output_file = add_suffix('darkcurrent1_output.fits', 'dark_current')
+    suffix = 'dark_current'
+    output_file_base, output_file = add_suffix('darkcurrent1_output.fits', suffix)
 
     try:
         os.remove(output_file)
@@ -26,7 +27,7 @@ def test_dark_current_nircam(_bigdata):
         pass
 
     DarkCurrentStep.call(_bigdata+'/nircam/test_dark_step/jw00017001001_01101_00001_NRCA1_saturation.fits',
-                         output_file=output_file_base
+                         output_file=output_file_base, suffix=suffix
                          )
     h = pf.open(output_file)
     href = pf.open(_bigdata+'/nircam/test_dark_step/jw00017001001_01101_00001_NRCA1_dark_current.fits')

--- a/jwst/tests_nightly/general/nircam/test_dq_init.py
+++ b/jwst/tests_nightly/general/nircam/test_dq_init.py
@@ -18,7 +18,8 @@ def test_dq_init_nircam(_bigdata):
     Regression test of dq_init step performed on uncalibrated NIRCam data.
 
     """
-    output_file_base, output_file = add_suffix('dqinit1_output.fits', 'dq_init')
+    suffix = 'dq_init'
+    output_file_base, output_file = add_suffix('dqinit1_output.fits', suffix)
 
     try:
         os.remove(output_file)
@@ -28,7 +29,7 @@ def test_dq_init_nircam(_bigdata):
 
 
     DQInitStep.call(_bigdata+'/nircam/test_dq_init/jw00017001001_01101_00001_NRCA1_uncal.fits',
-                    output_file=output_file_base
+                    output_file=output_file_base, suffix=suffix
                     )
     h = pf.open(output_file)
     href = pf.open(_bigdata+'/nircam/test_dq_init/jw00017001001_01101_00001_NRCA1_dq_init.fits')

--- a/jwst/tests_nightly/general/nircam/test_emission_step.py
+++ b/jwst/tests_nightly/general/nircam/test_emission_step.py
@@ -18,7 +18,8 @@ def test_emission_nircam(_bigdata):
     Regression test of emission step performed on calibrated NIRCam data.
 
     """
-    output_file_base, output_file = add_suffix('emission1_output.fits', 'emission')
+    suffix = 'emission'
+    output_file_base, output_file = add_suffix('emission1_output.fits', suffix)
 
     try:
         os.remove(output_file)
@@ -28,7 +29,7 @@ def test_emission_nircam(_bigdata):
 
 
     EmissionStep.call(_bigdata+'/nircam/test_emission/jw00017001001_01101_00001_NRCA1_persistence.fits',
-                      output_file=output_file_base
+                      output_file=output_file_base, suffix=suffix
                       )
     h = pf.open(output_file)
     href = pf.open(_bigdata+'/nircam/test_emission/jw00017001001_01101_00001_NRCA1_emission.fits')

--- a/jwst/tests_nightly/general/nircam/test_flat_field.py
+++ b/jwst/tests_nightly/general/nircam/test_flat_field.py
@@ -18,7 +18,8 @@ def test_flat_field_nircam(_bigdata):
     Regression test of flat_field step performed on MIRI data.
 
     """
-    output_file_base, output_file = add_suffix('flatfield1_output.fits', 'flat_field')
+    suffix = 'flat_field'
+    output_file_base, output_file = add_suffix('flatfield1_output.fits', suffix)
 
     try:
         os.remove(output_file)
@@ -28,7 +29,7 @@ def test_flat_field_nircam(_bigdata):
 
 
     FlatFieldStep.call(_bigdata+'/nircam/test_flat_field/jw00017001001_01101_00001_NRCA1_ramp_fit.fits',
-                       output_file=output_file_base
+                       output_file=output_file_base, suffix=suffix
                        )
     h = pf.open(output_file)
     href = pf.open(_bigdata+'/nircam/test_flat_field/jw00017001001_01101_00001_NRCA1_flat_field.fits')

--- a/jwst/tests_nightly/general/nircam/test_ipc_step.py
+++ b/jwst/tests_nightly/general/nircam/test_ipc_step.py
@@ -14,8 +14,8 @@ pytestmark = [
 
 def test_ipc_nircam(_bigdata):
     """Regression test of IPC step performed on NIRCam data."""
-
-    output_file_base, output_file = add_suffix('ipc1_output.fits', 'ipc')
+    suffix = 'ipc'
+    output_file_base, output_file = add_suffix('ipc1_output.fits', suffix)
 
     try:
         os.remove(output_file)
@@ -23,7 +23,8 @@ def test_ipc_nircam(_bigdata):
         pass
 
     IPCStep.call(_bigdata + '/nircam/test_ipc_step/jw00017001001_01101_00001_NRCA3_uncal.fits',
-                 output_file=output_file_base)
+                 output_file=output_file_base, suffix=suffix
+                 )
     h = pf.open(output_file)
     href = pf.open(_bigdata + '/nircam/test_ipc_step/jw00017001001_01101_00001_NRCA3_ipc.fits')
     newh = pf.HDUList([h['primary'], h['sci']])

--- a/jwst/tests_nightly/general/nircam/test_jump.py
+++ b/jwst/tests_nightly/general/nircam/test_jump.py
@@ -18,7 +18,8 @@ def test_jump_nircam(_bigdata):
     Regression test of jump step performed on NIRCam data.
 
     """
-    output_file_base, output_file = add_suffix('jump1_output.fits', 'jump')
+    suffix = 'jump'
+    output_file_base, output_file = add_suffix('jump1_output.fits', suffix)
 
     try:
         os.remove(output_file)
@@ -29,7 +30,7 @@ def test_jump_nircam(_bigdata):
 
     JumpStep.call(_bigdata+'/nircam/test_jump/jw00017001001_01101_00001_NRCA1_linearity.fits',
                   rejection_threshold=25.0,
-                  output_file=output_file_base
+                  output_file=output_file_base, suffix=suffix
                   )
     h = pf.open(output_file)
     href = pf.open(_bigdata+'/nircam/test_jump/jw00017001001_01101_00001_NRCA1_jump.fits')

--- a/jwst/tests_nightly/general/nircam/test_linearity_step.py
+++ b/jwst/tests_nightly/general/nircam/test_linearity_step.py
@@ -18,7 +18,8 @@ def test_linearity_nircam(_bigdata):
     Regression test of linearity step performed on NIRCam data.
 
     """
-    output_file_base, output_file = add_suffix('linearity1_output.fits', 'linearity')
+    suffix = 'linearity'
+    output_file_base, output_file = add_suffix('linearity1_output.fits', suffix)
 
     try:
         os.remove(output_file)
@@ -28,7 +29,7 @@ def test_linearity_nircam(_bigdata):
 
 
     LinearityStep.call(_bigdata+'/nircam/test_linearity/jw00017001001_01101_00001_NRCA1_dark_current.fits',
-                       output_file=output_file_base
+                       output_file=output_file_base, suffix=suffix
                        )
     h = pf.open(output_file)
     href = pf.open(_bigdata+'/nircam/test_linearity/jw00017001001_01101_00001_NRCA1_linearity.fits')

--- a/jwst/tests_nightly/general/nircam/test_persistence_step.py
+++ b/jwst/tests_nightly/general/nircam/test_persistence_step.py
@@ -18,7 +18,8 @@ def test_persistence_nircam(_bigdata):
     Regression test of persistence step performed on calibrated NIRCam data.
 
     """
-    output_file_base, output_file = add_suffix('persistence1_output.fits', 'persistence')
+    suffix = 'persistence'
+    output_file_base, output_file = add_suffix('persistence1_output.fits', suffix)
 
     try:
         os.remove(output_file)
@@ -28,7 +29,7 @@ def test_persistence_nircam(_bigdata):
 
 
     PersistenceStep.call(_bigdata+'/nircam/test_persistence/jw00017001001_01101_00001_NRCA1_ramp.fits',
-                         output_file=output_file_base
+                         output_file=output_file_base, suffix=suffix
                          )
     h = pf.open(output_file)
     href = pf.open(_bigdata+'/nircam/test_persistence/jw00017001001_01101_00001_NRCA1_persistence.fits')

--- a/jwst/tests_nightly/general/nircam/test_photom_step.py
+++ b/jwst/tests_nightly/general/nircam/test_photom_step.py
@@ -18,7 +18,8 @@ def test_photom_nircam(_bigdata):
     Regression test of photom step performed on NIRCam imaging data.
 
     """
-    output_file_base, output_file = add_suffix('photom1_output.fits', 'photom')
+    suffix = 'photom'
+    output_file_base, output_file = add_suffix('photom1_output.fits', suffix)
 
     try:
         os.remove(output_file)
@@ -28,7 +29,7 @@ def test_photom_nircam(_bigdata):
 
 
     PhotomStep.call(_bigdata+'/nircam/test_photom/jw00017001001_01101_00001_NRCA1_emission.fits',
-                    output_file=output_file_base
+                    output_file=output_file_base, suffix=suffix
                     )
     h = pf.open(output_file)
     href = pf.open(_bigdata+'/nircam/test_photom/jw00017001001_01101_00001_NRCA1_photom.fits')

--- a/jwst/tests_nightly/general/nircam/test_ramp_step.py
+++ b/jwst/tests_nightly/general/nircam/test_ramp_step.py
@@ -18,7 +18,8 @@ def test_ramp_fit_nircam(_bigdata):
     Regression test of ramp_fit step performed on NIRCam data.
 
     """
-    output_file_base, output_files = add_suffix('rampfit_output.fits', 'rampfit', list(range(1)))
+    suffix = 'rampfit'
+    output_file_base, output_files = add_suffix('rampfit_output.fits', suffix, list(range(1)))
 
     try:
         os.remove(output_files[0])
@@ -28,7 +29,7 @@ def test_ramp_fit_nircam(_bigdata):
 
 
     RampFitStep.call(_bigdata+'/nircam/test_ramp_fit/jw00017001001_01101_00001_NRCA1_jump.fits',
-                     output_file=output_file_base,
+                     output_file=output_file_base, suffix=suffix,
                      save_opt=True,
                      opt_name='rampfit_opt_out.fits'
                      )

--- a/jwst/tests_nightly/general/nircam/test_saturation.py
+++ b/jwst/tests_nightly/general/nircam/test_saturation.py
@@ -18,7 +18,8 @@ def test_saturation_nircam(_bigdata):
     Regression test of saturation step performed on NIRCam data.
 
     """
-    output_file_base, output_file = add_suffix('saturation1_output.fits', 'saturation')
+    suffix = 'saturation'
+    output_file_base, output_file = add_suffix('saturation1_output.fits', suffix)
 
     try:
         os.remove(output_file)
@@ -26,7 +27,7 @@ def test_saturation_nircam(_bigdata):
         pass
 
     SaturationStep.call(_bigdata+'/nircam/test_saturation/jw00017001001_01101_00001_NRCA1_bias_drift.fits',
-                        output_file=output_file_base
+                        output_file=output_file_base, suffix=suffix
                         )
     h = pf.open(output_file)
     href = pf.open(_bigdata+'/nircam/test_saturation/jw00017001001_01101_00001_NRCA1_saturation.fits')

--- a/jwst/tests_nightly/general/nircam/test_sloperpipeline_3.py
+++ b/jwst/tests_nightly/general/nircam/test_sloperpipeline_3.py
@@ -24,8 +24,8 @@ def test_detector1pipeline3(_bigdata):
     step.refpix.side_gain = 1.0
     step.jump.rejection_threshold = 250.0
     step.ramp_fit.save_opt = True
-    step.run(_bigdata+'/pipelines/jw82500001003_02101_00001_NRCALONG_uncal.fits',
-             output_file='jw82500001003_02101_00001_NRCALONG_rate.fits')
+    step.output_file = 'jw82500001003_02101_00001_NRCALONG_rate.fits'
+    step.run(_bigdata+'/pipelines/jw82500001003_02101_00001_NRCALONG_uncal.fits')
 
     # Compare ramp product
     n_ramp = 'jw82500001003_02101_00001_NRCALONG_ramp.fits'


### PR DESCRIPTION
In addition to fixing NIRCam regtests, this also

- Backs out ignoring an override reffile name in one of the MIRI linearity tests (see #1939)
- Specifies `suffix` instead of `name` when calling a step for a number of MIRI tests that had been previously modified in #1939, as it is much clearer what is going on for future maintainers.