### PR TITLE
Reorganize IFU-specific keywords

### DIFF
--- a/jwst/cube_build/blot_cube_build.py
+++ b/jwst/cube_build/blot_cube_build.py
@@ -32,11 +32,12 @@ class CubeBlot(object):
         self.median_skycube = median_model
         self.instrument = median_model.meta.instrument.name
         self.detector = median_model.meta.instrument.detector
+
         #information on how the IFUCube was constructed 
-        self.weight_power = median_model.meta.weight_power
-        self.weighting = median_model.meta.weighting # if AREA ABORT
-        self.rois = median_model.meta.roi_spatial
-        self.roiw = median_model.meta.roi_wave
+        self.weight_power = median_model.meta.ifu.weight_power
+        self.weighting = median_model.meta.ifu.weighting # if AREA ABORT
+        self.rois = median_model.meta.ifu.roi_spatial
+        self.roiw = median_model.meta.ifu.roi_wave
 
         #basic information about the type of data
         self.grating = None

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -155,7 +155,7 @@ class IFUCubeData(object):
                log.info('Increasing spatial region of interest' + \
                             ' default value set for 4 dithers %f', self.rois)
         if self.interpolation == 'pointcloud':
-            log.info('Region of interest  %f %f',self.rois,self.roiw)
+            log.info('Region of interest spatial, wavelength  %f %f',self.rois,self.roiw)
 
 #________________________________________________________________________________
 
@@ -737,20 +737,19 @@ class IFUCubeData(object):
         IFUCube.meta.wcsinfo.pc3_2 = 0
         IFUCube.meta.wcsinfo.pc3_3 = 1
 
-        IFUCube.meta.flux_extension = 'SCI'
-        IFUCube.meta.error_extension = 'ERR'
-        IFUCube.meta.dq_extension = 'DQ'
-        IFUCube.meta.roi_spatial = self.rois
-        IFUCube.meta.roi_wave = self.roiw
-        IFUCube.meta.weighting = self.weighting
-        IFUCube.meta.weight_power = self.weight_power
+        IFUCube.meta.ifu.flux_extension = 'SCI'
+        IFUCube.meta.ifu.error_extension = 'ERR'
+        IFUCube.meta.ifu.error_type = 'ERR'
+        IFUCube.meta.ifu.dq_extension = 'DQ'
+        IFUCube.meta.ifu.roi_spatial = self.rois
+        IFUCube.meta.ifu.roi_wave = self.roiw
+        IFUCube.meta.ifu.weighting = self.weighting
+        IFUCube.meta.ifu.weight_power = self.weight_power
 
 
         with datamodels.open(self.input_models[j]) as input:
             IFUCube.meta.bunit_data = input.meta.bunit_data
             IFUCube.meta.bunit_err = input.meta.bunit_err
-
-        IFUCube.error_type = 'ERR'
 
         if self.coord_system == 'alpha-beta' :
             IFUCube.meta.wcsinfo.cunit1 = 'arcsec'

--- a/jwst/datamodels/schemas/ifucube.schema.yaml
+++ b/jwst/datamodels/schemas/ifucube.schema.yaml
@@ -8,36 +8,44 @@ allOf:
     meta:
       type: object
       properties:
-        flux_extension:
-          title: EXTNAME of the extension containing flux data
-          type: string
-          fits_keyword: FLUXEXT
-        error_extension:
-          title: EXTNAME of the extension containing error data
-          type: string
-          fits_keyword: ERREXT
-        dq_extension:
-          title: EXTNAME of the extension containing data quality mask
-          type: string
-          fits_keyword: MASKEXT
-        roi_spatial:
-          title: Size of ROI in spatial dimension arcs seconds
-          type: number
-          fits_keyword: ROIS
-        roi_wave:
-          title: Size of ROI in wavelength dimension microns
-          type: number
-          fits_keyword: ROIW
-        weighting:
-          title: Type of weighting type (MSM,MIRIPSF,AREA)
-          type: string
-          fits_keyword: WTYPE
-        weight_power:
-          title: Weighting power for Modified Shepard Method
-          type: number
-          fits_keyword: WPOWER
-
-
+        ifu:
+          title: IFU cube parameters
+          type: object
+          properties:
+            flux_extension:
+              title: EXTNAME of the extension containing flux data
+              type: string
+              fits_keyword: FLUXEXT
+            error_extension:
+              title: EXTNAME of the extension containing error data
+              type: string
+              fits_keyword: ERREXT
+            error_type:
+              title: Type of errors stored here
+              type: string
+              enum: [ERR, IERR, VAR, IVAR]
+              fits_keyword: ERRTYPE
+              fits_hdu: ERR
+            dq_extension:
+              title: EXTNAME of the extension containing data quality mask
+              type: string
+              fits_keyword: MASKEXT
+            roi_spatial:
+              title: Size of ROI in spatial dimension [arcsec]
+              type: number
+              fits_keyword: ROIS
+            roi_wave:
+              title: Size of ROI in wavelength dimension [um]
+              type: number
+              fits_keyword: ROIW
+            weighting:
+              title: Weighting type (MSM,MIRIPSF,AREA)
+              type: string
+              fits_keyword: WTYPE
+            weight_power:
+              title: Weighting power for Modified Shepard Method
+              type: number
+              fits_keyword: WPOWER
 - type: object
   properties:
     data:
@@ -64,10 +72,4 @@ allOf:
       default: 0.0
       ndim: 3
       datatype: float32
-    error_type:
-      title: Type of errors stored here
-      type: string
-      enum: [ERR, IERR, VAR, IVAR]
-      fits_keyword: ERRTYPE
-      fits_hdu: ERR
 $schema: http://stsci.edu/schemas/fits-schema/fits-schema


### PR DESCRIPTION
As part of a larger effort to reorganize and clean-up some of the keyword schemas, this updates the IFUCubeModel schema to place all of the cube-specific keyword definitions within a new meta subsection called "ifu". Updates to cube_build modules are also made to point to the new meta tree locations of these keywords.