### PR TITLE
CubeModel bbox should be 2D

### DIFF
--- a/jwst/assign_wcs/fgs.py
+++ b/jwst/assign_wcs/fgs.py
@@ -69,10 +69,20 @@ def imaging_distortion(input_model, reference_files):
         bb = transform.bounding_box
     except NotImplementedError:
         shape = input_model.data.shape
-        # Note: Since bounding_box is attached to the model here it's in reverse order.
-        bb = ((-0.5, shape[0] - 0.5),
-              (-0.5, shape[1] - 0.5))
-    transform.bounding_box = bb
+        # Note: Since bounding_box is attached to the model here                                                                 
+        # it's in reverse order.                                                                                                 
+        # If the input is a CubeModel, need to set bbox to the                                                                   
+        # size of 2nd and 3rd dimension.
+        if isinstance(input_model, CubeModel):
+            bb = ((-0.5, shape[1] - 0.5),
+                  (-0.5, shape[2] - 0.5))
+        elif isinstance(input_model, ImageModel):
+            bb = ((-0.5, shape[0] - 0.5),
+                  (-0.5, shape[1] - 0.5))
+        else:
+            raise TypeError("Input is not an ImageModel or CubeModel")
+
+        transform.bounding_box = bb
     dist.close()
     return transform
 

--- a/jwst/assign_wcs/nircam.py
+++ b/jwst/assign_wcs/nircam.py
@@ -52,7 +52,8 @@ def imaging(input_model, reference_files):
 
 
 def imaging_distortion(input_model, reference_files):
-    transform = DistortionModel(reference_files['distortion']).model
+    dist = DistortionModel(reference_files['distortion'])
+    transform = dist.model
 
     try:
         bb = transform.bounding_box
@@ -71,7 +72,8 @@ def imaging_distortion(input_model, reference_files):
         else:
             raise TypeError("Input is not an ImageModel or CubeModel")
 
-    transform.bounding_box = bb
+        transform.bounding_box = bb
+    dist.close()
     return transform
 
 

--- a/jwst/assign_wcs/nircam.py
+++ b/jwst/assign_wcs/nircam.py
@@ -7,7 +7,8 @@ import gwcs.coordinate_frames as cf
 
 from . import pointing
 from .util import not_implemented_mode, subarray_transform
-from ..datamodels import ImageModel, NIRCAMGrismModel, DistortionModel
+from ..datamodels import (ImageModel, NIRCAMGrismModel, DistortionModel,
+                          CubeModel)
 from ..transforms.models import (NIRCAMForwardRowGrismDispersion,
                                  NIRCAMForwardColumnGrismDispersion,
                                  NIRCAMBackwardGrismDispersion)
@@ -57,9 +58,19 @@ def imaging_distortion(input_model, reference_files):
         bb = transform.bounding_box
     except NotImplementedError:
         shape = input_model.data.shape
-        # Note: Since bounding_box is attached to the model here it's in reverse order.
-        bb = ((-0.5, shape[0] - 0.5),
-              (-0.5, shape[1] - 0.5))
+        # Note: Since bounding_box is attached to the model here
+        # it's in reverse order.
+        # If the input is a CubeModel, need to set bbox to the
+        # size of 2nd and 3rd dimension.
+        if isinstance(input_model, CubeModel):
+            bb = ((-0.5, shape[1] - 0.5),
+                  (-0.5, shape[2] - 0.5))
+        elif isinstance(input_model, ImageModel):
+            bb = ((-0.5, shape[0] - 0.5),
+                  (-0.5, shape[1] - 0.5))
+        else:
+            raise TypeError("Input is not an ImageModel or CubeModel")
+
     transform.bounding_box = bb
     return transform
 

--- a/jwst/assign_wcs/niriss.py
+++ b/jwst/assign_wcs/niriss.py
@@ -154,12 +154,24 @@ def imaging_distortion(input_model, reference_files):
     dist = DistortionModel(reference_files['distortion'])
     distortion = dist.model
     try:
+        # Check if the model has a bounding box.
         distortion.bounding_box
     except NotImplementedError:
         shape = input_model.data.shape
-        # Note: Since bounding_box is attached to the model here it's in reverse order.
-        distortion.bounding_box = ((-0.5, shape[0] - 0.5),
-                                  (-0.5, shape[1] - 0.5))
+        # Note: Since bounding_box is attached to the model here
+        # it's in reverse order.
+        # If the input is a CubeModel, need to set bbox to the                                                                   
+        # size of 2nd and 3rd dimension.                                                                                          
+        if isinstance(input_model, CubeModel):
+            bb = ((-0.5, shape[1] - 0.5),
+                  (-0.5, shape[2] - 0.5))
+        elif isinstance(input_model, ImageModel):
+            bb = ((-0.5, shape[0] - 0.5),
+                  (-0.5, shape[1] - 0.5))
+        else:
+            raise TypeError("Input is not an ImageModel or CubeModel")
+        distortion.bounding_box = bb
+
     dist.close()
     return distortion
 


### PR DESCRIPTION
For a stack of images when the WCS bounding box is retrieved from the shape of the data it should still have length 2 because the input coordinate frame has 2 axes.