### PR TITLE
Nirspec bug fixes

### DIFF
--- a/jwst/transforms/models.py
+++ b/jwst/transforms/models.py
@@ -294,9 +294,9 @@ class RefractionIndexFromPrism(Model):
         super(RefractionIndexFromPrism, self).__init__(prism_angle=prism_angle, name=name)
 
     def evaluate(self, alpha_in, beta_in, alpha_out, prism_angle):
-        sangle = (math.sin(prism_angle)) ** 2
-        cangle = (math.cos(prism_angle)) ** 2
-        nsq = ((alpha_out + alpha_in * (1 - 2 * sangle)) / (2 * sangle * cangle)) **2 + \
+        sangle = (math.sin(prism_angle))
+        cangle = (math.cos(prism_angle))
+        nsq = ((alpha_out + alpha_in * (1 - 2 * sangle**2)) / (2 * sangle * cangle)) **2 + \
             alpha_in ** 2 + beta_in ** 2
         return np.sqrt(nsq)
 


### PR DESCRIPTION
This requires a bugfix in astropy and should be merged after astropy/astropy#7411 is merged.

There are three substantial changes in this PR:

- The computation of slit-y positions was done through fitting a line. This is now replaced 
   by linear interpolation.
- Similarly a relationship `lambda(n)`  was established by fitting a line. Now this is replaced with interpolation.
- The equation computing the refraction index from angles was changed to match the one in the  IDT team code.

This improves the prism wavelength computation by several orders of magnitude. 
