### PR TITLE
Skip nis_wfss_spec2 regtest via runslow [skip ci]

### DIFF
--- a/jwst/tests_nightly/general/pipelines/test_nis_wfss_spec2.py
+++ b/jwst/tests_nightly/general/pipelines/test_nis_wfss_spec2.py
@@ -9,7 +9,8 @@ pytestmark = [
                        reason='requires --bigdata')
 ]
 
-
+@pytest.mark.skipif(not pytest.config.getoption('--runslow'),
+                    reason="requires --runslow; (>4hr)")
 def test_nis_wfss_spec2(_bigdata):
     """
     Regression test of calwebb_spec2 pipeline performed on NIRISS WFSS data.


### PR DESCRIPTION
This test takes a long time to run, and it is currently not running on the Pandokia/SVN side.  I'm setting it to skip if the `--runslow` option is not used.