### PR TITLE
Allow one or two of the NIRSpec flat fields to be missing.

### DIFF
--- a/jwst/flatfield/flat_field_step.py
+++ b/jwst/flatfield/flat_field_step.py
@@ -78,12 +78,21 @@ class FlatFieldStep(Step):
                                         'sflat')
             self.d_flat_filename = self.get_reference_file(input_model,
                                         'dflat')
-            self.log.debug('Using FFLAT reference file: %s',
-                           self.f_flat_filename)
-            self.log.debug('Using SFLAT reference file: %s',
-                           self.s_flat_filename)
-            self.log.debug('Using DFLAT reference file: %s',
-                           self.d_flat_filename)
+            if self.f_flat_filename == 'N/A':
+                self.log.info('There is no FFLAT reference file.')
+            else:
+                self.log.debug('Using FFLAT reference file: %s',
+                               self.f_flat_filename)
+            if self.s_flat_filename == 'N/A':
+                self.log.info('There is no SFLAT reference file.')
+            else:
+                self.log.debug('Using SFLAT reference file: %s',
+                               self.s_flat_filename)
+            if self.d_flat_filename == 'N/A':
+                self.log.info('There is no DFLAT reference file.')
+            else:
+                self.log.debug('Using DFLAT reference file: %s',
+                               self.d_flat_filename)
         else:
             self.flat_filename = self.get_reference_file(input_model, 'flat')
             self.f_flat_filename = 'N/A'
@@ -94,11 +103,11 @@ class FlatFieldStep(Step):
         # Check for a valid reference file
         missing = False
         if is_NRS_spectrographic:
-            if (self.f_flat_filename == 'N/A' or
-                self.s_flat_filename == 'N/A' or
+            if (self.f_flat_filename == 'N/A' and
+                self.s_flat_filename == 'N/A' and
                 self.d_flat_filename == 'N/A'):
-                self.log.warning('One or more flat-field reference files '
-                                 'were missing')
+                self.log.warning('None of the three flat-field reference '
+                                 'files was found')
                 missing = True
         else:
             if self.flat_filename == 'N/A':
@@ -111,14 +120,22 @@ class FlatFieldStep(Step):
         # Find out what model to use for the flat field reference file(s).
         if is_NRS_spectrographic:
             flat_model = None
-            if exposure_type == "NRS_MSASPEC":
+            if self.f_flat_filename == 'N/A':
+                f_flat_model = None
+            elif exposure_type == "NRS_MSASPEC":
                 f_flat_model = \
                     datamodels.NirspecQuadFlatModel(self.f_flat_filename)
             else:
                 f_flat_model = \
                     datamodels.NirspecFlatModel(self.f_flat_filename)
-            s_flat_model = datamodels.NirspecFlatModel(self.s_flat_filename)
-            d_flat_model = datamodels.NirspecFlatModel(self.d_flat_filename)
+            if self.s_flat_filename == 'N/A':
+                s_flat_model = None
+            else:
+                s_flat_model = datamodels.NirspecFlatModel(self.s_flat_filename)
+            if self.d_flat_filename == 'N/A':
+                d_flat_model = None
+            else:
+                d_flat_model = datamodels.NirspecFlatModel(self.d_flat_filename)
         else:
             self.log.debug('Opening flat as FlatModel')
             flat_model = datamodels.FlatModel(self.flat_filename)
@@ -136,9 +153,12 @@ class FlatFieldStep(Step):
         # Close the inputs
         input_model.close()
         if is_NRS_spectrographic:
-            f_flat_model.close()
-            s_flat_model.close()
-            d_flat_model.close()
+            if f_flat_model is not None:
+                f_flat_model.close()
+            if s_flat_model is not None:
+                s_flat_model.close()
+            if d_flat_model is not None:
+                d_flat_model.close()
         else:
             flat_model.close()
 
@@ -161,4 +181,3 @@ class FlatFieldStep(Step):
         result.meta.cal_step.flat_field = "SKIPPED"
         input_model.close()
         return result
-


### PR DESCRIPTION
Tests were removed from flat_field_step.py that prohibited the step from running (for spectroscopic data) if any of the three NIRSpec flat fields was missing (meaning that the file name was "N/A").  Now, any one or two of the flat field reference files may be missing.  If no flat field reference file is found, however, this is logged as a warning and the step will be skipped.

In flat_field.py, the main change was to add a test at the beginning of each of `fore_optics_flat`, `spectrograph_flat`, and `detector_flat`.  If the respective `f_flat_model`, `s_flat_model`, or `d_flat_model` is None, the function creates an array of ones for the `f_flat` (`s_flat`, `d_flat`) and returns that array, along with None for the dq array.

See also issue #1914.