### PR TITLE
Fixed TSO3 test and removed pandokia baggage

### DIFF
--- a/jwst/tests_nightly/general/pipelines/test_nrc_tso3_1.py
+++ b/jwst/tests_nightly/general/pipelines/test_nrc_tso3_1.py
@@ -21,28 +21,6 @@ def test_tso3_pipeline1(_bigdata):
     # Define where this test data resides in testing tree
     subdir = 'pipelines/nircam_caltso3/'  # Can NOT start with path separator
 
-    # You need to have a tda dict for:
-    #  - recording information to make FlagOK work
-    #  - recording parameters to the task as attributes
-    global tda
-    tda = {}
-
-    output = [
-        # one dict for each output file to compare (i.e. each <val>)
-        {
-            'file'      : 'jw93065-a3001_t1_nircam_f150w-wlp8_phot.ecsv',
-            'reference' : os.path.join(_bigdata,subdir,'jw93065-a3001_t1_nircam_f150w-wlp8_phot_ref.ecsv'),
-            'comparator': 'diff',
-            'args'      : {},
-        }
-    ]
-
-    try:
-        os.remove("jw93065002001_02101_00001_nrca1_a3001_crfints.fits")
-        os.remove("jw93065-a3001_t1_nircam_f150w-wlp8_phot.ecsv")
-    except Exception:
-        pass
-
     # Run pipeline step...
     asn_file = os.path.join(_bigdata, subdir,
                             "jw93065-a3001_20170511t111213_tso3_001_asn.json")
@@ -77,10 +55,6 @@ def test_tso3_pipeline1(_bigdata):
     result = perform_FITS_comparison(fname, refname, extn_list=extn_list)
     assert result.identical, result.report()
 
-    # compare the output files - use this exact command
-    # DISABLED
-    # filecomp.compare_files(output, (__file__, testname), tda=tda,)
-
 
 def test_tso3_pipeline2(_bigdata):
     """Regression test of calwebb_tso3 pipeline on NIRCam simulated data.
@@ -92,32 +66,29 @@ def test_tso3_pipeline2(_bigdata):
     # Define where this test data resides in testing tree
     subdir = 'pipelines/nircam_caltso3/'  # Can NOT start with path separator
 
-    # You need to have a tda dict for:
-    #  - recording information to make FlagOK work
-    #  - recording parameters to the task as attributes
-    global tda
-    tda = {}
-
-    output = [
-        # one dict for each output file to compare (i.e. each <val>)
-        {
-            'file'      : 'jw93065-a3002_t1_nircam_f150w-wlp8_phot.ecsv',
-            'reference' : os.path.join(_bigdata,subdir,'jw93065-a3002_t1_nircam_f150w-wlp8_phot_ref.ecsv'),
-            'comparator': 'diff',
-            'args'      : {},
-        }
-    ]
-
-    try:
-        os.remove("jw93065002002_02101_00001_nrca1_a3002_crfints.fits")
-        os.remove("jw93065-a3002_t1_nircam_f150w-wlp8_phot.ecsv")
-    except Exception:
-        pass
-
     # Run pipeline step...
     asn_file = os.path.join(_bigdata, subdir,
                             "jw93065-a3002_20170511t111213_tso3_001_asn.json")
-    Tso3Pipeline.call(asn_file)
+    step = Tso3Pipeline()
+    step.scale_detection = True
+    step.outlier_detection.wht_type = 'exptime'
+    step.outlier_detection.pixfrac = 1.0
+    step.outlier_detection.kernel = 'square'
+    step.outlier_detection.fillval = 'INDEF'
+    step.outlier_detection.nlow = 0
+    step.outlier_detection.nhigh = 0
+    step.outlier_detection.maskpt = 0.7
+    step.outlier_detection.grow = 1
+    step.outlier_detection.snr = '4.0 3.0'
+    step.outlier_detection.scale = '0.5 0.4'
+    step.outlier_detection.backg = 0.0
+    step.outlier_detection.save_intermediate_results = False
+    step.outlier_detection.resample_data = False
+    step.outlier_detection.good_bits = 4
+    step.extract_1d.smoothing_length = 0
+    step.extract_1d.bkg_order = 0
+
+    step.run(asn_file)
 
     # Compare level-2c product
     fname = 'jw93065002002_02101_00001_nrca1_a3002_crfints.fits'
@@ -128,10 +99,6 @@ def test_tso3_pipeline2(_bigdata):
 
     result = perform_FITS_comparison(fname, refname, extn_list=extn_list)
     assert result.identical, result.report()
-
-    # compare the output files - use this exact command
-    # DISABLED
-    # filecomp.compare_files(output, (__file__, testname), tda=tda,)
 
 
 # Utility function to simplify FITS comparisons

--- a/jwst/tests_nightly/general/pipelines/test_nrs_msa_spec2.py
+++ b/jwst/tests_nightly/general/pipelines/test_nrs_msa_spec2.py
@@ -34,7 +34,7 @@ def test_nrs_msa_spec2(_bigdata):
     step.extract_1d.save_results = True
     step.extract_1d.smoothing_length = 0
     step.extract_1d.bkg_order = 0
-    step.call(os.path.join(_bigdata+'pipelines',
+    step.call(os.path.join(_bigdata,'pipelines',
                        'F170LP-G235M_MOS_observation-6-c0e0_001_DN_NRS1_mod.fits'),
                        output_file=na, name='Spec2Pipeline')
 


### PR DESCRIPTION
This removes some extraneous pandokia-related baggage from the TSO3 test, while also fixing (based on my testing) the results for the second test defined in this module. 