### PR TITLE
Add CubeModel to assign_wcs imports

### DIFF
--- a/jwst/assign_wcs/fgs.py
+++ b/jwst/assign_wcs/fgs.py
@@ -9,7 +9,7 @@ from gwcs import coordinate_frames as cf
 
 from .util import not_implemented_mode, subarray_transform
 from . import pointing
-from ..datamodels import DistortionModel
+from ..datamodels import (DistortionModel, ImageModel, CubeModel)
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)

--- a/jwst/assign_wcs/niriss.py
+++ b/jwst/assign_wcs/niriss.py
@@ -13,7 +13,9 @@ from ..transforms.models import (NirissSOSSModel,
                                  NIRISSForwardRowGrismDispersion,
                                  NIRISSBackwardGrismDispersion,
                                  NIRISSForwardColumnGrismDispersion)
-from ..datamodels import ImageModel, NIRISSGrismModel, DistortionModel
+from ..datamodels import (ImageModel, NIRISSGrismModel, DistortionModel,
+                          CubeModel)
+
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 


### PR DESCRIPTION
Yesterday's regression tests showed the error:
```
File "/data4/iraf_conda/bldtmp/pMIW/p/envs/dev/lib/python3.5/site-packages/jwst-0.9.3a0.dev176+g5ee05334-py3.5-linux-x86_64.egg/jwst/assign_wcs/fgs.py", line 79, in imaging_distortion
    if isinstance(input_model, CubeModel):

EXCEPTION
Type: NameError
Message: name 'CubeModel' is not defined
```
which is due to updates merged in #1966 that added the use of `CubeModel` and `ImageModel` to a few `assign_wcs` modules, but those modules were not importing `CubeModel` and/or `ImageModel`.