### PR TITLE
Fix both MSA Spec2 tests

### DIFF
--- a/jwst/tests_nightly/general/pipelines/test_nrs_msa_spec2.py
+++ b/jwst/tests_nightly/general/pipelines/test_nrs_msa_spec2.py
@@ -24,9 +24,11 @@ def test_nrs_msa_spec2(_bigdata):
 
     # define primary output name
     na = 'F170LP-G235M_MOS_observation-6-c0e0_001_DN_NRS1_mod_cal.fits'
+    nin = 'F170LP-G235M_MOS_observation-6-c0e0_001_DN_NRS1_mod.fits'
 
     # define step for use in test
     step = Spec2Pipeline()
+    step.output_file = na
     step.save_bsub = False
     step.output_use_model = True
     step.resample_spec.save_results = True
@@ -34,9 +36,7 @@ def test_nrs_msa_spec2(_bigdata):
     step.extract_1d.save_results = True
     step.extract_1d.smoothing_length = 0
     step.extract_1d.bkg_order = 0
-    step.call(os.path.join(_bigdata,'pipelines',
-                       'F170LP-G235M_MOS_observation-6-c0e0_001_DN_NRS1_mod.fits'),
-                       output_file=na, name='Spec2Pipeline')
+    step.run(os.path.join(_bigdata,'pipelines',nin))
 
     nbname = 'f170lp-g235m_mos_observation-6-c0e0_001_dn_nrs1_mod_cal_ref.fits'
     nb = os.path.join(_bigdata,'pipelines', nbname)
@@ -149,7 +149,7 @@ def test_nrs_msa_spec2(_bigdata):
     #                          rtol = 0.00001)
     #assert result.identical, result.report()
 
-    na = 'f170lp-g235m_mos_observation-6-c0e0_001_dn_nrs1_mod_x1d.fits'
+    na = 'F170LP-G235M_MOS_observation-6-c0e0_001_DN_NRS1_mod_x1d.fits'
     nbname = 'f170lp-g235m_mos_observation-6-c0e0_001_dn_nrs1_mod_x1d_ref.fits'
     nb = os.path.join(_bigdata, 'pipelines', nbname)
     h = pf.open(na)

--- a/jwst/tests_nightly/general/pipelines/test_nrs_msa_spec2b.py
+++ b/jwst/tests_nightly/general/pipelines/test_nrs_msa_spec2b.py
@@ -1,5 +1,7 @@
 import os
 import pytest
+import shutil
+
 from astropy.io import fits as pf
 from jwst.pipeline.calwebb_spec2 import Spec2Pipeline
 
@@ -16,17 +18,27 @@ def test_nrs_msa_spec2b(_bigdata):
     including barshadow correction.
 
     """
+    file_in = os.path.join(_bigdata, 'pipelines',
+                       'jw95065_nrs_msaspec_barshadow.fits')
+    # Insure the test can find the MSA shutter file referenced by the input 
+    msa_file = 'jwst_nirspec_shutters_barshadow.fits'
+    msa_ref_in = os.path.join(_bigdata, 'pipelines', msa_file)
+    msa_ref_out = os.path.join(os.path.abspath(os.curdir), msa_file)
+    shutil.copyfile(msa_ref_in, msa_ref_out)
+     
     step = Spec2Pipeline()
     step.output_file='jw95065_nrs_msaspec_barshadow_cal.fits'
-    step.save_bsub = True
+    step.save_bsub = False
     step.save_results = True
+    step.resample_spec.skip = True
     step.resample_spec.save_results = True
     step.cube_build.save_results = True
     step.extract_1d.save_results = True
-    step.run(_bigdata+'/pipelines/jw95065_nrs_msaspec_barshadow.fits')
+    step.run(file_in)
 
     na = 'jw95065_nrs_msaspec_barshadow_cal.fits'
-    nb = _bigdata+'/pipelines/jw95065_nrs_msaspec_barshadow_cal_ref.fits'
+    nb = os.path.join(_bigdata,'pipelines',
+                      'jw95065_nrs_msaspec_barshadow_cal_ref.fits')
     h = pf.open(na)
     href = pf.open(nb)
     newh = pf.HDUList([h['primary'],h['sci',1],h['err',1],h['dq',1],h['relsens',1],
@@ -135,7 +147,8 @@ def test_nrs_msa_spec2b(_bigdata):
     assert result.identical, result.report()
 
     na = 'jw95065_nrs_msaspec_barshadow_x1d.fits'
-    nb = _bigdata+'/pipelines/jw95065_nrs_msaspec_barshadow_x1d_ref.fits'
+    nb = os.path.join(_bigdata,'pipelines',
+                      'jw95065_nrs_msaspec_barshadow_x1d_ref.fits')
     h = pf.open(na)
     href = pf.open(nb)
     newh = pf.HDUList([h['primary'],h['extract1d',1],h['extract1d',2],h['extract1d',3],h['extract1d',4],h['extract1d',5],h['extract1d',6],h['extract1d',7],h['extract1d',8],h['extract1d',9],h['extract1d',10]])


### PR DESCRIPTION
This addresses the problem with finding the MSAREF file specified in the input file, as well as the incorrect syntax used to start the pipeline (needs .run() instead of .call()).  As a result, both MSA_SPEC2 tests should now run correctly.  

One consequence of this change is that the MSAREF file for the test needs to be moved from the test definition directory to the input data directory.  In the meantime, an issue should be filed to document this problem and spur some thought on a possible solution for the entire pipeline.