### PR TITLE
Fix pipelines for regtests

### DIFF
--- a/jwst/tests_nightly/general/pipelines/test_coron3_1.py
+++ b/jwst/tests_nightly/general/pipelines/test_coron3_1.py
@@ -19,30 +19,10 @@ def test_coron3_pipeline1(_bigdata):
     asn_file = os.path.join(subdir, asn_name)
     override_psfmask = os.path.join(subdir, 'jwst_nircam_psfmask_somb.fits')
 
-    step = Coron3Pipeline()
-    step.align_refs.override_psfmask = override_psfmask
-    step.outlier_detection.wht_type = 'exptime'
-    step.outlier_detection.pixfrac = 1.0
-    step.outlier_detection.kernel = 'square'
-    step.outlier_detection.fillval = 'INDEF'
-    step.outlier_detection.nlow = 0
-    step.outlier_detection.nhigh = 0
-    step.outlier_detection.maskpt = 0.7
-    step.outlier_detection.grow = 1
-    step.outlier_detection.snr = '4.0 3.0'
-    step.outlier_detection.scale = '0.5 0.4'
-    step.outlier_detection.backg = 0.0
-    step.outlier_detection.save_intermediate_results = False
-    step.outlier_detection.resample_data = False
-    step.outlier_detection.good_bits = 4
-    step.resample.single = False
-    step.resample.wht_type = 'exptime'
-    step.resample.pixfrac = 1.0
-    step.resample.kernel = 'square'
-    step.resample.fillval = 'INDEF'
-    step.resample.good_bits = 4
-    step.resample.blendheaders = True
-    step.run(asn_file)
+    pipe = Coron3Pipeline()
+    pipe.align_refs.override_psfmask = override_psfmask
+    pipe.outlier_detection.resample_data = False
+    pipe.run(asn_file)
 
     # Compare psfstack product
     n_cur = 'jw99999-a3001_t1_nircam_f140m-maskbar_psfstack.fits'

--- a/jwst/tests_nightly/general/pipelines/test_fgs_sloper_1.py
+++ b/jwst/tests_nightly/general/pipelines/test_fgs_sloper_1.py
@@ -11,20 +11,27 @@ pytestmark = [
 
 def test_fgs_detector1_1(_bigdata):
     """
-
     Regression test of calwebb_detector1 pipeline performed on FGS imaging mode data.
-
     """
+    pipe = Detector1Pipeline()
+    pipe.ipc.skip = True
+    pipe.refpix.odd_even_columns = True
+    pipe.refpix.use_side_ref_pixels = True
+    pipe.refpix.side_smoothing_length = 11
+    pipe.refpix.side_gain = 1.0
+    pipe.refpix.odd_even_rows = True
+    pipe.jump.rejection_threshold = 250.0
+    pipe.persistence.skip = True
+    pipe.ramp_fit.save_opt = False
+    pipe.save_calibrated_ramp = True
 
-    Detector1Pipeline.call(_bigdata+'/fgs/test_sloperpipeline/jw86500007001_02101_00001_GUIDER2_uncal.fits',
-                           save_calibrated_ramp=True,
-                           output_file='jw86500007001_02101_00001_GUIDER2_rate.fits')
+    pipe.run(_bigdata+'/fgs/test_sloperpipeline/jw86500007001_02101_00001_GUIDER2_uncal.fits')
 
     # Compare calibrated ramp product
     n_cr = 'jw86500007001_02101_00001_GUIDER2_ramp.fits'
-    h = pf.open( n_cr )
+    h = pf.open(n_cr)
     n_ref = _bigdata+'/fgs/test_sloperpipeline/jw86500007001_02101_00001_GUIDER2_ramp_ref.fits'
-    href = pf.open( n_ref )
+    href = pf.open(n_ref)
     newh = pf.HDUList([h['primary'],h['sci'],h['err'],h['groupdq'],h['pixeldq']])
     newhref = pf.HDUList([href['primary'],href['sci'],href['err'],href['groupdq'],href['pixeldq']])
     result = pf.diff.FITSDiff(newh,
@@ -36,9 +43,9 @@ def test_fgs_detector1_1(_bigdata):
 
     # Compare multi-integration countrate image product
     n_int = 'jw86500007001_02101_00001_GUIDER2_rateints.fits'
-    h = pf.open( n_int )
+    h = pf.open(n_int)
     n_ref = _bigdata+'/fgs/test_sloperpipeline/jw86500007001_02101_00001_GUIDER2_rateints_ref.fits'
-    href = pf.open( n_ref )
+    href = pf.open(n_ref)
     newh = pf.HDUList([h['primary'],h['sci'],h['err'],h['dq']])
     newhref = pf.HDUList([href['primary'],href['sci'],href['err'],href['dq']])
     result = pf.diff.FITSDiff(newh,
@@ -50,9 +57,9 @@ def test_fgs_detector1_1(_bigdata):
 
     # Compare countrate image product
     n_rate = 'jw86500007001_02101_00001_GUIDER2_rate.fits'
-    h = pf.open( n_rate )
+    h = pf.open(n_rate)
     n_ref = _bigdata+'/fgs/test_sloperpipeline/jw86500007001_02101_00001_GUIDER2_rate_ref.fits'
-    href = pf.open( n_ref )
+    href = pf.open(n_ref)
     newh = pf.HDUList([h['primary'],h['sci'],h['err'],h['dq']])
     newhref = pf.HDUList([href['primary'],href['sci'],href['err'],href['dq']])
     result = pf.diff.FITSDiff(newh,

--- a/jwst/tests_nightly/general/pipelines/test_nirspec_dark.py
+++ b/jwst/tests_nightly/general/pipelines/test_nirspec_dark.py
@@ -11,19 +11,19 @@ pytestmark = [
 
 def test_nirspec_dark_pipeline(_bigdata):
     """
-
     Regression test of calwebb_dark pipeline performed on NIRSpec raw data.
-
     """
-    step = DarkPipeline(name='DarkPipeline')
-    step.suffix = "dark"
-    step.output_file='jw84500013001_02103_00003_NRS1_dark.fits'
-    step.refpix.odd_even_columns = True
-    step.refpix.use_side_ref_pixels = True
-    step.refpix.side_smoothing_length=11
-    step.refpix.side_gain=1.0
+    pipe = DarkPipeline()
+    pipe.suffix = 'dark'
+    pipe.ipc.skip = True
+    pipe.refpix.odd_even_columns = True
+    pipe.refpix.use_side_ref_pixels = True
+    pipe.refpix.side_smoothing_length = 11
+    pipe.refpix.side_gain = 1.0
+    pipe.refpix.odd_even_rows = True
+    pipe.output_file = 'jw84500013001_02103_00003_NRS1_uncal.fits'
 
-    step.run(_bigdata+'/pipelines/jw84500013001_02103_00003_NRS1_uncal.fits')
+    pipe.run(_bigdata+'/pipelines/jw84500013001_02103_00003_NRS1_uncal.fits')
 
     h = pf.open('jw84500013001_02103_00003_NRS1_dark.fits')
     href = pf.open(_bigdata+'/pipelines/jw84500013001_02103_00003_NRS1_dark_ref.fits')

--- a/jwst/tests_nightly/general/pipelines/test_nrc_image3_1.py
+++ b/jwst/tests_nightly/general/pipelines/test_nrc_image3_1.py
@@ -15,58 +15,52 @@ def test_image3_pipeline1(_bigdata):
 
     Regression test of calwebb_image3 pipeline on NIRCam
     simulated long-wave data.
-
     """
+
     subdir = os.path.join(_bigdata, 'pipelines', 'nircam_calimage3')
     ignore_kws = ['DATE', 'CAL_VER', 'CAL_VCS', 'CRDS_VER', 'CRDS_CTX']
 
-    try:
-        os.remove("nrca5_47Tuc_subpix_dither1_newpos_a3001_crf.fits")
-        os.remove("mosaic_long_i2d.fits")
-        os.remove("mosaic_long_cat.ecsv")
-    except:
-        pass
-
     asn_file = os.path.join(subdir, "mosaic_long_asn.json")
-    step = Image3Pipeline()
-    step.tweakreg.skip = True
-    skymethod = 'global+match'
-    step.skymatch.match_down =True
-    step.skymatch.subtract = False
-    step.skymatch.skystat = 'mode'
-    step.skymatch.nclip = 5
-    step.skymatch.lsigma = 4.0
-    step.skymatch.usigma = 4.0
-    step.skymatch.binwidth = 0.1
-    step.outlier_detection.wht_type = 'exptime'
-    step.outlier_detection.pixfrac = 1.0
-    step.outlier_detection.kernel = 'square'
-    step.outlier_detection.fillval = 'INDEF'
-    step.outlier_detection.nlow = 0
-    step.outlier_detection.nhigh = 0
-    step.outlier_detection.maskpt = 0.7
-    step.outlier_detection.grow = 1
-    step.outlier_detection.snr = '4.0 3.0'
-    step.outlier_detection.scale = '0.5 0.4'
-    step.outlier_detection.backg = 0.0
-    step.outlier_detection.save_intermediate_results = False
-    step.outlier_detection.resample_data = True
-    step.outlier_detection.good_bits = 4
-    step.resample.single = False
-    step.resample.wht_type = 'exptime'
-    step.resample.pixfrac = 1.0
-    step.resample.kernel = 'square'
-    step.resample.fillval = 'INDEF'
-    step.resample.good_bits = 4
-    step.resample.blendheaders = True
-    step.source_catalog.kernel_fwhm = 3.
-    step.source_catalog.kernel_xsize = 5.
-    step.source_catalog.kernel_ysize = 5.
-    step.source_catalog.snr_threshold = 3.
-    step.source_catalog.npixels = 50
-    step.source_catalog.deblend = False
 
-    step.run(asn_file)
+    pipe = Image3Pipeline()
+    pipe.tweakreg.skip = True
+    pipe.skymethod = 'global+match'
+    pipe.skymatch.match_down = True
+    pipe.skymatch.subtract = False
+    pipe.skymatch.skystat = 'mode'
+    pipe.skymatch.nclip = 5
+    pipe.skymatch.lsigma = 4.0
+    pipe.skymatch.usigma = 4.0
+    pipe.skymatch.binwidth = 0.1
+    pipe.outlier_detection.wht_type = 'exptime'
+    pipe.outlier_detection.pixfrac = 1.0
+    pipe.outlier_detection.kernel = 'square'
+    pipe.outlier_detection.fillval = 'INDEF'
+    pipe.outlier_detection.nlow = 0
+    pipe.outlier_detection.nhigh = 0
+    pipe.outlier_detection.maskpt = 0.7
+    pipe.outlier_detection.grow = 1
+    pipe.outlier_detection.snr = '4.0 3.0'
+    pipe.outlier_detection.scale = '0.5 0.4'
+    pipe.outlier_detection.backg = 0.0
+    pipe.outlier_detection.save_intermediate_results = False
+    pipe.outlier_detection.resample_data = True
+    pipe.outlier_detection.good_bits = 4
+    pipe.resample.single = False
+    pipe.resample.wht_type = 'exptime'
+    pipe.resample.pixfrac = 1.0
+    pipe.resample.kernel = 'square'
+    pipe.resample.fillval = 'INDEF'
+    pipe.resample.good_bits = 4
+    pipe.resample.blendheaders = True
+    pipe.source_catalog.kernel_fwhm = 3.
+    pipe.source_catalog.kernel_xsize = 5.
+    pipe.source_catalog.kernel_ysize = 5.
+    pipe.source_catalog.snr_threshold = 3.
+    pipe.source_catalog.npixels = 50
+    pipe.source_catalog.deblend = False
+
+    pipe.run(asn_file)
 
     # Compare level-2c product
     n_cur = 'nrca5_47Tuc_subpix_dither1_newpos_a3001_crf.fits'

--- a/jwst/tests_nightly/general/pipelines/test_nrs_ifu_spec2.py
+++ b/jwst/tests_nightly/general/pipelines/test_nrs_ifu_spec2.py
@@ -15,13 +15,13 @@ def test_nrs_ifu_spec2(_bigdata):
     Regression test of calwebb_spec2 pipeline performed on NIRSpec IFU data.
 
     """
-    step = Spec2Pipeline()
-    step.save_bsub = True
-    step.save_results = True
-    step.resample_spec.save_results = True
-    step.cube_build.save_results = True
-    step.extract_1d.save_results = True
-    step.run(_bigdata+'/pipelines/jw95175001001_02104_00001_nrs1_rate.fits')
+    pipe = Spec2Pipeline()
+    pipe.save_bsub = True
+    pipe.save_results = True
+    pipe.resample_spec.save_results = True
+    pipe.cube_build.save_results = True
+    pipe.extract_1d.save_results = True
+    pipe.run(_bigdata+'/pipelines/jw95175001001_02104_00001_nrs1_rate.fits')
 
     na = 'jw95175001001_02104_00001_nrs1_cal.fits'
     nb = _bigdata+'/pipelines/jw95175001001_02104_00001_nrs1_cal_ref.fits'


### PR DESCRIPTION
Fix regression tests for the following pipelines:
- NIRCam coron3
- FGS detector1
- NIRSpec dark
- NIRCam image3
- NIRSpec IFU spec2