### PR TITLE
Strip abspath from reffiles stored in R_* header keywords for override

### DIFF
--- a/jwst/stpipe/step.py
+++ b/jwst/stpipe/step.py
@@ -625,7 +625,7 @@ class Step():
         if override is not None:
             if override.strip() != "":
                 self._reference_files_used.append(
-                    (reference_file_type, abspath(override)))
+                    (reference_file_type, basename(override)))
                 reference_name = override
             else:
                 return ""


### PR DESCRIPTION
Now the overridden reference file stored in the keyword will be

`my_override_reffile.fits`

instead of

`/path/to/my_override_reffile.fits`

This improves portability of testing.