### PR TITLE
Fix straylight typo in log message

### DIFF
--- a/jwst/straylight/straylight_step.py
+++ b/jwst/straylight/straylight_step.py
@@ -58,7 +58,7 @@ class StraylightStep (Step):
                     #det2ab is a RegionsSelector model
                     slices = det2ab.label_mapper.mapper
 
-                    self.log.info(' Region of influence radius (pixels) %62f',self.roi)
+                    self.log.info(' Region of influence radius (pixels) %6.2f',self.roi)
                     self.log.info(' Modified Shepard weighting power %5.2f',self.power)
                 # Do the correction
                     result = straylight.correct_MRS_ModShepard(input_model, 


### PR DESCRIPTION
Change '62f' format to '6.2f' (62 was a little excessive for values that are only in the hundreds!)