### PR TITLE
For extract_1d, find nod/dither offset from xoffset and yoffset

### DIFF
--- a/jwst/extract_1d/extract1d.py
+++ b/jwst/extract_1d/extract1d.py
@@ -107,7 +107,7 @@ def extract1d(image, lambdas, disp_range,
     # Sanity check:  check for extraction limits that are out of bounds,
     # or a lower limit that's above the upper limit (limit curves just
     # swapped, or crossing each other).
-    # Truncate extraction limits that are out of bounds, but log an error.
+    # Truncate extraction limits that are out of bounds, but log a warning.
     shape = image.shape
     for i in range(n_srclim):
         lower = srclim[i][0]
@@ -126,12 +126,12 @@ def extract1d(image, lambdas, disp_range,
                                  " cross each other.")
         del diff
         if np.any(lower < -0.5) or np.any(upper < -0.5):
-            log.error("Source extraction limit extends below -0.5")
+            log.warning("Source extraction limit extends below -0.5")
             srclim[i][0][:] = np.where(lower < -0.5, -0.5, lower)
             srclim[i][1][:] = np.where(upper < -0.5, -0.5, upper)
         upper_limit = float(shape[0]) - 0.5
         if np.any(lower > upper_limit) or np.any(upper > upper_limit):
-            log.error("Source extraction limit extends above %g", upper_limit)
+            log.warning("Source extraction limit extends above %g", upper_limit)
             srclim[i][0][:] = np.where(lower > upper_limit, upper_limit, lower)
             srclim[i][1][:] = np.where(upper > upper_limit, upper_limit, upper)
     for i in range(nbkglim):
@@ -151,12 +151,12 @@ def extract1d(image, lambdas, disp_range,
                                  " cross each other.")
         del diff
         if np.any(lower < -0.5) or np.any(upper < -0.5):
-            log.error("Background limit extends below -0.5")
+            log.warning("Background limit extends below -0.5")
             bkglim[i][0][:] = np.where(lower < -0.5, -0.5, lower)
             bkglim[i][1][:] = np.where(upper < -0.5, -0.5, upper)
         upper_limit = float(shape[0]) - 0.5
         if np.any(lower > upper_limit) or np.any(upper > upper_limit):
-            log.error("Background limit extends above %g", upper_limit)
+            log.warning("Background limit extends above %g", upper_limit)
             bkglim[i][0][:] = np.where(lower > upper_limit, upper_limit, lower)
             bkglim[i][1][:] = np.where(upper > upper_limit, upper_limit, upper)
 


### PR DESCRIPTION
Finding the nod/dither offset by using the WCS function did not work.  An alternative is to use keywords XOFFSET and YOFFSET.  These can't be applied directly, because they are in units of arcseconds in the Ideal coordinate system, not detector pixels.  Method offset_from_offset was added, which gets these offsets and converts to offsets in detector coordinates.  Due to the lack of test data at the present time, however, the computed offset will not actually be applied to the data.  If the offset is not zero, it will be written to the log using DEBUG level, so it can be tested when suitable data become available.

Several calls to log.error were changed to log.warning.

See issue #1894.