### PR TITLE
Define an input API

### DIFF
--- a/docs/jwst/introduction.rst
+++ b/docs/jwst/introduction.rst
@@ -327,10 +327,10 @@ There are two general types of input to any stage: references files
 and data files.  The references files, unless explicitly
 overridden, are provided through CRDS.
 
-The data files, such as the exposure FITS files and associations, are
-all presumed to be co-resident: They will all be located within the
-same directory. This input directory is presumed to be the same as
-where the primary input file is located.
+The input data files - the exposure FITS files, association JSON files
+and input catalogs - are presumed to all be in the same directory as
+the primary input file. Sometimes the primary input is an association
+JSON file, and sometimes it is an exposure FITS file.
 
 Output File Names
 =================

--- a/docs/jwst/introduction.rst
+++ b/docs/jwst/introduction.rst
@@ -320,6 +320,18 @@ logging level designations of `DEBUG`, `INFO`, `WARNING`, `ERROR`, and
 will be displayed.
 
 
+Input Files
+===========
+
+There are two general types of input to any stage: references files
+and data files.  The references files, unless explicitly
+overridden, are provided through CRDS.
+
+The data files, such as the exposure FITS files and associations, are
+all presumed to be co-resident: They will all be located within the
+same directory. This input directory is presumed to be the same as
+where the primary input file is located.
+
 Output File Names
 =================
 

--- a/docs/jwst/stpipe/devel_io_design.rst
+++ b/docs/jwst/stpipe/devel_io_design.rst
@@ -35,6 +35,8 @@ Classes, Methods, Functions
 
     - :meth:`Step.open_model <jwst.stpipe.step.Step.open_model>`: Open
       a `DataModel`
+    - :meth:`Step.load_as_level2_asn`: Open a list or file as Level2 association.
+    - :meth:`Step.load_as_level3_asn`: Open a list or file as Level3 association.
     - :meth:`Step.make_input_path
       <jwst.stpipe.step.Step.make_input_path>`: Create a file name to
       be used as input
@@ -164,6 +166,9 @@ is, among other features, a list-like object where each element is the
 `DataModel` of each member of the association. The `meta.asn_table` is
 populated with the association data structure, allowing direct access
 to the association itself.
+
+To read in a list of files, or an association file, as an association,
+use the `load_as_level2_asn` or `load_as_level3_asn` methods.
 
 Input Source
 ------------

--- a/docs/jwst/stpipe/devel_io_design.rst
+++ b/docs/jwst/stpipe/devel_io_design.rst
@@ -33,8 +33,15 @@ API Summary
 Classes, Methods, Functions
 ---------------------------
 
-    - :meth:`Step.save_model <jwst.stpipe.step.Step.save_model>`: Save a `DataModel` immediately.
-    - :attr:`Step.make_output_path <jwst.stpipe.step.Step._make_output_path>`: Create a file name.
+    - :meth:`Step.open_model <jwst.stpipe.step.Step.open_model>`: Open
+      a `DataModel`
+    - :meth:`Step.make_input_path
+      <jwst.stpipe.step.Step.make_input_path>`: Create a file name to
+      be used as input
+    - :meth:`Step.save_model <jwst.stpipe.step.Step.save_model>`: Save a `DataModel` immediately
+    - :attr:`Step.make_output_path
+      <jwst.stpipe.step.Step._make_output_path>`: Create a file name
+      to be used as output
 
 Design
 ======
@@ -122,33 +129,41 @@ is expected to accept other object types as well.
 
 For JWST-produced code, nearly all `Step`'s primary argument is
 expected to be either a string containing the file path to a data
-file, or a JWST :class:`~jwst.datamodels.DataModel` object. The utility
-function :func:`~jwst.datamodels.open` handles either type of input,
+file, or a JWST :class:`~jwst.datamodels.DataModel` object. The method
+:meth:`~jwst.stpipe.step.Step.open_model` handles either type of input,
 returning a `DataModel` from the specified file or a shallow copy of
-the `DataModel` that was originally passed to it. The code to
-accomplish this looks like::
+the `DataModel` that was originally passed to it. A typical pattern
+for handling input arguments is::
 
   class MyStep(jwst.stpipe.step.Step):
 
       def process(self, input_argument):
 
-          input_model = jwst.datamodels.open(input_argument)
+          input_model = self.open_model(input_argument)
 
           ...
 
 `input_argument` can either be a string containing a path to a data
 file, such as `FITS` file, or a `DataModel` directly.
 
+:meth:`~jwst.stpipe.step.Step.open_model` handles `Step`-specific
+issues, such ensuring consistency of input directory handling.
+
+If some other file type is to be opened, the lower level method
+:meth:`~jwst.stpipe.step.Step.make_input_path` can be used to make a
+`Step`-safe file path.
+
 Input and Associations
 ----------------------
 
 Many of the JWST calibration steps and pipelines expect an
 :ref:`Association <associations>` file as input. When opened with
-:func:`jwst.datamodels.open`, a :class:`~jwst.datamodels.ModelContainer`
-is returned. `ModelContainer` is, among other features, a list-like
-object where each element is the `DataModel` of each member of the
-association. The `meta.asn_table` is populated with the association
-data structure, allowing direct access to the association itself.
+:meth:`~jwst.stpipe.step.Step.open_model`, a
+:class:`~jwst.datamodels.ModelContainer` is returned. `ModelContainer`
+is, among other features, a list-like object where each element is the
+`DataModel` of each member of the association. The `meta.asn_table` is
+populated with the association data structure, allowing direct access
+to the association itself.
 
 Input Source
 ------------

--- a/docs/jwst/stpipe/devel_io_design.rst
+++ b/docs/jwst/stpipe/devel_io_design.rst
@@ -27,8 +27,8 @@ API Summary
       parent `Step` or `Pipeline`. :ref:`[more]<devel_io_substeps_and_output>`
     - `output_use_model`: True to always base output file names on the
       `DataModel.meta.filename` of the `DataModel` being saved.
-    - `input_dir`: The directory where the input files are located.
-      General defined by the primary input file.
+    - `input_dir`: Generally defined by the location of the primary
+      input file unless otherwise specified. 
 
 Classes, Methods, Functions
 ---------------------------
@@ -129,13 +129,13 @@ arguments to expect are the same number of arguments defined by
 However, to facilitate code development and interactive usage, code
 is expected to accept other object types as well.
 
-For JWST-produced code, nearly all `Step`'s primary argument is
-expected to be either a string containing the file path to a data
-file, or a JWST :class:`~jwst.datamodels.DataModel` object. The method
-:meth:`~jwst.stpipe.step.Step.open_model` handles either type of input,
-returning a `DataModel` from the specified file or a shallow copy of
-the `DataModel` that was originally passed to it. A typical pattern
-for handling input arguments is::
+A `Step`'s primary argument is expected to be either a string containing
+the file path to a data file, or a JWST
+:class:`~jwst.datamodels.DataModel` object. The method
+:meth:`~jwst.stpipe.step.Step.open_model` handles either type of
+input, returning a `DataModel` from the specified file or a shallow
+copy of the `DataModel` that was originally passed to it. A typical
+pattern for handling input arguments is::
 
   class MyStep(jwst.stpipe.step.Step):
 
@@ -152,8 +152,8 @@ file, such as `FITS` file, or a `DataModel` directly.
 issues, such ensuring consistency of input directory handling.
 
 If some other file type is to be opened, the lower level method
-:meth:`~jwst.stpipe.step.Step.make_input_path` can be used to make a
-`Step`-safe file path.
+:meth:`~jwst.stpipe.step.Step.make_input_path` can be used to specify
+the input directory location.
 
 Input and Associations
 ----------------------

--- a/docs/jwst/stpipe/devel_io_design.rst
+++ b/docs/jwst/stpipe/devel_io_design.rst
@@ -27,6 +27,8 @@ API Summary
       parent `Step` or `Pipeline`. :ref:`[more]<devel_io_substeps_and_output>`
     - `output_use_model`: True to always base output file names on the
       `DataModel.meta.filename` of the `DataModel` being saved.
+    - `input_dir`: The directory where the input files are located.
+      General defined by the primary input file.
 
 Classes, Methods, Functions
 ---------------------------
@@ -147,6 +149,15 @@ is returned. `ModelContainer` is, among other features, a list-like
 object where each element is the `DataModel` of each member of the
 association. The `meta.asn_table` is populated with the association
 data structure, allowing direct access to the association itself.
+
+Input Source
+------------
+
+In general, all input, except for references files provided by CRDS,
+are expected to be co-resident in the same directory. That directory
+is determined by the directory in which the primary input file
+resides. For programmatic use, this directory is available in the
+`Step.input_dir` attribute.
 
 Output
 ======

--- a/jwst/pipeline/calwebb_ami3.py
+++ b/jwst/pipeline/calwebb_ami3.py
@@ -43,7 +43,7 @@ class Ami3Pipeline(Pipeline):
         log.info('Starting calwebb_ami3')
 
         # Load the input association table
-        asn = LoadAsAssociation.load(input)
+        asn = self.load_as_level3_asn(input)
 
         # We assume there's one final product defined by the
         # association

--- a/jwst/pipeline/calwebb_spec2.py
+++ b/jwst/pipeline/calwebb_spec2.py
@@ -2,7 +2,6 @@
 from collections import defaultdict
 
 from .. import datamodels
-from ..associations.load_as_asn import LoadAsLevel2Asn
 from ..lib.pipe_utils import is_tso
 from ..stpipe import Pipeline
 
@@ -73,7 +72,7 @@ class Spec2Pipeline(Pipeline):
         self.log.info('Starting calwebb_spec2 ...')
 
         # Retrieve the input(s)
-        asn = LoadAsLevel2Asn.load(input, basename=self.output_file)
+        asn = self.load_as_level2_asn(input)
 
         # Each exposure is a product in the association.
         # Process each exposure.
@@ -127,10 +126,7 @@ class Spec2Pipeline(Pipeline):
         science = science[0]
 
         self.log.info('Working on input %s ...', science)
-        if isinstance(science, datamodels.DataModel):
-            input = science
-        else:
-            input = datamodels.open(science)
+        input = self.open_model(science)
         exp_type = input.meta.exposure.type
         tso_mode = is_tso(input)
 

--- a/jwst/pipeline/tests/test_calwebb_spec2.py
+++ b/jwst/pipeline/tests/test_calwebb_spec2.py
@@ -3,6 +3,7 @@
 from glob import glob
 from os import path
 import pytest
+from shutil import copyfile
 
 from .helpers import (
     SCRIPT_DATA_PATH,
@@ -48,23 +49,31 @@ def test_full_run(mk_tmp_dirs):
 
 def test_asn_with_bkg(mk_tmp_dirs):
     tmp_current_path, tmp_data_path, tmp_config_path = mk_tmp_dirs
-    exppath = path.join(DATAPATH, EXPFILE)
+
+    # Setup input folder
+    copyfile(
+        path.join(DATAPATH, EXPFILE),
+        path.join(tmp_data_path, EXPFILE)
+    )
+
+    # Setup the association
     lv2_meta = {
         'program': 'test',
         'target': 'test',
         'asn_pool': 'test',
     }
-    asn = asn_from_list([exppath], rule=DMSLevel2bBase, meta=lv2_meta)
+    asn = asn_from_list([EXPFILE], rule=DMSLevel2bBase, meta=lv2_meta)
     asn['products'][0]['members'].append({
-        'expname': exppath, 'exptype': 'BACKGROUND'
+        'expname': EXPFILE, 'exptype': 'BACKGROUND'
     })
     asn_file, serialized = asn.dump()
-    with open(asn_file, 'w') as fp:
+    asn_path = path.join(tmp_data_path, asn_file)
+    with open(asn_path, 'w') as fp:
         fp.write(serialized)
 
     args = [
         path.join(SCRIPT_DATA_PATH, 'calwebb_spec2_basic.cfg'),
-        asn_file,
+        asn_path,
         '--steps.bkg_subtract.save_results=true'
     ]
 

--- a/jwst/pipeline/tests/test_nis_ami3.py
+++ b/jwst/pipeline/tests/test_nis_ami3.py
@@ -28,10 +28,7 @@ def test_run_full(mk_tmp_dirs):
     """Test a full run"""
     tmp_current_path, tmp_data_path, tmp_config_path = mk_tmp_dirs
 
-    asn_path = update_asn_basedir(
-        path.join(DATAPATH, 'test_lg1_asn.json'),
-        root=DATAPATH
-    )
+    asn_path = path.join(DATAPATH, 'test_lg1_correct_asn.json')
     args = [
         path.join(SCRIPT_DATA_PATH, 'cfgs', 'calwebb_ami3.cfg'),
         asn_path,

--- a/jwst/stpipe/step.py
+++ b/jwst/stpipe/step.py
@@ -892,6 +892,30 @@ class Step():
                 )
         gc.collect()
 
+    def make_input_path(self, file_path):
+        """Create an input path for a given file path
+
+        If `file_path` has no directory path, use `self.input_dir`
+        as the directory path.
+
+        Parameters
+        ----------
+        file_path: str
+            The supplied file path to check and modify.
+
+        Returns
+        -------
+        full_path: str
+            File path using `input_dir` if the input
+            had no directory path.
+        """
+        full_path = file_path
+        original_path, file_name = split(file_path)
+        if not len(original_path):
+            full_path = join(self.input_dir, file_name)
+
+        return full_path
+
     def _set_input_dir(self, args):
         """Set the input directory
 

--- a/jwst/stpipe/step.py
+++ b/jwst/stpipe/step.py
@@ -9,6 +9,7 @@ from os.path import (
     dirname,
     expanduser,
     expandvars,
+    isfile,
     join,
     split,
     splitext,
@@ -47,6 +48,7 @@ class Step():
     skip               = boolean(default=False)      # Skip this step
     suffix             = string(default=None)        # Default suffix for output files
     search_output_file = boolean(default=True)       # Use outputfile define in parent step
+    input_dir          = string(default=None)        # Input directory
     """
 
     # Reference types for both command line override
@@ -352,6 +354,8 @@ class Step():
         self.log.info(
             'Step {0} running with args {1}.'.format(
                 self.name, args))
+
+        self._set_input_dir(args)
 
         try:
             # prefetch truly occurs at the Pipeline (or subclass) level.
@@ -887,6 +891,28 @@ class Step():
                     'Reason:\n{}'.format(item, exception)
                 )
         gc.collect()
+
+    def _set_input_dir(self, args):
+        """Set the input directory
+
+        If sufficient information is at hand, set a value
+        for the attribute `input_dir`.
+
+        Parameters
+        ----------
+        args: list
+            The arguments passed.
+
+        """
+        if self.input_dir is None:
+            self.input_dir = self.search_attr('input_dir', default='')
+            if len(args):
+                try:
+                    if isfile(args[0]):
+                        self.input_dir = split(args[0])[0]
+                except Exception:
+                    # Not a file-checkable object. Ignore.
+                    pass
 
 
 # #########

--- a/jwst/stpipe/step.py
+++ b/jwst/stpipe/step.py
@@ -28,7 +28,7 @@ from . import log
 from .suffix import remove_suffix
 from . import utilities
 from .. import __version_commit__, __version__
-from ..associations.load_as_asn import LoadAsLevel2Asn
+from ..associations.load_as_asn import (LoadAsAssociation, LoadAsLevel2Asn)
 from ..associations.lib.format_template import FormatTemplate
 from ..associations.lib.update_path import update_key_value
 from ..datamodels import (DataModel, ModelContainer)
@@ -957,6 +957,26 @@ class Step():
             Association
         """
         asn = LoadAsLevel2Asn.load(obj, basename=self.output_file)
+        update_key_value(asn, 'expname', (), mod_func=self.make_input_path)
+        return asn
+
+    def load_as_level3_asn(self, obj):
+        """Load object as an association
+
+        Loads the specified object into a Level3 association.
+        If necessary, prepend `Step.input_dir` to all members.
+
+        Parameters
+        ----------
+        obj: object
+            Object to load as a Level3 association
+
+        Returns
+        -------
+        association: jwst.associations.lib.rules_level3_base.DMS_Level3_Base
+            Association
+        """
+        asn = LoadAsAssociation.load(obj)
         update_key_value(asn, 'expname', (), mod_func=self.make_input_path)
         return asn
 

--- a/jwst/stpipe/step.py
+++ b/jwst/stpipe/step.py
@@ -30,6 +30,7 @@ from . import utilities
 from .. import __version_commit__, __version__
 from ..associations.lib.format_template import FormatTemplate
 from ..datamodels import (DataModel, ModelContainer)
+from ..datamodels import open as dm_open
 
 
 class Step():
@@ -892,6 +893,24 @@ class Step():
                 )
         gc.collect()
 
+    def open_model(self, obj):
+        """Open a datamodel
+
+        Primarily a wrapper around `DataModel.open` to
+        handle `Step` peculiarities
+
+        Parameters
+        ----------
+        obj: object
+            The object to open
+
+        Returns
+        -------
+        datamodel: DataModel
+            Object opened as a datamodel
+        """
+        return dm_open(self.make_input_path(obj))
+
     def make_input_path(self, file_path):
         """Create an input path for a given file path
 
@@ -900,19 +919,22 @@ class Step():
 
         Parameters
         ----------
-        file_path: str
+        file_path: str or obj
             The supplied file path to check and modify.
+            If anything other than `str`, the object
+            is simply passed back.
 
         Returns
         -------
-        full_path: str
+        full_path: str or obj
             File path using `input_dir` if the input
             had no directory path.
         """
         full_path = file_path
-        original_path, file_name = split(file_path)
-        if not len(original_path):
-            full_path = join(self.input_dir, file_name)
+        if isinstance(file_path, str):
+            original_path, file_name = split(file_path)
+            if not len(original_path):
+                full_path = join(self.input_dir, file_name)
 
         return full_path
 

--- a/jwst/stpipe/step.py
+++ b/jwst/stpipe/step.py
@@ -28,7 +28,9 @@ from . import log
 from .suffix import remove_suffix
 from . import utilities
 from .. import __version_commit__, __version__
+from ..associations.load_as_asn import LoadAsLevel2Asn
 from ..associations.lib.format_template import FormatTemplate
+from ..associations.lib.update_path import update_key_value
 from ..datamodels import (DataModel, ModelContainer)
 from ..datamodels import open as dm_open
 
@@ -937,6 +939,26 @@ class Step():
                 full_path = join(self.input_dir, file_name)
 
         return full_path
+
+    def load_as_level2_asn(self, obj):
+        """Load object as an association
+
+        Loads the specified object into a Level2 association.
+        If necessary, prepend `Step.input_dir` to all members.
+
+        Parameters
+        ----------
+        obj: object
+            Object to load as a Level2 association
+
+        Returns
+        -------
+        association: jwst.associations.lib.rules_level2_base.DMSLevel2bBase
+            Association
+        """
+        asn = LoadAsLevel2Asn.load(obj, basename=self.output_file)
+        update_key_value(asn, 'expname', (), mod_func=self.make_input_path)
+        return asn
 
     def _set_input_dir(self, args):
         """Set the input directory

--- a/jwst/stpipe/tests/steps/__init__.py
+++ b/jwst/stpipe/tests/steps/__init__.py
@@ -56,7 +56,8 @@ class StepWithModel(Step):
     def process(self, *args):
         from ....datamodels import ImageModel
 
-        model = ImageModel(args[0])
+        input_path = self.make_input_path(args[0])
+        model = ImageModel(input_path)
 
         return model
 

--- a/jwst/stpipe/tests/steps/__init__.py
+++ b/jwst/stpipe/tests/steps/__init__.py
@@ -56,7 +56,7 @@ class StepWithModel(Step):
     def process(self, *args):
         from ....datamodels import ImageModel
 
-        input_path = self.make_input_path(args[0])
+        input_path = self.open_model(args[0])
         model = ImageModel(input_path)
 
         return model

--- a/jwst/stpipe/tests/test_input.py
+++ b/jwst/stpipe/tests/test_input.py
@@ -51,7 +51,6 @@ def test_use_input_dir(mk_tmp_dirs):
 
 def test_fail_input_dir(mk_tmp_dirs):
 
-    input_dir = t_path('data')
     input_file = 'flat.fits'
 
     with pytest.raises(FileNotFoundError):

--- a/jwst/stpipe/tests/test_input.py
+++ b/jwst/stpipe/tests/test_input.py
@@ -1,0 +1,19 @@
+"""Test input directory usage"""
+from os import path
+
+from .util import (mk_tmp_dirs, t_path)
+from ..step import Step
+
+
+def test_default_input_dir(mk_tmp_dirs):
+
+    input_file = t_path('data/flat.fits')
+
+    step = Step.from_cmdline([
+        'jwst.stpipe.tests.steps.StepWithModel',
+        input_file
+    ])
+
+    # Check that `input_dir` is set.
+    input_path = path.split(input_file)[0]
+    assert step.input_dir == input_path

--- a/jwst/stpipe/tests/test_input.py
+++ b/jwst/stpipe/tests/test_input.py
@@ -1,5 +1,6 @@
 """Test input directory usage"""
 from os import path
+import pytest
 
 from .util import (mk_tmp_dirs, t_path)
 from ..step import Step
@@ -31,3 +32,30 @@ def test_set_input_dir(mk_tmp_dirs):
 
     # Check that `input_dir` is set.
     assert step.input_dir == 'junkdir'
+
+
+def test_use_input_dir(mk_tmp_dirs):
+
+    input_dir = t_path('data')
+    input_file = 'flat.fits'
+
+    step = Step.from_cmdline([
+        'jwst.stpipe.tests.steps.StepWithModel',
+        input_file,
+        '--input_dir', input_dir
+    ])
+
+    # Check that `input_dir` is set.
+    assert step.input_dir == input_dir
+
+
+def test_fail_input_dir(mk_tmp_dirs):
+
+    input_dir = t_path('data')
+    input_file = 'flat.fits'
+
+    with pytest.raises(FileNotFoundError):
+        step = Step.from_cmdline([
+            'jwst.stpipe.tests.steps.StepWithModel',
+            input_file,
+        ])

--- a/jwst/stpipe/tests/test_input.py
+++ b/jwst/stpipe/tests/test_input.py
@@ -17,3 +17,17 @@ def test_default_input_dir(mk_tmp_dirs):
     # Check that `input_dir` is set.
     input_path = path.split(input_file)[0]
     assert step.input_dir == input_path
+
+
+def test_set_input_dir(mk_tmp_dirs):
+
+    input_file = t_path('data/flat.fits')
+
+    step = Step.from_cmdline([
+        'jwst.stpipe.tests.steps.StepWithModel',
+        input_file,
+        '--input_dir', 'junkdir'
+    ])
+
+    # Check that `input_dir` is set.
+    assert step.input_dir == 'junkdir'

--- a/jwst/stpipe/tests/test_input.py
+++ b/jwst/stpipe/tests/test_input.py
@@ -2,12 +2,14 @@
 from os import path
 import pytest
 
+from .steps import StepWithModel
 from .util import (mk_tmp_dirs, t_path)
 from ..step import Step
+from ...datamodels import open as dm_open
 
 
 def test_default_input_dir(mk_tmp_dirs):
-
+    """Test defaults"""
     input_file = t_path('data/flat.fits')
 
     step = Step.from_cmdline([
@@ -21,7 +23,7 @@ def test_default_input_dir(mk_tmp_dirs):
 
 
 def test_set_input_dir(mk_tmp_dirs):
-
+    """Simply set the path"""
     input_file = t_path('data/flat.fits')
 
     step = Step.from_cmdline([
@@ -35,7 +37,7 @@ def test_set_input_dir(mk_tmp_dirs):
 
 
 def test_use_input_dir(mk_tmp_dirs):
-
+    """Test with a specified path"""
     input_dir = t_path('data')
     input_file = 'flat.fits'
 
@@ -50,7 +52,7 @@ def test_use_input_dir(mk_tmp_dirs):
 
 
 def test_fail_input_dir(mk_tmp_dirs):
-
+    """Fail with a bad file path"""
     input_file = 'flat.fits'
 
     with pytest.raises(FileNotFoundError):
@@ -58,3 +60,12 @@ def test_fail_input_dir(mk_tmp_dirs):
             'jwst.stpipe.tests.steps.StepWithModel',
             input_file,
         ])
+
+
+def test_input_dir_with_model(mk_tmp_dirs):
+    """Use with an already opened DataModel"""
+    model = dm_open(t_path('data/flat.fits'))
+    step = StepWithModel()
+    step.run(model)
+
+    assert step.input_dir == ''

--- a/jwst/stpipe/tests/test_saving.py
+++ b/jwst/stpipe/tests/test_saving.py
@@ -3,29 +3,13 @@ from glob import glob
 import os
 from os import path
 import shutil
-import tempfile
-
-import pytest
 
 from ..step import Step
+from .util import mk_tmp_dirs
 
 data_fn = 'flat.fits'
 data_fn_path = path.join(path.dirname(__file__), 'data', data_fn)
 data_name, data_ext = path.splitext(data_fn)
-
-
-@pytest.fixture
-def mk_tmp_dirs():
-    tmp_current_path = tempfile.mkdtemp()
-    tmp_data_path = tempfile.mkdtemp()
-    tmp_config_path = tempfile.mkdtemp()
-
-    old_path = os.getcwd()
-    try:
-        os.chdir(tmp_current_path)
-        yield (tmp_current_path, tmp_data_path, tmp_config_path)
-    finally:
-        os.chdir(old_path)
 
 
 def test_make_output_path():

--- a/jwst/stpipe/tests/util.py
+++ b/jwst/stpipe/tests/util.py
@@ -34,6 +34,7 @@ Contains a number of testing utilities.
 import contextlib
 import logging
 import os
+import pytest
 import re
 import tempfile
 
@@ -107,9 +108,34 @@ def match_log(log, expected):
                     fd.write('    {0!r},\n'.format(a))
                 fd.write(']\n')
 
-            raise ValueError(
-                "Logs do not match.\nExpected:\n   '{0}'\nGot:\n   '{1}'\n".format(
-                b, msg))
+            raise ValueError((
+                "Logs do not match."
+                "\nExpected:"
+                "\n   '{0}'"
+                "\nGot:"
+                "\n   '{1}'\n".format(
+                    b, msg
+                )))
+
+
+def t_path(partial_path):
+    """Construction the full path for test files"""
+    test_dir = os.path.dirname(__file__)
+    return os.path.join(test_dir, partial_path)
+
+
+@pytest.fixture
+def mk_tmp_dirs():
+    tmp_current_path = tempfile.mkdtemp()
+    tmp_data_path = tempfile.mkdtemp()
+    tmp_config_path = tempfile.mkdtemp()
+
+    old_path = os.getcwd()
+    try:
+        os.chdir(tmp_current_path)
+        yield (tmp_current_path, tmp_data_path, tmp_config_path)
+    finally:
+        os.chdir(old_path)
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
Create a parallel API for input as already exists for output. 

This PR is intended as proof-of-concept and promote discussion.

Main documentation is found in `devel_io_design.rst`. Conceptually this is under the `Step I/O Design` section of `STPIPE`. The API includes the methods `Step.open_model` and `Step.make_input_path` now exist, mimicking the `save_model` and `make_output_path` methods.

Note: This PR will only apply the API to a specific case, _TBD_. Once vetted, another issue will track the deployment to the rest of the codebase.