### PR TITLE
Only extract an 80x80 subarray, if input is full-frame

### DIFF
--- a/docs/jwst/ami/main.rst
+++ b/docs/jwst/ami/main.rst
@@ -1,6 +1,6 @@
 Tasks in the Package
 ====================
-The Aperture Masking Interferometry (AMI) package currently consists
+The Aperture Masking Interferometry (AMI) pipeline package currently consists
 of three tasks:
 
 1) ``ami_analyze``: apply the LG algorithm to a NIRISS AMI exposure
@@ -17,39 +17,35 @@ CALWEBB_AMI3 Pipeline
 Overview
 --------
 The ``calwebb_ami3`` pipeline module can be used to apply all 3 steps of AMI
-processing to an association (ASN) of AMI exposures. The processing flow through
-the pipeline is as follows:
+processing to an association of AMI exposures. The processing flow through the
+pipeline is as follows:
 
 1) Apply the ``ami_analyze`` step to all products listed in the input
-   association table. Output files will have a product type suffix of ``ami``.
-   There will be one ``ami`` product per input exposure.
+   association table. Output files will have a file name suffix of ``lg``.
 
-2) Apply the ``ami_average`` step to combine the above results for both
-   science target and reference target exposures, if both types exist in the
-   ASN table. If the optional parameter ``save_averages`` is set to true
-   (see below), the results will be saved to output files with a product type
-   suffix of ``amiavg``.
-   There will be one ``amiavg`` product for the science target and one for
-   the reference target.
+2) Apply the ``ami_average`` step to combine the above results for reference
+   target exposures contained in the association. The output file will have a
+   file name suffix of ``lgavgr``.
 
-3) If reference target results exist, apply the ``ami_normalize`` step to the
-   averaged science target result, using the averaged reference target result
-   to do the normalization. The output file will have a product type suffix of
-   ``aminorm``.
+3) Apply the ``ami_average`` step to combine the above results for science
+   target exposures contained in the association. The output file will have
+   a file name suffix of ``lgavgt``.
+
+4) If reference target results exist, apply the ``ami_normalize`` step to the
+   averaged science target result (``lgavgt``), using the averaged reference
+   target result (``lgavgr``) to do the normalization.
+   The output file will have a file name suffix of ``lgnorm``.
 
 Input
 -----
 The only input to the ``calwebb_ami3`` pipeline is the name of a json-formatted
-association file. There is one optional parameter ``save_averages``. If set to
-true, the results of the ``ami_average`` step will be saved to files.
-It is assumed that the
-ASN file will define a single output product for the science target result,
-containing a list of input member file names, for both science target and
-reference target exposures. An example ASN file is shown below.
+association file. There are no optional parameters. It is assumed that the
+ASN file will define a single output product, containing a list of input
+member file names. An example ASN file is shown below.
 
 ::
 
- {"asn_rule": "NIRISS_AMI", "targname": "NGC-3603", "asn_pool": "jw00017_001_01_pool", "program": "00017",
+ {"asn_rule": "AMI", "targname": "NGC-3603", "asn_pool": "jw00017_001_01_pool", "program": "00017",
  "products": [
      {"prodtype": "ami", "name": "jw87003-c1001_t001_niriss_f277w-nrm",
       "members": [
@@ -63,8 +59,8 @@ reference target exposures. An example ASN file is shown below.
  "asn_id": "c1001"}
 
 Note that the ``exptype`` attribute value for each input member is used to
-indicate which files contain science target images and which contain reference
-psf images.
+indicate which files contain science target data and which contain reference
+psf data.
 
 AMI_Analyze
 ===========
@@ -75,12 +71,17 @@ The ``ami_analyze`` step applies the Lacour-Greenbaum (LG) image plane
 modeling algorithm to a NIRISS AMI image.
 The routine computes a number of parameters, including a model fit (and
 residuals) to the image, fringe amplitudes and phases, and closure phases
-and amplitudes.
+and amplitudes.  For a full-frame exposure, instead of using the FULL image,
+a subarray will be extracted to keep the execution time acceptable.  Because the
+AMI observing template allows only SUBARRAY values of FULL or SUB80, the
+extraction from the full-frame exposures will match the location and size of
+the SUB80 subarray.
+
 
 Inputs
 ------
 The ``ami_analyze`` step takes a single input image, in the form of a simple 2D
-ImageModel. There are two optional parameters:
+ImageModel. Their are two optional parameters:
 
 1) ``oversample``: specifies the oversampling factor to be used in the model fit
    (default value = 3)
@@ -106,8 +107,8 @@ AMI_Average
 
 Overview
 --------
-The ``ami_average`` step averages the results of LG processing from the
-``ami_analyze`` step for multiple exposures of a given target. It averages
+The ``ami_average`` step averages the results of LG processing (from the
+``ami_analyze`` step) for multiple exposures of a given target. It averages
 all 8 components of the ``ami_analyze`` output files for all input exposures.
 
 Inputs

--- a/jwst/ami/NRM_consts.py
+++ b/jwst/ami/NRM_consts.py
@@ -2,8 +2,6 @@
 # have been moved here
 #
 
-from __future__ import division
-
 import numpy as np
 
 # Constants used in NRM_Model.py
@@ -17,14 +15,14 @@ phi_nb = np.array([0.028838669455909766, -0.061516214504502634, \
 phi_nb = phi_nb * 4.3e-6 # phi_nb in m
 
 ctrs = np.array([[0.00000000, -2.640000],
-                  [-2.2863100, 0.0000000],
-                  [2.2863100, -1.3200001],
-                  [-2.2863100, 1.3200001],
-                  [-1.1431500, 1.9800000],
-                  [2.2863100, 1.3200001],
-                  [1.1431500, 1.9800000]])
+                 [-2.2863100, 0.0000000],
+                 [2.2863100, -1.3200001],
+                 [-2.2863100, 1.3200001],
+                 [-1.1431500, 1.9800000],
+                 [2.2863100, 1.3200001],
+                 [1.1431500, 1.9800000]])
 
-# Constants in (but not used) in webb_psf.py; included here in case
+# Constants in (but not used) webb_psf.py; included here in case
 #    they will be used
 m_ = 1.0
 mm_ = m_ / 1000.0

--- a/jwst/ami/__init__.py
+++ b/jwst/ami/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from .ami_analyze_step import AmiAnalyzeStep
 from .ami_average_step import AmiAverageStep
 from .ami_normalize_step import AmiNormalizeStep

--- a/jwst/ami/ami_average.py
+++ b/jwst/ami/ami_average.py
@@ -1,9 +1,6 @@
-from __future__ import division
-
 #
 #  Module for averaging LG results for a set of AMI exposures
 #
-
 import logging
 from .. import datamodels
 
@@ -26,14 +23,13 @@ def average_LG(lg_products):
     -------
     output_model: Fringe model object
         Averaged fringe data
-
     """
 
     # Create the ouput model as a copy of the first input model
     log.debug(' Create output as copy of %s', lg_products[0])
     output_model = datamodels.AmiLgModel(lg_products[0]).copy()
 
-    # Loop over the remaining list of inputs, adding their values to the output
+    # Loop over remaining list of inputs, adding their values to the output
     for file in lg_products[1:]:
 
         log.debug(' Accumulate data from %s', file)
@@ -41,11 +37,16 @@ def average_LG(lg_products):
 
         output_model.fit_image += prod.fit_image
         output_model.resid_image += prod.resid_image
-        output_model.closure_amp_table['coeffs'] += prod.closure_amp_table['coeffs']
-        output_model.closure_phase_table['coeffs'] += prod.closure_phase_table['coeffs']
-        output_model.fringe_amp_table['coeffs'] += prod.fringe_amp_table['coeffs']
-        output_model.fringe_phase_table['coeffs'] += prod.fringe_phase_table['coeffs']
-        output_model.pupil_phase_table['coeffs'] += prod.pupil_phase_table['coeffs']
+        output_model.closure_amp_table['coeffs'] += \
+                     prod.closure_amp_table['coeffs']
+        output_model.closure_phase_table['coeffs'] += \
+                     prod.closure_phase_table['coeffs']
+        output_model.fringe_amp_table['coeffs'] += \
+                     prod.fringe_amp_table['coeffs']
+        output_model.fringe_phase_table['coeffs'] += \
+                     prod.fringe_phase_table['coeffs']
+        output_model.pupil_phase_table['coeffs'] += \
+                     prod.pupil_phase_table['coeffs']
         output_model.solns_table['coeffs'] += prod.solns_table['coeffs']
 
         prod.close()

--- a/jwst/ami/ami_normalize.py
+++ b/jwst/ami/ami_normalize.py
@@ -1,12 +1,9 @@
-from __future__ import division
-
 #
 #  Module for normalizing the LG results for a science target by
 #  the LG results for a reference target
 #
 
 import logging
-from .. import datamodels
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
@@ -31,21 +28,16 @@ def normalize_LG(target_model, reference_model):
     -------
     output_model: AmiLgModel data model
         Normalized fringe data for the target
-
     """
 
     # Create the ouput model as a copy of the input target model
     output_model = target_model.copy()
 
     # Apply the normalizations to the target data
-    # output_model.fit_image =
-    # output_model.resid_image =
-    # output_model.closure_amp_table['coeffs'] =
-    output_model.closure_phase_table['coeffs'] -= reference_model.closure_phase_table['coeffs']
-    output_model.fringe_amp_table['coeffs'] /= reference_model.fringe_amp_table['coeffs']
-    # output_model.fringe_phase_table['coeffs'] =
-    # output_model.pupil_phase_table['coeffs'] =
-    # output_model.solns_table['coeffs'] =
+    output_model.closure_phase_table['coeffs'] -= \
+            reference_model.closure_phase_table['coeffs']
+    output_model.fringe_amp_table['coeffs'] /= \
+            reference_model.fringe_amp_table['coeffs']
 
     # Return the normalized target model
     return output_model

--- a/jwst/ami/leastsqnrm.py
+++ b/jwst/ami/leastsqnrm.py
@@ -63,6 +63,27 @@ def rotatevectors(vectors, thetarad):
     return rot_vectors
 
 
+def mas2rad(mas):
+    """
+    Short Summary
+    -------------
+    Convert angle in milli arc-sec to radians
+
+    Parameters
+    ----------
+    mas: float
+        angle in milli arc-sec
+
+    Returns
+    -------
+    rad: float
+        angle in radians
+    """
+
+    rad = mas * (10**(-3)) / (3600 * 180 / np.pi)
+    return rad
+
+
 def rad2mas(rad):
     """
     Short Summary

--- a/jwst/ami/webb_psf.py
+++ b/jwst/ami/webb_psf.py
@@ -1,7 +1,7 @@
-from __future__ import absolute_import, division
 
-import numpy as np
 import logging
+import numpy as np
+
 from . import utils
 from . import NRM_consts
 
@@ -31,7 +31,6 @@ def get_webbpsf_filter(filter_model, specbin=None, trim=False):
     spec - 2D float array
         filter bandpass data: [weight, wavelength_in_microns]
     """
-
     W = 1  # remove confusion - wavelength index
     T = 0  # remove confusion - trans index after reading in...
 
@@ -49,7 +48,7 @@ def get_webbpsf_filter(filter_model, specbin=None, trim=False):
     spec = tmp_array[flag, :]
 
     # rebin as desired - fewer wavelengths for debugging quickly
-    if specbin:
+    if specbin is not None:
         smallshape = spec.shape[0] // specbin
 
         log.debug(' bin filter data by %d from %d to %d', specbin,


### PR DESCRIPTION
Update ami_analyze to always extract an 80x80 subarray from full-frame data. This is equivalent to the user using the SUB80 subarray in the first place, so the subarray matches the location and size of the SUB80 subarray. Updated docs. This addresses github issue #1837.