### PR TITLE
Fix some model_blender issues in cube_build

### DIFF
--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -684,7 +684,12 @@ class IFUCubeData(object):
         IFUCube.update(self.input_models[j])
         IFUCube.meta.filename = self.output_name
         
-        self.blend_output_metadata(IFUCube)
+        # Call model_blender if there are multiple inputs
+        if len(self.input_models) > 1:
+            saved_model_type = IFUCube.meta.model_type
+            self.blend_output_metadata(IFUCube)
+            IFUCube.meta.model_type = saved_model_type  # Reset to original
+
 #______________________________________________________________________
         if self.output_type == 'single':
             with datamodels.open(self.input_models[j]) as input:

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -685,10 +685,10 @@ class IFUCubeData(object):
         IFUCube.meta.filename = self.output_name
         
         # Call model_blender if there are multiple inputs
-        if len(self.input_models) > 1:
-            saved_model_type = IFUCube.meta.model_type
-            self.blend_output_metadata(IFUCube)
-            IFUCube.meta.model_type = saved_model_type  # Reset to original
+        #if len(self.input_models) > 1:
+        #    saved_model_type = IFUCube.meta.model_type
+        #    self.blend_output_metadata(IFUCube)
+        #    IFUCube.meta.model_type = saved_model_type  # Reset to original
 
 #______________________________________________________________________
         if self.output_type == 'single':

--- a/jwst/datamodels/schemas/core.schema.yaml
+++ b/jwst/datamodels/schemas/core.schema.yaml
@@ -358,7 +358,7 @@ properties:
             fits_keyword: MODULE
             blend_table: True
           channel:
-            title: 'MIRI channel: long or short'
+            title: 'NIRCam channel: long or short'
             type: string
             enum: [LONG, SHORT, '12', '34', '1', '2', '3', '4', ANY, N/A, '1234', '123', '234']
             fits_keyword: CHANNEL

--- a/jwst/datamodels/schemas/keyword_band.schema.yaml
+++ b/jwst/datamodels/schemas/keyword_band.schema.yaml
@@ -9,5 +9,5 @@ properties:
           band:
             title: MRS wavelength band
             type: string
-            enum: [SHORT, MEDIUM, LONG, N/A, ANY]
+            enum: [SHORT, MEDIUM, LONG, N/A, ANY, MULTIPLE]
             fits_keyword: BAND

--- a/jwst/datamodels/schemas/keyword_filter.schema.yaml
+++ b/jwst/datamodels/schemas/keyword_filter.schema.yaml
@@ -15,5 +15,5 @@ properties:
               F212N, F227W, F2300C, F250M, F2550W, F2550WR, F277W, F290LP, F300M,
               F322W2, F335M, F356W, F360M, F380M, F410M, F430M, F444W,
               F460M, F480M, F560W, F770W, FLENS, FND, FNDP750L, GR150C,
-              GR150R, OPAQUE, P750L, WL3, WLP4, N/A]
+              GR150R, OPAQUE, P750L, WL3, WLP4, N/A, MULTIPLE]
             fits_keyword: FILTER

--- a/jwst/datamodels/schemas/keyword_grating.schema.yaml
+++ b/jwst/datamodels/schemas/keyword_grating.schema.yaml
@@ -9,5 +9,5 @@ properties:
           grating:
             title: Name of the grating element used
             type: string
-            enum: [G140M, G235M, G395M, G140H, G235H, G395H, PRISM, MIRROR, N/A, ANY]
+            enum: [G140M, G235M, G395M, G140H, G235H, G395H, PRISM, MIRROR, N/A, ANY, MULTIPLE]
             fits_keyword: GRATING


### PR DESCRIPTION
Several fixes related to the recent implementation of model_blender in cube_build:
 - Updated the cube_build step itself to only call model_blender when there are multiple inputs. It still leaves in place the error associated with input file names not being in the working directory (@hack is working on a parallel fix for that).
 - Changed the comment string on the `CHANNEL` keyword back to its original value, just to avoid a whole lot of regression tests showing differences. It needs to be updated some time in the future, but not right now.
 - Added `MULTIPLE` as an allowed value to the keyword-specific schemas for `FILTER`, `BAND`, and `GRATING`, as was done recently for those keywords in the core schema. So now they're in sync again.
