### PR TITLE
Use models to call blendmodels

### DIFF
--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -685,10 +685,10 @@ class IFUCubeData(object):
         IFUCube.meta.filename = self.output_name
         
         # Call model_blender if there are multiple inputs
-        #if len(self.input_models) > 1:
-        #    saved_model_type = IFUCube.meta.model_type
-        #    self.blend_output_metadata(IFUCube)
-        #    IFUCube.meta.model_type = saved_model_type  # Reset to original
+        if len(self.input_models) > 1:
+            saved_model_type = IFUCube.meta.model_type
+            self.blend_output_metadata(IFUCube)
+            IFUCube.meta.model_type = saved_model_type  # Reset to original
 
 #______________________________________________________________________
         if self.output_type == 'single':
@@ -873,9 +873,8 @@ class IFUCubeData(object):
 
         """Create new output metadata based on blending all input metadata."""
         # Run fitsblender on output product
-        input_list = [i.meta.filename for i in self.input_models]
         output_file = IFUCube.meta.filename
 
         log.info('Blending metadata for {}'.format(output_file))
-        blendmeta.blendmodels(IFUCube, inputs=input_list,
+        blendmeta.blendmodels(IFUCube, inputs=self.input_models,
                               output=output_file)

--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -128,11 +128,10 @@ class ResampleData:
     def blend_output_metadata(self, output_model):
         """Create new output metadata based on blending all input metadata."""
         # Run fitsblender on output product
-        input_list = [i.meta.filename for i in self.input_models]
         output_file = output_model.meta.filename
 
         log.info('Blending metadata for {}'.format(output_file))
-        blendmeta.blendmodels(output_model, inputs=input_list,
+        blendmeta.blendmodels(output_model, inputs=self.input_models,
                               output=output_file)
 
     def do_drizzle(self):


### PR DESCRIPTION
Changes implemented include:
- calling blendmodels in resample and ifu_cube with already opened model instances instead of filenames
- turning on blendmodels use again for ifu_cube

These changes should correct the ERRORS seen in the regression tests on 10-May-2018 and 11-May-2018 due to files not being found.  
This PR should only be merged AFTER PR #2023 has been merged in order to avoid problems with array-based metadata during blending.