### PR TITLE
Add additional information to validation error message

### DIFF
--- a/jwst/datamodels/fits_support.py
+++ b/jwst/datamodels/fits_support.py
@@ -461,11 +461,11 @@ def _load_from_schema(hdulist, schema, tree, context):
                 ctx.get('hdu_index'), known_keywords)
 
             if result is None:
-                util.validate_schema(result, schema,
+                util.validate_schema(path, result, schema,
                                      context._pass_invalid_values,
                                      context._strict_validation)
             else:
-                if util.validate_schema(result, schema,
+                if util.validate_schema(path, result, schema,
                                         context._pass_invalid_values,
                                         context._strict_validation):
                     properties.put_value(path, result, tree)
@@ -476,11 +476,11 @@ def _load_from_schema(hdulist, schema, tree, context):
                 hdulist, schema, ctx.get('hdu_index'), known_datas)
 
             if result is None:
-                util.validate_schema(result, schema,
+                util.validate_schema(path, result, schema,
                                      context._pass_invalid_values,
                                      context._strict_validation)
             else:
-                if util.validate_schema(result, schema,
+                if util.validate_schema(path, result, schema,
                                         context._pass_invalid_values,
                                         context._strict_validation):
                     properties.put_value(path, result, tree)

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -314,7 +314,7 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         """
         Re-validate the model instance againsst its schema
         """
-        util.validate_schema(self._instance, self._schema,
+        util.validate_schema(str(self), self._instance, self._schema,
                              self._pass_invalid_values,
                              self._strict_validation)
 
@@ -506,7 +506,7 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         """
         schema = {'allOf': [self._schema, new_schema]}
         self._schema = mschema.flatten_combiners(schema)
-        self._validate()
+        self.validate()
         return self
 
     def add_schema_entry(self, position, new_schema):

--- a/jwst/datamodels/ndmodel.py
+++ b/jwst/datamodels/ndmodel.py
@@ -16,7 +16,7 @@ from . import properties
 #---------------------------------------
 # astropy.io.registry compatibility
 #---------------------------------------
- 
+
 def identify(origin, path, fileobj, *args, **kwargs):
     """
     Identify if file is a DataModel for astropy.io.registry
@@ -38,12 +38,12 @@ def read(data, *args, **kwargs):
     """
     Astropy.io registry compatibility function to wrap util.open
     """
-    
+
     # Translate keyword arguments to those expected by ImageModel
     xargs = {}
     if kwargs.get("mask"):
         xargs["dq"] = kwargs["mask"]
-        
+
     uncertainty = kwargs.get("uncertainty")
     if uncertainty:
         if isinstance(uncertainty, Quantity):
@@ -64,7 +64,7 @@ def read(data, *args, **kwargs):
         data = data.value
     else:
         unit = kwargs.get("unit")
-        
+
     # Create the model using the transformed arguments
     model = util.open(data, **xargs)
 
@@ -78,7 +78,7 @@ def read(data, *args, **kwargs):
 
     if uncertainty_type:
         model.meta.bunit_err = uncertainty_type
-    
+
     return model
 
 def write(data, path, *args, **kwargs):
@@ -91,8 +91,8 @@ def write(data, path, *args, **kwargs):
         model = DataModel(data)
     else:
         model = data
-    
-    if isinstance(path, str): 
+
+    if isinstance(path, str):
         model.save(path, *args, **kwargs)
     else:
         raise ValueError("Path to write DataModel was not found")
@@ -122,7 +122,7 @@ class NDModel(nddata_base.NDDataBase):
         Write the stored dataset.
         """
         properties.ObjectNode.__setattr__(self, 'data', value)
-    
+
     @property
     def mask(self):
         """
@@ -207,13 +207,13 @@ class MetaNode(properties.ObjectNode, collections.MutableMapping):
     """
     NDData compatibility class for meta node
     """
-    def __init__(self, instance, schema, ctx):
-        properties.ObjectNode.__init__(self, instance, schema, ctx)
+    def __init__(self, name, instance, schema, ctx):
+        properties.ObjectNode.__init__(self, name, instance, schema, ctx)
 
     def _find(self, path):
         if not path:
             return self
-        
+
         cursor = self._instance
         schema = self._schema
         for attr in path:
@@ -222,8 +222,9 @@ class MetaNode(properties.ObjectNode, collections.MutableMapping):
             except KeyError:
                 raise KeyError("'%s'" % '.'.join(path))
             schema = properties._get_schema_for_property(schema, attr)
-            
-        return properties._make_node(cursor, schema, self._ctx)
+
+        key = '.'.join(path)
+        return properties._make_node(key, cursor, schema, self._ctx)
 
     def __delitem__(self, key):
         path = key.split('.')
@@ -236,7 +237,7 @@ class MetaNode(properties.ObjectNode, collections.MutableMapping):
     def __getitem__(self, key):
         path = key.split('.')
         return self._find(path)
-    
+
     def __len__(self):
         def recurse(val):
             n = 0

--- a/jwst/datamodels/properties.py
+++ b/jwst/datamodels/properties.py
@@ -120,11 +120,11 @@ def _make_default(attr, schema, ctx):
     return None
 
 
-def _make_node(instance, schema, ctx):
+def _make_node(attr, instance, schema, ctx):
     if isinstance(instance, dict):
-        return ObjectNode(instance, schema, ctx)
+        return ObjectNode(attr, instance, schema, ctx)
     elif isinstance(instance, list):
-        return ListNode(instance, schema, ctx)
+        return ListNode(attr, instance, schema, ctx)
     else:
         return instance
 
@@ -166,7 +166,8 @@ def _find_property(schema, attr):
     return find
 
 class Node(object):
-    def __init__(self, instance, schema, ctx):
+    def __init__(self, attr, instance, schema, ctx):
+        self._name = attr
         self._instance = instance
         self._schema = schema
         self._schema['$schema'] = 'http://stsci.edu/schemas/asdf-schema/0.1.0/asdf-schema'
@@ -175,8 +176,8 @@ class Node(object):
     def _validate(self):
         instance = yamlutil.custom_tree_to_tagged_tree(self._instance,
                                                        self._ctx._asdf)
-        return util.validate_schema(instance, self._schema, False,
-                                    self._ctx._strict_validation)
+        return util.validate_schema(self._name, instance, self._schema,
+                                    False, self._ctx._strict_validation)
 
     @property
     def instance(self):
@@ -206,16 +207,17 @@ class ObjectNode(Node):
             if schema == {}:
                 raise AttributeError("No attribute '{0}'".format(attr))
             val = _make_default(attr, schema, self._ctx)
-            self._instance[attr] = val
+            if val is not None:
+                self._instance[attr] = val
 
         if isinstance(val, dict):
             # Meta is special cased to support NDData interface
             if attr == 'meta':
-                node = ndmodel.MetaNode(val, schema, self._ctx)
+                node = ndmodel.MetaNode(attr, val, schema, self._ctx)
             else:
-                node = ObjectNode(val, schema, self._ctx)
+                node = ObjectNode(attr, val, schema, self._ctx)
         elif isinstance(val, list):
-            node = ListNode(val, schema, self._ctx)
+            node = ListNode(attr, val, schema, self._ctx)
         else:
             node = val
 
@@ -230,7 +232,7 @@ class ObjectNode(Node):
                 val = _make_default(attr, schema, self._ctx)
             val = _cast(val, schema)
 
-            node = ObjectNode(val, schema, self._ctx)
+            node = ObjectNode(attr, val, schema, self._ctx)
             if node._validate():
                 self._instance[attr] = val
 
@@ -239,7 +241,7 @@ class ObjectNode(Node):
             del self.__dict__[attr]
         else:
             schema = _get_schema_for_property(self._schema, attr)
-            if not util.validate_schema(None, schema, False,
+            if not util.validate_schema(attr, None, schema, False,
                                         self._ctx._strict_validation):
                 return
 
@@ -287,12 +289,12 @@ class ListNode(Node):
 
     def __getitem__(self, i):
         schema = _get_schema_for_index(self._schema, i)
-        return _make_node(self._instance[i], schema, self._ctx)
+        return _make_node(self._name, self._instance[i], schema, self._ctx)
 
     def __setitem__(self, i, val):
         schema = _get_schema_for_index(self._schema, i)
         val =  _cast(val, schema)
-        node = ObjectNode(val, schema, self._ctx)
+        node = ObjectNode(self._name, val, schema, self._ctx)
         if node._validate():
             self._instance[i] = val
 
@@ -309,7 +311,7 @@ class ListNode(Node):
         else:
             schema_parts = self._schema['items']
         schema = {'type': 'array', 'items': schema_parts}
-        return _make_node(self._instance[i:j], schema, self._ctx)
+        return _make_node(self._name, self._instance[i:j], schema, self._ctx)
 
     def __setslice__(self, i, j, other):
         parts = _unmake_node(other)
@@ -325,21 +327,21 @@ class ListNode(Node):
     def append(self, item):
         schema = _get_schema_for_index(self._schema, len(self._instance))
         item = _cast(item, schema)
-        node = ObjectNode(item, schema, self._ctx)
+        node = ObjectNode(self._name, item, schema, self._ctx)
         if node._validate():
             self._instance.append(item)
 
     def insert(self, i, item):
         schema = _get_schema_for_index(self._schema, i)
         item = _cast(item, schema)
-        node = ObjectNode(item, schema, self._ctx)
+        node = ObjectNode(self._name, item, schema, self._ctx)
         if node._validate():
             self._instance.insert(i, item)
 
     def pop(self, i=-1):
         schema = _get_schema_for_index(self._schema, 0)
         x = self._instance.pop(i)
-        return _make_node(x, schema, self._ctx)
+        return _make_node(self._name, x, schema, self._ctx)
 
     def remove(self, item):
         self._instance.remove(item)
@@ -362,7 +364,8 @@ class ListNode(Node):
 
     def item(self, **kwargs):
         assert isinstance(self._schema['items'], dict)
-        node = ObjectNode(kwargs, self._schema['items'], self._ctx)
+        node = ObjectNode(self._name, kwargs, self._schema['items'],
+                          self._ctx)
         if not node._validate():
             node = None
         return node


### PR DESCRIPTION
This change catches metadata validation errors and adds a line at the start of the error with the name of the attribute being validated. Theline looks like:

    While validating X the following error occurred:

The reason for the additional line is to make it easier to determine the cause of the error.

This change also addresses an error encountered during testing. The code which sets a metadata item to its default value now only does so if the value is not None. It's never correct to set the value to None because this causes the type of the metadata item to be invalid.