### PR TITLE
Updated first frame and last frame steps so if NGROUPS < 4, skip firs…

### DIFF
--- a/jwst/firstframe/firstframe_step.py
+++ b/jwst/firstframe/firstframe_step.py
@@ -6,7 +6,7 @@ from . import firstframe_sub
 class FirstFrameStep(Step):
     """
     FirstFrameStep: This is a MIRI specific task.  If the number of groups
-    is greater than 1, the DO_NOT_USE group data quality flag is added to 
+    is greater than 3, the DO_NOT_USE group data quality flag is added to 
     first group.
     """
 

--- a/jwst/firstframe/firstframe_sub.py
+++ b/jwst/firstframe/firstframe_sub.py
@@ -17,7 +17,7 @@ def do_correction(input_model):
     -------------
     The sole correction is to add the DO_NOT_USE flat to the GROUP data 
     quality flags for the first group, if the number of groups is greater 
-    than 1.
+    than 3.
     
     Parameters
     ----------
@@ -37,9 +37,9 @@ def do_correction(input_model):
     # Create output as a copy of the input science data model
     output = input_model.copy()
 
-    # Update the step status, and if ngroups > 1, set all of the GROUPDQ in
+    # Update the step status, and if ngroups > 3, set all of the GROUPDQ in
     # the first group to 'DO_NOT_USE'
-    if sci_ngroups > 1:
+    if sci_ngroups > 3:
         output.groupdq[:, 0, :, :] = \
             np.bitwise_or(output.groupdq[:,0,:,:], dqflags.group['DO_NOT_USE'])
         log.debug("FirstFrame Sub: resetting GROUPDQ in first frame to DO_NOT_USE")

--- a/jwst/lastframe/lastframe_step.py
+++ b/jwst/lastframe/lastframe_step.py
@@ -6,7 +6,7 @@ from . import lastframe_sub
 class LastFrameStep(Step):
     """
     LastFrameStep: This is a MIRI specific task.  If the number of groups
-    is greater than 1, the GROUP data quality flags for the final group will
+    is greater than 2, the GROUP data quality flags for the final group will
     be set to DO_NOT_USE.
     """
 

--- a/jwst/lastframe/lastframe_sub.py
+++ b/jwst/lastframe/lastframe_sub.py
@@ -16,7 +16,7 @@ def do_correction(input_model):
     Short Summary
     -------------
     The sole correction is to reset to DO_NOT_USE the GROUP data quality flags
-    for the final group, if the number of groups is greater than 1.
+    for the final group, if the number of groups is greater than 2.
     
     Parameters
     ----------
@@ -36,9 +36,9 @@ def do_correction(input_model):
     # Create output as a copy of the input science data model
     output = input_model.copy()
 
-    # Update the step status, and if ngroups > 1, set all of the GROUPDQ in
+    # Update the step status, and if ngroups > 2, set all of the GROUPDQ in
     # the final group to 'DO_NOT_USE'
-    if sci_ngroups > 1:
+    if sci_ngroups > 2:
         output.groupdq[:, -1, :, :] = \
             np.bitwise_or(output.groupdq[:,-1,:,:], dqflags.group['DO_NOT_USE'])
         log.debug("LastFrame Sub: resetting GROUPDQ in last frame to DO_NOT_USE")

--- a/jwst/ramp_fitting/ramp_fit.py
+++ b/jwst/ramp_fitting/ramp_fit.py
@@ -152,7 +152,6 @@ def ols_ramp_fit(model, buffsize, save_opt, readnoise_model, gain_model,
         DM object containing optional OLS-specific ramp fitting data for the
         exposure; this will be None if save_opt is False
     """
-
     tstart = time.time()
 
     # get needed sizes and shapes
@@ -180,8 +179,8 @@ def ols_ramp_fit(model, buffsize, save_opt, readnoise_model, gain_model,
         # Next block is to satisfy github issue 1681:
         # "MIRI FirstFrame and LastFrame minimum number of groups #1681"
         if (ngroups < 2):
-            log.error('MIRI datasets require at least 2 groups/integration')
-            log.error('(NGROUPS), so will not process this dataset.')
+            log.warning('MIRI datasets require at least 2 groups/integration')
+            log.warning('(NGROUPS), so will not process this dataset.')
             return None, None, None
 
     if (ngroups == 1):


### PR DESCRIPTION
…tframe, and if NGROUPS < 3, skip lastframe. See 'Ramp_fit error on MIRI NGROUPS<=2 exposure' #2035, and 'MIRI FirstFrame and LastFrame minimum number of groups' #1681. Changed logging 'error' message to 'warning' in ramp_fit.py