### PR TITLE
In find_dispaxis, regard wavelength = 0 as invalid

### DIFF
--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -342,8 +342,8 @@ def find_dispaxis(input_model, slit, spectral_order, extract_params):
         if np.any(mask):
             wl_array[mask] = np.nan
         del mask
-        dwlx = wl_array[:, 1:-1] - wl_array[:, 0:-2]
-        dwly = wl_array[1:-1, :] - wl_array[0:-2, :]
+        dwlx = wl_array[:, 1:] - wl_array[:, 0:-1]
+        dwly = wl_array[1:, :] - wl_array[0:-1, :]
         dwlx = np.nanmean(dwlx)
         dwly = np.nanmean(dwly)
         log.debug("find_dispaxis, wavelength attribute:  dwlx = %s dwly = %s",
@@ -409,8 +409,8 @@ def find_dispaxis(input_model, slit, spectral_order, extract_params):
                     if np.any(mask):
                         wl_wcs[mask] = np.nan
                     del mask
-                dwlx = wl_wcs[:, 1:-1] - wl_wcs[:, 0:-2]
-                dwly = wl_wcs[1:-1, :] - wl_wcs[0:-2, :]
+                dwlx = wl_wcs[:, 1:] - wl_wcs[:, 0:-1]
+                dwly = wl_wcs[1:, :] - wl_wcs[0:-1, :]
                 dwlx = np.nanmean(dwlx)
                 dwly = np.nanmean(dwly)
         log.debug("find_dispaxis, using wcs:  dwlx = %s dwly = %s",


### PR DESCRIPTION
The `input_model` was added to the calling sequence of `find_dispaxis`, and some information (e.g. exposure type) is gotten from `input_model` rather than from `slit`.  In the section for computing wavelengths from the wcs function, grism data are now supported.

See issue #2031.