### PR TITLE
Fix NIRISS WFSS spec2 regression test

### DIFF
--- a/jwst/pipeline/calwebb_image3.py
+++ b/jwst/pipeline/calwebb_image3.py
@@ -92,7 +92,7 @@ class Image3Pipeline(Pipeline):
 
         try:
             result.meta.asn.pool_name = input_models.meta.asn_table.asn_pool
-            result.meta.asn.table_name = input
+            result.meta.asn.table_name = os.path.basename(input)
             result.meta.filename = input_models.meta.asn_table.products[0].name
         except:
             pass

--- a/jwst/pipeline/calwebb_spec2.py
+++ b/jwst/pipeline/calwebb_spec2.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 from collections import defaultdict
+import os.path as op
 
 from .. import datamodels
 from ..associations.load_as_asn import LoadAsLevel2Asn
@@ -234,7 +235,7 @@ class Spec2Pipeline(Pipeline):
 
         # Record ASN pool and table names in output
         input.meta.asn.pool_name = pool_name
-        input.meta.asn.table_name = asn_file
+        input.meta.asn.table_name = op.basename(asn_file)
 
         # Setup to save the calibrated exposure at end of step.
         self.suffix = 'cal'

--- a/jwst/pipeline/calwebb_tso3.py
+++ b/jwst/pipeline/calwebb_tso3.py
@@ -1,3 +1,5 @@
+import os.path as op
+
 from astropy.table import vstack
 
 from ..stpipe import Pipeline
@@ -135,7 +137,7 @@ class Tso3Pipeline(Pipeline):
             # Update some metadata from the association
             x1d_result.meta.asn.pool_name = \
                 input_models.meta.asn_table.asn_pool
-            x1d_result.meta.asn.table_name = input
+            x1d_result.meta.asn.table_name = op.basename(input)
 
             # Save the final x1d Multispec model
             self.save_model(x1d_result, suffix='x1dints')

--- a/jwst/tests_nightly/general/pipelines/test_nis_wfss_spec2.py
+++ b/jwst/tests_nightly/general/pipelines/test_nis_wfss_spec2.py
@@ -9,52 +9,37 @@ pytestmark = [
                        reason='requires --bigdata')
 ]
 
-@pytest.fixture
-def run_spec2_pipeline_nis_wfss(_bigdata):
-    """Fixture to run the level 2 pipeline for WFSS"""
-    Spec2Pipeline.call(_bigdata+'/pipelines/jw87600-a3001_20171109T145456_spec2_001_asn.json')
-
-
-@pytest.mark.skipif(not pytest.config.getoption('--runslow'),
-                    reason="requires --runslow; (>4hr)")
-def test_nis_wfss_spec2_cal(_bigdata, run_spec2_pipeline_nis_wfss):
+def test_nis_wfss_spec2(_bigdata):
     """
     Regression test of calwebb_spec2 pipeline performed on NIRISS WFSS data.
-    Check the cal file.
     """
+    pipe = Spec2Pipeline()
+    pipe.save_bsub = True
+    pipe.save_results = True
+    pipe.resample_spec.save_results = True
+    pipe.extract_1d.save_results = True
+    pipe.run(_bigdata+'/pipelines/jw87600-a3001_20171109T145456_spec2_001_asn.json')
 
+    # Compare the _cal file
     na = 'jw87600017001_02101_00002_nis_cal.fits'
     nb = _bigdata+'/pipelines/jw87600017001_02101_00002_nis_cal_ref.fits'
     h = pf.open(na)
     href = pf.open(nb)
-    newh = pf.HDUList([h['primary'],h['sci',1],h['err',1],h['dq',1],h['relsens',1],h['wavelength',1],
-                                    h['sci',2],h['err',2],h['dq',2],h['relsens',2],
-                                    h['sci',3],h['err',3],h['dq',3],h['relsens',3],h['wavelength',3]])
-    newhref = pf.HDUList([href['primary'],href['sci',1],href['err',1],href['dq',1],href['relsens',1],href['wavelength',1],
-                                          href['sci',2],href['err',2],href['dq',2],href['relsens',2],
-                                          href['sci',3],href['err',3],href['dq',3],href['relsens',3],href['wavelength',3]])
-    result = pf.diff.FITSDiff(newh, newhref,
+    h = h[:-1]
+    href = href[:-1]
+    result = pf.diff.FITSDiff(h, href,
                               ignore_keywords = ['DATE','CAL_VER','CAL_VCS','CRDS_VER','CRDS_CTX'],
                               rtol = 0.00001)
     assert result.identical, result.report()
 
-
-@pytest.mark.skipif(not pytest.config.getoption('--runslow'),
-                    reason="requires --runslow; (>4hr)")
-def test_nis_wfss_spec2_x1d(_bigdata, run_spec2_pipeline_nis_wfss):
-    """
-    Regression test of calwebb_spec2 pipeline performed on NIRISS WFSS data.
-    Check the x1d file.
-    """
-
+    # Compare the _x1d file
     na = 'jw87600017001_02101_00002_nis_x1d.fits'
     nb = _bigdata+'/pipelines/jw87600017001_02101_00002_nis_x1d_ref.fits'
     h = pf.open(na)
     href = pf.open(nb)
-    newh = pf.HDUList([h['primary'],h['extract1d',1],h['extract1d',2]])
-    newhref = pf.HDUList([href['primary'],href['extract1d',1],href['extract1d',2]])
-    result = pf.diff.FITSDiff(newh, newhref,
+    h = h[:-1]
+    href = href[:-1]
+    result = pf.diff.FITSDiff(h, href,
                               ignore_keywords = ['DATE','CAL_VER','CAL_VCS','CRDS_VER','CRDS_CTX'],
                               rtol = 0.00001)
     assert result.identical, result.report()
-


### PR DESCRIPTION
- Removed the `runslow` marker from the test, as @hbushouse has pruned the input file so that the test runs in a few minutes.  This now enables this test to run on Jenkins.
- Extended the work of #1982 which didn't catch all (or even most) of the instances of `meta.asn.table_name` being populated with a full path in our pipelines.  This test uses the spec2 pipeline, which had this bug.