### PR TITLE
Handle MSA metadata file only in assign_wcs step using Step.input_dir

### DIFF
--- a/jwst/assign_wcs/assign_wcs_step.py
+++ b/jwst/assign_wcs/assign_wcs_step.py
@@ -1,4 +1,5 @@
 #! /usr/bin/env python
+from os.path import join, basename
 from ..stpipe import Step, cmdline
 from .. import datamodels
 import logging
@@ -59,7 +60,12 @@ class AssignWcsStep(Step):
                 reffile = self.get_reference_file(input_model, reftype)
                 reference_file_names[reftype] = reffile if reffile else ""
 
+            # Get the MSA metadata file if needed and add to reffiles
+            msa_metadata_file = input_model.meta.instrument.msa_metadata_file
+            if msa_metadata_file:
+                msa_metadata_file = join(self.input_dir, basename(msa_metadata_file))
+                reference_file_names['msametafile'] = msa_metadata_file
+
             result = load_wcs(input_model, reference_file_names)
 
         return result
-

--- a/jwst/assign_wcs/assign_wcs_step.py
+++ b/jwst/assign_wcs/assign_wcs_step.py
@@ -1,5 +1,4 @@
 #! /usr/bin/env python
-from os.path import join, basename
 from ..stpipe import Step, cmdline
 from .. import datamodels
 import logging
@@ -62,8 +61,8 @@ class AssignWcsStep(Step):
 
             # Get the MSA metadata file if needed and add to reffiles
             msa_metadata_file = input_model.meta.instrument.msa_metadata_file
-            if msa_metadata_file:
-                msa_metadata_file = join(self.input_dir, basename(msa_metadata_file))
+            if msa_metadata_file is not None:
+                msa_metadata_file = self.make_input_path(msa_metadata_file)
                 reference_file_names['msametafile'] = msa_metadata_file
 
             result = load_wcs(input_model, reference_file_names)

--- a/jwst/assign_wcs/nirspec.py
+++ b/jwst/assign_wcs/nirspec.py
@@ -292,7 +292,7 @@ def slitlets_wcs(input_model, reference_files, open_slits_id):
 def get_open_slits(input_model, reference_files=None):
     exp_type = input_model.meta.exposure.type.lower()
     if exp_type == "nrs_msaspec":
-        msa_metadata_file, msa_metadata_id = get_msa_metadata(input_model)
+        msa_metadata_file, msa_metadata_id = get_msa_metadata(input_model, reference_files)
         slits = get_open_msa_slits(msa_metadata_file, msa_metadata_id)
     elif exp_type == "nrs_fixedslit":
         slits = get_open_fixed_slits(input_model)
@@ -338,16 +338,17 @@ def get_open_fixed_slits(input_model):
     return slits
 
 
-def get_msa_metadata(input_model):
+def get_msa_metadata(input_model, reference_files):
     """
     Get the MSA metadata file (MSAMTFL) and the msa metadata id (MSAMETID).
 
     """
-    msa_config = input_model.meta.instrument.msa_metadata_file
-    if msa_config is None:
-        message = "MSA metadata file is not available (keyword MSAMETFL)."
+    try:
+        msa_config = reference_files['msametafile']
+    except KeyError:
+        msa_config = None
+        message = "MSA metadata file is not defined (keyword MSAMETFL)"
         log.critical(message)
-        raise KeyError(message)
     msa_metadata_id = input_model.meta.instrument.msa_metadata_id
     if msa_metadata_id is None:
         message = "MSA metadata ID is not available (keyword MSAMETID)."

--- a/jwst/assign_wcs/nirspec.py
+++ b/jwst/assign_wcs/nirspec.py
@@ -345,10 +345,14 @@ def get_msa_metadata(input_model, reference_files):
     """
     try:
         msa_config = reference_files['msametafile']
-    except KeyError:
-        msa_config = None
-        message = "MSA metadata file is not defined (keyword MSAMETFL)"
-        log.critical(message)
+    except KeyError as error:
+        log.info('MSA metadata file not in reference files dict')
+        log.info('Getting MSA metadata file from MSAMETFL keyword')
+        msa_config = input_model.meta.instrument.msa_metadata_file
+        if msa_config is None:
+            message = "MSA metadata file is not available (keyword MSAMETFL)."
+            log.critical(message)
+            raise KeyError(message)
     msa_metadata_id = input_model.meta.instrument.msa_metadata_id
     if msa_metadata_id is None:
         message = "MSA metadata ID is not available (keyword MSAMETID)."

--- a/jwst/datamodels/schemas/slitdata.schema.yaml
+++ b/jwst/datamodels/schemas/slitdata.schema.yaml
@@ -80,6 +80,18 @@ allOf:
       default: ""
       fits_keyword: SHUTSTA
       fits_hdu: SCI
+    quadrant:
+      title: MSA quadrant for slit
+      type: integer
+      fits_hdu: SCI
+    xcen:
+      title: Center of shutter in MSA coordinates (X dir)
+      type: integer
+      fits_hdu: SCI
+    ycen:
+      title: Center of shutter in MSA coordinates (Y dir)
+      type: integer
+      fits_hdu: SCI
     data:
       title: The science data
       fits_hdu: SCI

--- a/jwst/datamodels/schemas/slitdata.schema.yaml
+++ b/jwst/datamodels/schemas/slitdata.schema.yaml
@@ -83,15 +83,12 @@ allOf:
     quadrant:
       title: MSA quadrant for slit
       type: integer
-      fits_hdu: SCI
     xcen:
       title: Center of shutter in MSA coordinates (X dir)
       type: integer
-      fits_hdu: SCI
     ycen:
       title: Center of shutter in MSA coordinates (Y dir)
       type: integer
-      fits_hdu: SCI
     data:
       title: The science data
       fits_hdu: SCI

--- a/jwst/extract_2d/nirspec.py
+++ b/jwst/extract_2d/nirspec.py
@@ -121,6 +121,9 @@ def set_slit_attributes(output_model, slit, xlo, xhi, ylo, yhi):
         output_model.source_xpos = float(slit.source_xpos)
         output_model.source_ypos = float(slit.source_ypos)
         output_model.slitlet_id = int(slit.name)
+        output_model.quadrant = int(slit.quadrant)
+        output_model.xcen = int(slit.xcen)
+        output_model.ycen = int(slit.ycen)
         # for pathloss correction
         output_model.shutter_state = slit.shutter_state
     log.info('set slit_attributes completed')

--- a/jwst/flatfield/flat_field.py
+++ b/jwst/flatfield/flat_field.py
@@ -278,29 +278,12 @@ def do_NIRSpec_flat_field(output_model,
         interpolated_flats = None
 
     any_updated = False
-    if exposure_type == "NRS_MSASPEC":
-        # This is not the same as output_model.slits; `slits` will be
-        # used a few lines farther down.
-        slits = nirspec.get_open_slits(output_model)
+
     for (k, slit) in enumerate(output_model.slits):
         log.info("Processing slit %s", slit.name)
-        slit_nt = None
+        slit_nt = slit
         flat_2d = np.ones_like(slit.data)       # default values
         flat_dq_2d = np.zeros_like(slit.dq)
-        if exposure_type == "NRS_MSASPEC":
-            # Find this slit in the list of open slits.
-            for j in range(len(slits)):
-                if str(slits[j].name) == slit.name:
-                    slit_nt = slits[j]
-                    break
-            if slit_nt is None:
-                log.error("Couldn't find slit %s in list of open slits; "
-                          "skipping ...", slit.name)
-                populate_interpolated_flats(k, slit,
-                                            interpolated_flats, output_model,
-                                            flat_2d, flat_dq_2d,
-                                            got_wl_attribute=False)
-                continue
 
         # pixels with respect to the original image
         ysize, xsize = slit.data.shape

--- a/jwst/tests_nightly/general/pipelines/test_nrs_msa_spec2.py
+++ b/jwst/tests_nightly/general/pipelines/test_nrs_msa_spec2.py
@@ -16,12 +16,6 @@ def test_nrs_msa_spec2(_bigdata):
     Regression test of calwebb_spec2 pipeline performed on NIRSpec MSA data.
 
     """
-    curdir = os.path.abspath(os.curdir)
-    # copy over input-specific reference files, such as MSA Metadata file
-    msafile = os.path.join(_bigdata, 'pipelines',
-                           'jw95065006001_0_short_msa.fits')
-    shutil.copy(msafile, curdir)
-
     input = 'F170LP-G235M_MOS_observation-6-c0e0_001_DN_NRS1_mod.fits'
 
     # define step for use in test
@@ -35,10 +29,10 @@ def test_nrs_msa_spec2(_bigdata):
     step.extract_1d.bkg_order = 0
     step.run(os.path.join(_bigdata, 'pipelines', input))
 
+    # compare _cal files
     output = 'F170LP-G235M_MOS_observation-6-c0e0_001_DN_NRS1_mod_cal.fits'
     nbname = 'f170lp-g235m_mos_observation-6-c0e0_001_dn_nrs1_mod_cal_ref.fits'
     nb = os.path.join(_bigdata,'pipelines', nbname)
-                      
     h = pf.open(output)
     href = pf.open(nb)
     h = h[:-1]
@@ -46,13 +40,12 @@ def test_nrs_msa_spec2(_bigdata):
     result = pf.diff.FITSDiff(h, href,
                               ignore_keywords = ['DATE','CAL_VER','CAL_VCS','CRDS_VER','CRDS_CTX','FILENAME'],
                               rtol = 0.00001)
-
     assert result.identical, result.report()
 
+    # compare _x1d files
     output2 = 'F170LP-G235M_MOS_observation-6-c0e0_001_DN_NRS1_mod_x1d.fits'
     nbname = 'f170lp-g235m_mos_observation-6-c0e0_001_dn_nrs1_mod_x1d_ref.fits'
     nb = os.path.join(_bigdata, 'pipelines', nbname)
-
     h = pf.open(output2)
     href = pf.open(nb)
     h = h[:-1]
@@ -60,5 +53,4 @@ def test_nrs_msa_spec2(_bigdata):
     result = pf.diff.FITSDiff(h, href,
                               ignore_keywords = ['DATE','CAL_VER','CAL_VCS','CRDS_VER','CRDS_CTX','FILENAME'],
                               rtol = 0.00001)
-
     assert result.identical, result.report()

--- a/jwst/tests_nightly/general/pipelines/test_nrs_msa_spec2b.py
+++ b/jwst/tests_nightly/general/pipelines/test_nrs_msa_spec2b.py
@@ -20,12 +20,7 @@ def test_nrs_msa_spec2b(_bigdata):
     """
     file_in = os.path.join(_bigdata, 'pipelines',
                        'jw95065_nrs_msaspec_barshadow.fits')
-    # Insure the test can find the MSA shutter file referenced by the input 
-    msa_file = 'jwst_nirspec_shutters_barshadow.fits'
-    msa_ref_in = os.path.join(_bigdata, 'pipelines', msa_file)
-    msa_ref_out = os.path.join(os.path.abspath(os.curdir), msa_file)
-    shutil.copyfile(msa_ref_in, msa_ref_out)
-     
+
     step = Spec2Pipeline()
     step.output_file='jw95065_nrs_msaspec_barshadow_cal.fits'
     step.save_bsub = False
@@ -36,93 +31,15 @@ def test_nrs_msa_spec2b(_bigdata):
     step.extract_1d.save_results = True
     step.run(file_in)
 
+    # compare _cal file
     na = 'jw95065_nrs_msaspec_barshadow_cal.fits'
     nb = os.path.join(_bigdata,'pipelines',
                       'jw95065_nrs_msaspec_barshadow_cal_ref.fits')
     h = pf.open(na)
     href = pf.open(nb)
-    newh = pf.HDUList([h['primary'],h['sci',1],h['err',1],h['dq',1],h['relsens',1],
-                                    h['pathloss_pointsource',1],h['wavelength_pointsource',1],
-                                    h['pathloss_uniformsource',1],h['wavelength_uniformsource',1],
-                                    h['barshadow', 1],
-                                    h['sci',2],h['err',2],h['dq',2],h['relsens',2],
-                                    h['pathloss_pointsource',2],h['wavelength_pointsource',2],
-                                    h['pathloss_uniformsource',2],h['wavelength_uniformsource',2],
-                                    h['barshadow', 2],
-                                    h['sci',3],h['err',3],h['dq',3],h['relsens',3],
-                                    h['pathloss_pointsource',3],h['wavelength_pointsource',3],
-                                    h['pathloss_uniformsource',3],h['wavelength_uniformsource',3],
-                                    h['barshadow', 3],
-                                    h['sci',4],h['err',4],h['dq',4],h['relsens',4],
-                                    h['pathloss_pointsource',4],h['wavelength_pointsource',4],
-                                    h['pathloss_uniformsource',4],h['wavelength_uniformsource',4],
-                                    h['barshadow', 4],
-                                    h['sci',5],h['err',5],h['dq',5],h['relsens',5],
-                                    h['pathloss_pointsource',5],h['wavelength_pointsource',5],
-                                    h['pathloss_uniformsource',5],h['wavelength_uniformsource',5],
-                                    h['barshadow', 5],
-                                    h['sci',6],h['err',6],h['dq',6],h['relsens',6],
-                                    h['pathloss_pointsource',6],h['wavelength_pointsource',6],
-                                    h['pathloss_uniformsource',6],h['wavelength_uniformsource',6],
-                                    h['barshadow', 6],
-                                    h['sci',7],h['err',7],h['dq',7],h['relsens',7],
-                                    h['pathloss_pointsource',7],h['wavelength_pointsource',7],
-                                    h['pathloss_uniformsource',7],h['wavelength_uniformsource',7],
-                                    h['barshadow', 7],
-                                    h['sci',8],h['err',8],h['dq',8],h['relsens',8],
-                                    h['pathloss_pointsource',8],h['wavelength_pointsource',8],
-                                    h['pathloss_uniformsource',8],h['wavelength_uniformsource',8],
-                                    h['barshadow', 8],
-                                    h['sci',9],h['err',9],h['dq',9],h['relsens',9],
-                                    h['pathloss_pointsource',9],h['wavelength_pointsource',9],
-                                    h['pathloss_uniformsource',9],h['wavelength_uniformsource',9],
-                                    h['barshadow', 9],
-                                    h['sci',10],h['err',10],h['dq',10],h['relsens',10],
-                                    h['pathloss_pointsource',10],h['wavelength_pointsource',10],
-                                    h['pathloss_uniformsource',10],h['wavelength_uniformsource',10],
-                                    h['barshadow', 10]])
-
-    newhref = pf.HDUList([href['primary'],href['sci',1],href['err',1],href['dq',1],href['relsens',1],
-                                          href['pathloss_pointsource',1],href['wavelength_pointsource',1],
-                                          href['pathloss_uniformsource',1],href['wavelength_uniformsource',1],
-                                          href['barshadow', 1],
-                                          href['sci',2],href['err',2],href['dq',2],href['relsens',2],
-                                          href['pathloss_pointsource',2],href['wavelength_pointsource',2],
-                                          href['pathloss_uniformsource',2],href['wavelength_uniformsource',2],
-                                          href['barshadow', 2],
-                                          href['sci',3],href['err',3],href['dq',3],href['relsens',3],
-                                          href['pathloss_pointsource',3],href['wavelength_pointsource',3],
-                                          href['pathloss_uniformsource',3],href['wavelength_uniformsource',3],
-                                          href['barshadow', 3],
-                                          href['sci',4],href['err',4],href['dq',4],href['relsens',4],
-                                          href['pathloss_pointsource',4],href['wavelength_pointsource',4],
-                                          href['pathloss_uniformsource',4],href['wavelength_uniformsource',4],
-                                          href['barshadow', 4],
-                                          href['sci',5],href['err',5],href['dq',5],href['relsens',5],
-                                          href['pathloss_pointsource',5],href['wavelength_pointsource',5],
-                                          href['pathloss_uniformsource',5],href['wavelength_uniformsource',5],
-                                          href['barshadow', 5],
-                                          href['sci',6],href['err',6],href['dq',6],href['relsens',6],
-                                          href['pathloss_pointsource',6],href['wavelength_pointsource',6],
-                                          href['pathloss_uniformsource',6],href['wavelength_uniformsource',6],
-                                          href['barshadow', 6],
-                                          href['sci',7],href['err',7],href['dq',7],href['relsens',7],
-                                          href['pathloss_pointsource',7],href['wavelength_pointsource',7],
-                                          href['pathloss_uniformsource',7],href['wavelength_uniformsource',7],
-                                          href['barshadow', 7],
-                                          href['sci',8],href['err',8],href['dq',8],href['relsens',8],
-                                          href['pathloss_pointsource',8],href['wavelength_pointsource',8],
-                                          href['pathloss_uniformsource',8],href['wavelength_uniformsource',8],
-                                          href['barshadow', 8],
-                                          href['sci',9],href['err',9],href['dq',9],href['relsens',9],
-                                          href['pathloss_pointsource',9],href['wavelength_pointsource',9],
-                                          href['pathloss_uniformsource',9],href['wavelength_uniformsource',9],
-                                          href['barshadow', 9],
-                                          href['sci',10],href['err',10],href['dq',10],href['relsens',10],
-                                          href['pathloss_pointsource',10],href['wavelength_pointsource',10],
-                                          href['pathloss_uniformsource',10],href['wavelength_uniformsource',10],
-                                          href['barshadow', 10]])
-    result = pf.diff.FITSDiff(newh, newhref,
+    h = h[:-1]
+    href = href[:-1]
+    result = pf.diff.FITSDiff(h, href,
                               ignore_keywords = ['DATE','CAL_VER','CAL_VCS','CRDS_VER','CRDS_CTX'],
                               rtol = 0.00001)
     assert result.identical, result.report()
@@ -146,14 +63,15 @@ def test_nrs_msa_spec2b(_bigdata):
     #                          rtol = 0.00001)
     assert result.identical, result.report()
 
+    # compare _x1d file
     na = 'jw95065_nrs_msaspec_barshadow_x1d.fits'
     nb = os.path.join(_bigdata,'pipelines',
                       'jw95065_nrs_msaspec_barshadow_x1d_ref.fits')
     h = pf.open(na)
     href = pf.open(nb)
-    newh = pf.HDUList([h['primary'],h['extract1d',1],h['extract1d',2],h['extract1d',3],h['extract1d',4],h['extract1d',5],h['extract1d',6],h['extract1d',7],h['extract1d',8],h['extract1d',9],h['extract1d',10]])
-    newhref = pf.HDUList([href['primary'],href['extract1d',1],href['extract1d',2],href['extract1d',3],href['extract1d',4],href['extract1d',5],href['extract1d',6],href['extract1d',7],href['extract1d',8],href['extract1d',9],href['extract1d',10]])
-    result = pf.diff.FITSDiff(newh, newhref,
+    h = h[:-1]
+    href = href[:-1]
+    result = pf.diff.FITSDiff(h, href,
                               ignore_keywords = ['DATE','CAL_VER','CAL_VCS','CRDS_VER','CRDS_CTX'],
                               rtol = 0.00001)
     assert result.identical, result.report()


### PR DESCRIPTION
* Utilize Step.input_dir to find the MSA metadata file
* Move all reading of the MSA metadata file to assign_wcs step
* Store MSA info needed in flat_field step in each slit instead of rereading MSA file
* Update the MultiSlitModel schema to store `quadrant, xcen, ycen` in each slit