### PR TITLE
extract_1d should not repeat log messages for every integration

### DIFF
--- a/docs/jwst/extract_1d/arguments.rst
+++ b/docs/jwst/extract_1d/arguments.rst
@@ -1,7 +1,7 @@
 Step Arguments
 ==============
 
-The extract_1d step has two step-specific arguments.  Currently neither of
+The extract_1d step has three step-specific arguments.  Currently none of
 these is used for IFU data.
 
 *  ``--smoothing_length``
@@ -24,3 +24,17 @@ subtracted from the target data.  ``bkg_order`` = 0 (the minimum allowed
 value) means to fit a constant.  The user-supplied value (if any)
 overrides the value in the reference file.  If neither is specified, a
 value of 0 will be used.
+
+*  ``--log_increment``
+
+Most log messages are suppressed while looping over integrations, i.e. when
+the input is a CubeModel or a 3-D SlitModel.  Messages will be logged while
+processing the first integration, but since they would be the same for
+every integration, most messages will only be written once.  However, since
+there can be hundreds or thousands of integrations, which can take a long
+time to process, it would be useful to log a message every now and then to
+let the user know that the step is still running.
+
+``log_increment`` is an integer, with default value 50.  If it is greater
+than 0, an INFO message will be printed every ``log_increment``
+integrations, e.g. "... 150 integrations done".

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -25,6 +25,10 @@ FILE_TYPE_JSON = "JSON"
 FILE_TYPE_IMAGE = "IMAGE"
 FILE_TYPE_OTHER = "N/A"
 
+# This is to prevent calling offset_from_offset multiple times for
+# multi-integration data.
+OFFSET_NOT_ASSIGNED_YET = "not assigned yet"
+
 # For full-frame input data, keyword SLTNAME may not be populated, so use
 # the following string to indicate that the first slit in the reference
 # file should be used.
@@ -457,7 +461,7 @@ def log_initial_parameters(extract_params):
     log.debug("bkg_order = %d", extract_params["bkg_order"])
 
 
-def get_aperture(im_shape, wcs, extract_params):
+def get_aperture(im_shape, wcs, verbose, extract_params):
     """Get the extraction limits xstart, xstop, ystart, ystop.
 
     Parameters
@@ -468,6 +472,9 @@ def get_aperture(im_shape, wcs, extract_params):
 
     wcs: a WCS object, or None
         The wcs (if any) for the input data or slit.
+
+    verbose: bool
+        If True, log messages.
 
     extract_params: dictionary
         Parameters read from the reference file.
@@ -484,12 +491,12 @@ def get_aperture(im_shape, wcs, extract_params):
     ap_ref = aperture_from_ref(extract_params, im_shape)
 
     (ap_ref, truncated) = update_from_shape(ap_ref, im_shape)
-    if truncated:
+    if truncated and verbose:
         log.warning("Extraction limits extended outside the input image "
                     "borders; limits have been truncated.")
 
     if wcs is not None:
-        ap_wcs = aperture_from_wcs(wcs)
+        ap_wcs = aperture_from_wcs(wcs, verbose)
     else:
         ap_wcs = None
 
@@ -497,7 +504,7 @@ def get_aperture(im_shape, wcs, extract_params):
     # direction, the extraction region should be centered within the
     # WCS bounding box (domain).
     ap_ref = update_from_wcs(ap_ref, ap_wcs, extract_params["extract_width"],
-                             extract_params["dispaxis"])
+                             extract_params["dispaxis"], verbose)
     ap_ref = update_from_width(ap_ref, extract_params["extract_width"],
                                extract_params["dispaxis"])
 
@@ -656,13 +663,16 @@ def update_from_shape(ap, im_shape):
     return (ap_shape, truncated)
 
 
-def aperture_from_wcs(wcs):
+def aperture_from_wcs(wcs, verbose):
     """Get the limits over which the WCS is defined.
 
     Parameters
     ----------
     wcs: data model
         The world coordinate system interface.
+
+    verbose: bool
+        If True, log messages.
 
     Returns
     -------
@@ -677,18 +687,21 @@ def aperture_from_wcs(wcs):
         bounding_box = wcs.bounding_box
         got_bounding_box = True
     except AttributeError:
-        log.info("wcs.bounding_box not found; using wcs.domain instead.")
+        if verbose:
+            log.info("wcs.bounding_box not found; using wcs.domain instead.")
         bounding_box = ((wcs.domain[0]['lower'], wcs.domain[0]['upper']),
                         (wcs.domain[1]['lower'], wcs.domain[1]['upper']))
 
     if got_bounding_box and bounding_box is None:
-        log.warning("wcs.bounding_box is None")
+        if verbose:
+            log.warning("wcs.bounding_box is None")
         return None
 
     # bounding_box should be a tuple of tuples, each of the latter
     # consisting of (lower, upper) limits.
     if len(bounding_box) < 2:
-        log.warning("wcs.bounding_box has the wrong shape")
+        if verbose:
+            log.warning("wcs.bounding_box has the wrong shape")
         return None
 
     # These limits are float, and they are inclusive.
@@ -702,7 +715,7 @@ def aperture_from_wcs(wcs):
     return ap_wcs
 
 
-def update_from_wcs(ap_ref, ap_wcs, extract_width, direction):
+def update_from_wcs(ap_ref, ap_wcs, extract_width, direction, verbose):
     """Limit the extraction region to the WCS bounding box.
 
     Parameters
@@ -724,6 +737,9 @@ def update_from_wcs(ap_ref, ap_wcs, extract_width, direction):
         horizontal.  VERTICAL (2) if the dispersion direction is
         predominantly vertical.
 
+    verbose: bool
+        If True, log messages.
+
     Returns
     -------
     ap: namedtuple
@@ -734,7 +750,7 @@ def update_from_wcs(ap_ref, ap_wcs, extract_width, direction):
         return ap_ref
 
     # If the wcs limits don't pass the sanity test, ignore the bounding box.
-    if not sanity_check_limits(ap_ref, ap_wcs):
+    if not sanity_check_limits(ap_ref, ap_wcs, verbose):
         return ap_ref
 
     # ap_wcs has the limits over which the WCS transformation is defined;
@@ -750,15 +766,16 @@ def update_from_wcs(ap_ref, ap_wcs, extract_width, direction):
         else:
             width = xstop - xstart + 1
         if width < extract_width:
-            log.warning("extract_width was truncated from %g to %g",
-                        extract_width, width)
+            if verbose:
+                log.warning("extract_width was truncated from %g to %g",
+                            extract_width, width)
 
     ap = Aperture(xstart=xstart, xstop=xstop, ystart=ystart, ystop=ystop)
 
     return ap
 
 
-def sanity_check_limits(ap_ref, ap_wcs):
+def sanity_check_limits(ap_ref, ap_wcs, verbose):
     """Sanity check.
 
     Parameters
@@ -771,6 +788,9 @@ def sanity_check_limits(ap_ref, ap_wcs):
     ap_wcs: namedtuple
         These are the bounding box limits.
 
+    verbose: bool
+        If True, log messages.
+
     Returns
     -------
     flag: boolean
@@ -779,14 +799,15 @@ def sanity_check_limits(ap_ref, ap_wcs):
 
     if (ap_wcs.xstart >= ap_ref.xstop or ap_wcs.xstop <= ap_ref.xstart or
         ap_wcs.ystart >= ap_ref.ystop or ap_wcs.ystop <= ap_ref.ystart):
-        log.warning("The WCS bounding box is outside the aperture:")
-        log.warning("  aperture:  %s, %s, %s, %s",
-                    str(ap_ref.xstart), str(ap_ref.xstop),
-                    str(ap_ref.ystart), str(ap_ref.ystop))
-        log.warning("  wcs:       %s, %s, %s, %s",
-                    str(ap_wcs.xstart), str(ap_wcs.xstop),
-                    str(ap_wcs.ystart), str(ap_wcs.ystop))
-        log.warning(" so the wcs bounding box will be ignored.")
+        if verbose:
+            log.warning("The WCS bounding box is outside the aperture:")
+            log.warning("  aperture:  %s, %s, %s, %s",
+                        str(ap_ref.xstart), str(ap_ref.xstop),
+                        str(ap_ref.ystart), str(ap_ref.ystop))
+            log.warning("  wcs:       %s, %s, %s, %s",
+                        str(ap_wcs.xstart), str(ap_wcs.xstop),
+                        str(ap_wcs.ystart), str(ap_wcs.ystop))
+            log.warning(" so the wcs bounding box will be ignored.")
         flag = False
     else:
         flag = True
@@ -923,7 +944,7 @@ class ExtractBase:
         pass
 
 
-    def assign_polynomial_limits(self):
+    def assign_polynomial_limits(self, verbose):
         pass
 
 
@@ -937,6 +958,10 @@ class ExtractBase:
 
         verbose: boolean
             If True, write log messages.
+
+        Returns
+        -------
+        offset: float
         """
 
         total_points = input_model.meta.dither.total_points
@@ -944,18 +969,18 @@ class ExtractBase:
             if verbose:
                 log.info("Total number of dither points = %s; assuming no "
                          "nod/dither offset", str(total_points))
-            return None
+            return 0.
 
         if 'detector' not in self.wcs.available_frames:
             if verbose:
                 log.warning("detector frame not available, so "
                             "can't compute nod/dither offset")
-            return None
+            return 0.
         if 'v2v3' not in self.wcs.available_frames:
             if verbose:
                 log.warning("v2v3 frame not available, so "
                             "can't compute nod/dither offset")
-            return None
+            return 0.
         v2v3_detector = self.wcs.get_transform('v2v3', 'detector')
 
         xoffset = input_model.meta.dither.x_offset      # in arcsec
@@ -966,7 +991,7 @@ class ExtractBase:
             if verbose:
                 log.warning("XOFFSET and/or YOFFSET not found; "
                             "assuming no nod/dither offset")
-            return None
+            return 0.
 
         if hasattr(input_model.meta.wcsinfo, "v2_ref"):
             v2ref = input_model.meta.wcsinfo.v2_ref     # in arcsec
@@ -1003,7 +1028,7 @@ class ExtractBase:
                 if verbose:
                     log.warning("Missing wcsinfo values; "
                                 "can't compute nod/dither offset")
-                return None
+                return 0.
 
         idl_v23 = trmodels.IdealToV2V3(v3idlyangle, v2ref, v3ref, vparity)
 
@@ -1021,7 +1046,7 @@ class ExtractBase:
             if verbose:
                 log.warning("One or more of x, y, x0, y0 is None; "
                             "can't compute nod/dither offset")
-            return None
+            return 0.
         # offsets from xoffset = 0, yoffset = 0
         dx = x - x0
         dy = y - y0
@@ -1188,7 +1213,7 @@ class ExtractModel(ExtractBase):
             log.warning("WCS function not found in input.")
 
 
-    def add_nod_correction(self):
+    def add_nod_correction(self, verbose):
         """Add the nod offset to the extraction location (in-place).
 
         If source extraction coefficients src_coeff were specified, this
@@ -1213,12 +1238,16 @@ class ExtractModel(ExtractBase):
                 dir = "x"
                 self.xstart += self.nod_correction
                 self.xstop += self.nod_correction
-            log.info("Applying nod/dither offset of %s to %sstart and %sstop",
-                     str(self.nod_correction), dir, dir)
+            if verbose:
+                log.info("Applying nod/dither offset of %s "
+                         "to %sstart and %sstop",
+                         str(self.nod_correction), dir, dir)
 
         if self.src_coeff is not None or self.bkg_coeff is not None:
-            log.info("Applying nod/dither offset of %s "
-                     "to polynomial coefficients", str(self.nod_correction))
+            if verbose:
+                log.info("Applying nod/dither offset of %s "
+                         "to polynomial coefficients",
+                         str(self.nod_correction))
 
         if self.src_coeff is not None:
             n_lists = len(self.src_coeff)
@@ -1280,7 +1309,7 @@ class ExtractModel(ExtractBase):
             log.debug("bkg_coeff = %s", str(self.bkg_coeff))
 
 
-    def assign_polynomial_limits(self):
+    def assign_polynomial_limits(self, verbose):
         """Create polynomial functions for extraction limits.
 
         self.src_coeff and self.bkg_coeff contain lists of polynomial
@@ -1318,8 +1347,9 @@ class ExtractModel(ExtractBase):
             else:
                 lower = float(self.xstart) - 0.5
                 upper = float(self.xstop) + 0.5
-            log.debug("Converting extraction limits to [[%g], [%g]]",
-                      lower, upper)
+            if verbose:
+                log.debug("Converting extraction limits to [[%g], [%g]]",
+                          lower, upper)
             self.p_src = [[create_poly([lower]), create_poly([upper])]]
         else:
             # The source extraction can include more than one region.
@@ -1353,7 +1383,7 @@ class ExtractModel(ExtractBase):
                 expect_lower = not expect_lower
 
 
-    def extract(self, data, wl_array):
+    def extract(self, data, wl_array, verbose):
         """
         Do the actual extraction, for the case that the reference file
         is a JSON file, or that there is no reference file.
@@ -1366,6 +1396,9 @@ class ExtractModel(ExtractBase):
         wl_array: array_like (2-D) or None
             Wavelengths corresponding to `data`, or None if no WAVELENGTH
             was found in the input file.
+
+        verbose: bool
+            If True, log messages.
 
         Returns
         -------
@@ -1391,7 +1424,8 @@ class ExtractModel(ExtractBase):
         if not got_wavelength or wl_array.min() == 0. and wl_array.max() == 0.:
             got_wavelength = False
         if got_wavelength:
-            log.debug("Wavelengths are from wavelength attribute.")
+            if verbose:
+                log.debug("Wavelengths are from wavelength attribute.")
             # We need a 1-D array of wavelengths, one element for each
             # output table row.
             # These are slice limits.
@@ -1429,7 +1463,7 @@ class ExtractModel(ExtractBase):
             x_array.fill((self.xstart + self.xstop) / 2.)
 
         if self.wcs is not None:
-            if not got_wavelength:
+            if verbose and not got_wavelength:
                 log.debug("Wavelengths are from the wcs function.")
             nelem = slice1 - slice0
             if self.exp_type in WFSS_EXPTYPES:
@@ -1449,9 +1483,11 @@ class ExtractModel(ExtractBase):
                         ra[i], dec[i], wcs_wl[i], _ = transform(
                                 x_array[i], y_array[i], self.spectral_order)
                 else:
-                    log.warning("n_inputs for wcs function is %d", n_inputs)
-                    log.warning("WCS function was expected to take "
-                                "either 2 or 3 arguments.")
+                    if verbose:
+                        log.warning("n_inputs for wcs function is %d",
+                                    n_inputs)
+                        log.warning("WCS function was expected to take "
+                                    "either 2 or 3 arguments.")
                     ra[:] = -999.
                     dec[:] = -999.
                     wcs_wl[:] = -999.
@@ -1467,8 +1503,9 @@ class ExtractModel(ExtractBase):
                 max_ra = ra2.max()
                 ra = (min_ra + max_ra) / 2.
             else:
-                log.warning("All right ascension values are NaN; "
-                            "assigning dummy value -999.")
+                if verbose:
+                    log.warning("All right ascension values are NaN; "
+                                "assigning dummy value -999.")
                 ra = -999.
             mask = np.isnan(dec)
             not_nan = np.logical_not(mask)
@@ -1478,8 +1515,9 @@ class ExtractModel(ExtractBase):
                 max_dec = dec2.max()
                 dec = (min_dec + max_dec) / 2.
             else:
-                log.warning("All declination values are NaN; "
-                            "assigning dummy value -999.")
+                if verbose:
+                    log.warning("All declination values are NaN; "
+                                "assigning dummy value -999.")
                 dec = -999.
 
         else:
@@ -1495,7 +1533,8 @@ class ExtractModel(ExtractBase):
         else:
             image = np.transpose(data, (1, 0))
         if wavelength is None:
-            log.warning("Wavelengths could not be determined.")
+            if verbose:
+                log.warning("Wavelengths could not be determined.")
             if slice0 <= 0:
                 wavelength = np.arange(1, slice1 - slice0 + 1,
                                        dtype=np.float64)
@@ -1506,7 +1545,8 @@ class ExtractModel(ExtractBase):
         nan_mask = np.isnan(wavelength)
         n_nan = nan_mask.sum(dtype=np.intp)
         if n_nan > 0:
-            log.warning("%d NaNs in wavelength array", n_nan)
+            if verbose:
+                log.warning("%d NaNs in wavelength array", n_nan)
             temp_wl[nan_mask] = 0.01            # because NaNs cause problems
 
         # src total flux, area, total weight
@@ -1520,7 +1560,7 @@ class ExtractModel(ExtractBase):
         dq = np.zeros(net.shape, dtype=np.int32)
         if n_nan > 0:
             (wavelength, net, background, dq) = \
-                nans_at_endpoints(wavelength, net, background, dq)
+                nans_at_endpoints(wavelength, net, background, dq, verbose)
 
         return (ra, dec, wavelength, net, background, dq)
 
@@ -1580,23 +1620,29 @@ class ImageExtractModel(ExtractBase):
             log.warning("WCS function not found in input.")
 
 
-    def add_nod_correction(self):
+    def add_nod_correction(self, verbose):
         """Shift the reference image (in-place)."""
 
         if self.nod_correction == 0:
             return
 
-        log.info("Applying nod/dither offset of %s", str(self.nod_correction))
+        if verbose:
+            log.info("Applying nod/dither offset of %s",
+                     str(self.nod_correction))
 
         # Shift the image in the cross-dispersion direction.
         ref = self.ref_image.data.copy()
         shift = self.nod_correction
         ishift = int(round(shift))
         if ishift != shift:
-            log.info("Rounding nod/dither offset of %g to %d", shift, ishift)
+            if verbose:
+                log.info("Rounding nod/dither offset of %g to %d",
+                         shift, ishift)
         if self.dispaxis == HORIZONTAL:
             if abs(ishift) >= ref.shape[0]:
-                log.error("Nod offset %d is too large, skipping ...", ishift)
+                if verbose:
+                    log.warning("Nod offset %d is too large, skipping ...",
+                                ishift)
                 return
             self.ref_image.data[:, :] = 0.
             if ishift > 0:
@@ -1606,7 +1652,9 @@ class ImageExtractModel(ExtractBase):
                 self.ref_image.data[:-ishift, :] = ref[ishift:, :]
         else:
             if abs(ishift) >= ref.shape[1]:
-                log.error("Nod offset %d is too large, skipping ...", ishift)
+                if verbose:
+                    log.warning("Nod offset %d is too large, skipping ...",
+                                ishift)
                 return
             self.ref_image.data[:, :] = 0.
             if ishift > 0:
@@ -1625,7 +1673,7 @@ class ImageExtractModel(ExtractBase):
         log.debug("nod_correction = %s", str(self.nod_correction))
 
 
-    def extract(self, data, wl_array):
+    def extract(self, data, wl_array, verbose):
         """
         Do the actual extraction, for the case that the reference file
         is an image.
@@ -1638,6 +1686,9 @@ class ImageExtractModel(ExtractBase):
         wl_array: array_like (2-D) or None
             Wavelengths corresponding to `data`, or None if no WAVELENGTH
             was found in the input file.
+
+        verbose: bool
+            If True, log messages.
 
         Returns
         -------
@@ -1739,7 +1790,8 @@ class ImageExtractModel(ExtractBase):
             y_array = y_array[trim_slc]
 
         if got_wavelength:
-            log.debug("Wavelengths are from wavelength attribute.")
+            if verbose:
+                log.debug("Wavelengths are from wavelength attribute.")
             indx = np.around(x_array).astype(np.int)
             indy = np.around(y_array).astype(np.int)
             indx = np.where(indx < 0, 0, indx)
@@ -1751,7 +1803,7 @@ class ImageExtractModel(ExtractBase):
         nelem = len(x_array)
 
         if self.wcs is not None:
-            if not got_wavelength:
+            if verbose and not got_wavelength:
                 log.debug("Wavelengths are from the wcs function.")
             if self.exp_type in WFSS_EXPTYPES:
                 # We expect two (x and y) or three (x, y, spectral order).
@@ -1770,9 +1822,11 @@ class ImageExtractModel(ExtractBase):
                         ra[i], dec[i], wcs_wl[i], _ = transform(
                                 x_array[i], y_array[i], self.spectral_order)
                 else:
-                    log.warning("n_inputs for wcs function is %d", n_inputs)
-                    log.warning("WCS function was expected to take "
-                                "either 2 or 3 arguments.")
+                    if verbose:
+                        log.warning("n_inputs for wcs function is %d",
+                                    n_inputs)
+                        log.warning("WCS function was expected to take "
+                                    "either 2 or 3 arguments.")
                     ra[:] = -999.
                     dec[:] = -999.
                     wcs_wl[:] = -999.
@@ -1792,16 +1846,21 @@ class ImageExtractModel(ExtractBase):
             mask = np.isnan(ra)
             not_nan = np.logical_not(mask)
             if not_nan[middle]:
-                log.debug("Using midpoint of spectral trace for RA and Dec.")
+                if verbose:
+                    log.debug("Using midpoint of spectral trace "
+                              "for RA and Dec.")
                 ra = ra[middle]
             else:
                 if np.any(not_nan):
-                    log.warning("Midpoint of coordinate array is NaN; using "
-                                "the average of non-NaN min and max values.")
+                    if verbose:
+                        log.warning("Midpoint of coordinate array is NaN; "
+                                    "using the average of non-NaN min and "
+                                    "max values.")
                     ra = (np.nanmin(ra) + np.nanmax(ra)) / 2.
                 else:
-                    log.warning("All right ascension values are NaN; "
-                                "assigning dummy value -999.")
+                    if verbose:
+                        log.warning("All right ascension values are NaN; "
+                                    "assigning dummy value -999.")
                     ra = -999.
             mask = np.isnan(dec)
             not_nan = np.logical_not(mask)
@@ -1811,8 +1870,9 @@ class ImageExtractModel(ExtractBase):
                 if np.any(not_nan):
                     dec = (np.nanmin(dec) + np.nanmax(dec)) / 2.
                 else:
-                    log.warning("All declination values are NaN; "
-                                "assigning dummy value -999.")
+                    if verbose:
+                        log.warning("All declination values are NaN; "
+                                    "assigning dummy value -999.")
                     dec = -999.
 
         else:
@@ -1831,9 +1891,10 @@ class ImageExtractModel(ExtractBase):
         nan_mask = np.isnan(wavelength)
         n_nan = nan_mask.sum(dtype=np.intp)
         if n_nan > 0:
-            log.warning("%d NaNs in wavelength array", n_nan)
+            if verbose:
+                log.warning("%d NaNs in wavelength array", n_nan)
             (wavelength, net, background, dq) = \
-                nans_at_endpoints(wavelength, net, background, dq)
+                nans_at_endpoints(wavelength, net, background, dq, verbose)
 
         return (ra, dec, wavelength, net, background, dq)
 
@@ -1927,7 +1988,8 @@ def interpolate_response(wavelength, relsens):
     return r_factor
 
 
-def do_extract1d(input_model, refname, smoothing_length, bkg_order):
+def do_extract1d(input_model, refname, smoothing_length, bkg_order,
+                 log_increment):
 
     output_model = datamodels.MultiSpecModel()
     output_model.update(input_model)
@@ -1947,6 +2009,7 @@ def do_extract1d(input_model, refname, smoothing_length, bkg_order):
         # Loop over the slits in the input model
         for slit in slits:
             log.info('Working on slit %s', slit.name)
+            prev_offset = OFFSET_NOT_ASSIGNED_YET
             if np.size(slit.data) <= 0:
                 log.info('No data for slit %s, skipping ...', slit.name)
                 continue
@@ -1964,10 +2027,10 @@ def do_extract1d(input_model, refname, smoothing_length, bkg_order):
             find_dispaxis(input_model, slit, sp_order, extract_params)
 
             try:
-                (ra, dec, wavelength, net, background, dq) = \
-                        extract_one_slit(input_model, slit, -1,
-                                         verbose=True,
-                                         **extract_params)
+                (ra, dec, wavelength, net, background, dq,
+                 prev_offset) = extract_one_slit(
+                                        input_model, slit, -1,
+                                        prev_offset, True, extract_params)
             except InvalidSpectralOrderNumberError as e:
                 log.info(str(e) + ", skipping ...")
                 continue
@@ -2025,6 +2088,7 @@ def do_extract1d(input_model, refname, smoothing_length, bkg_order):
 
         if isinstance(input_model, (datamodels.ImageModel,
                                     datamodels.DrizProductModel)):
+            prev_offset = OFFSET_NOT_ASSIGNED_YET
             for sp_order in spectral_order_list:
                 if sp_order == "not set yet":
                     sp_order = get_spectral_order(input_model)
@@ -2038,10 +2102,10 @@ def do_extract1d(input_model, refname, smoothing_length, bkg_order):
                     slit = DUMMY
                     find_dispaxis(input_model, slit, sp_order, extract_params)
                     try:
-                        (ra, dec, wavelength, net, background, dq) = \
-                                extract_one_slit(input_model, slit, -1,
-                                                 verbose=True,
-                                                 **extract_params)
+                        (ra, dec, wavelength, net, background, dq,
+                         prev_offset) = extract_one_slit(
+                                        input_model, slit, -1,
+                                        prev_offset, True, extract_params)
                     except InvalidSpectralOrderNumberError as e:
                         log.info(str(e) + ", skipping ...")
                         continue
@@ -2096,6 +2160,7 @@ def do_extract1d(input_model, refname, smoothing_length, bkg_order):
             slit = DUMMY
 
             # NRS_BRIGHTOBJ exposures are instances of SlitModel.
+            prev_offset = OFFSET_NOT_ASSIGNED_YET
             for sp_order in spectral_order_list:
                 if sp_order == "not set yet":
                     sp_order = get_spectral_order(input_model)
@@ -2127,13 +2192,18 @@ def do_extract1d(input_model, refname, smoothing_length, bkg_order):
 
                 # Loop over each integration in the input model
                 verbose = True          # for just the first integration
+                if input_model.data.shape[0] == 1:
+                    log.info("Beginning loop, just 1 integration ...")
+                else:
+                    log.info("Beginning loop over %d integrations ...",
+                             input_model.data.shape[0])
                 for integ in range(input_model.data.shape[0]):
                     # Extract spectrum
                     try:
-                        (ra, dec, wavelength, net, background, dq) = \
-                                extract_one_slit(input_model, slit, integ,
-                                                 verbose=verbose,
-                                                 **extract_params)
+                        (ra, dec, wavelength, net, background, dq,
+                         prev_offset) = extract_one_slit(
+                                        input_model, slit, integ,
+                                        prev_offset, verbose, extract_params)
                     except InvalidSpectralOrderNumberError as e:
                         log.info(str(e) + ", skipping ...")
                         break
@@ -2165,6 +2235,29 @@ def do_extract1d(input_model, refname, smoothing_length, bkg_order):
                     spec.slit_dec = dec
                     spec.spectral_order = sp_order
                     output_model.spec.append(spec)
+
+                    if (log_increment > 0 and
+                        (integ + 1) % log_increment == 0):
+                            if integ == 0:
+                                if input_model.data.shape[0] == 1:
+                                    log.info("1 integration done")
+                                else:
+                                    log.info("... 1 integration done")
+                            elif integ == input_model.data.shape[0] - 1:
+                                log.info("All %d integrations done",
+                                         input_model.data.shape[0])
+                            else:
+                                log.info("... %d integrations done", integ + 1)
+                            progress_msg_printed = True
+                    else:
+                            progress_msg_printed = False
+
+                if not progress_msg_printed:
+                    if input_model.data.shape[0] == 1:
+                        log.info("1 integration done")
+                    else:
+                        log.info("All %d integrations done",
+                                 input_model.data.shape[0])
 
         elif isinstance(input_model, datamodels.IFUCubeModel):
 
@@ -2410,7 +2503,8 @@ def copy_keyword_info(slit, slitname, spec):
         spec.shutter_state = slit.shutter_state
 
 
-def extract_one_slit(input_model, slit, integ, verbose, **extract_params):
+def extract_one_slit(input_model, slit, integ,
+                     prev_offset, verbose, extract_params):
     """Extract data for one slit, or spectral order, or plane.
     Parameters
     ----------
@@ -2428,15 +2522,23 @@ def extract_one_slit(input_model, slit, integ, verbose, **extract_params):
         `integ` is the integration number.  If the integration number is
         not relevant (i.e. the data array is 2-D), `integ` should be -1.
 
+    prev_offset: float or str
+        When extracting from multi-integration data, the nod/dither offset
+        only needs to be determined once.  `prev_offset` is either the
+        previously computed offset or a value (currently a string)
+        indicating that the offset hasn't been computed yet.  In the latter
+        case, method offset_from_offset will be called to determine the
+        offset.
+
     verbose: boolean
-        If True, log more info (extraction parameters, in particular).
+        If True, log more info (extraction parameters, for example).
 
     extract_params: dictionary
         Parameters read from the reference file.
 
     Returns
     -------
-    tuple (ra, dec, wavelength, net, background, dq)
+    tuple (ra, dec, wavelength, net, background, dq, offset)
         `ra` and `dec` are floats, and the others are 1-D arrays.
         `ra` and `dec` are the right ascension and declination at the
         nominal center of the slit.  `wavelength` is the wavelength in
@@ -2444,6 +2546,9 @@ def extract_one_slit(input_model, slit, integ, verbose, **extract_params):
         minus the background at each pixel.  `background` is the background
         count rate that was subtracted from the total source count rate
         to get `net`.  `dq` is the data quality array.
+        `offset` is the nod/dither offset in the cross-dispersion
+        direction, either computed by calling offset_from_offset in this
+        function, or copied from the input `prev_offset`.
     """
 
     if verbose:
@@ -2485,31 +2590,34 @@ def extract_one_slit(input_model, slit, integ, verbose, **extract_params):
         # If there is a reference file (there doesn't have to be), it's in
         # JSON format.
         extract_model = ExtractModel(input_model, slit, **extract_params)
-        ap = get_aperture(data.shape, extract_model.wcs, extract_params)
+        ap = get_aperture(data.shape, extract_model.wcs,
+                          verbose, extract_params)
         extract_model.update_extraction_limits(ap)
 
-    # xxx This only needs to be called for the first integration.
-    offset = extract_model.offset_from_offset(input_model, verbose=verbose)
-    if offset is not None:
+    # Only call this method for the first integration.
+    if prev_offset == OFFSET_NOT_ASSIGNED_YET:
+        offset = extract_model.offset_from_offset(input_model, verbose)
         if offset != 0:                         # xxx should be temporary
             if verbose:
                 log.debug("Computed nod/dither offset = %s, but don't "
                           "trust this yet, so assuming 0", str(offset))
             offset = 0.                         # xxx should be temporary
-        extract_model.nod_correction = offset
+    else:
+        offset = prev_offset
+    extract_model.nod_correction = offset
 
     # Add the nod/dither offset to the polynomial coefficients, or shift
     # the reference image (depending on the type of reference file).
-    extract_model.add_nod_correction()
+    extract_model.add_nod_correction(verbose)
 
     if verbose:
         extract_model.log_extraction_parameters()
 
-    extract_model.assign_polynomial_limits()
+    extract_model.assign_polynomial_limits(verbose)
     (ra, dec, wavelength, net, background, dq) = \
-                extract_model.extract(data, wl_array)
+                extract_model.extract(data, wl_array, verbose)
 
-    return (ra, dec, wavelength, net, background, dq)
+    return (ra, dec, wavelength, net, background, dq, offset)
 
 
 def replace_bad_values(data, input_dq, fill=0.):
@@ -2544,7 +2652,7 @@ def replace_bad_values(data, input_dq, fill=0.):
     else:
         return data
 
-def nans_at_endpoints(wavelength, net, background, dq):
+def nans_at_endpoints(wavelength, net, background, dq, verbose):
     """Flag NaNs in the wavelength array.
 
     All five input arrays should be 1-D and the same shape.
@@ -2566,6 +2674,9 @@ def nans_at_endpoints(wavelength, net, background, dq):
 
     dq: ndarray
         Data quality array.
+
+    verbose: bool
+        If True, log a message.
 
     Returns
     -------
@@ -2590,8 +2701,9 @@ def nans_at_endpoints(wavelength, net, background, dq):
     if len(flag[0]) > 0:
         n_trimmed = flag[0][0] + nelem - (flag[0][-1] + 1)
         if n_trimmed > 0:
-            log.info("Output arrays have been trimmed by %d elements",
-                     n_trimmed)
+            if verbose:
+                log.info("Output arrays have been trimmed by %d elements",
+                         n_trimmed)
             slc = slice(flag[0][0], flag[0][-1] + 1)
             new_wl = new_wl[slc]
             new_net = new_net[slc]

--- a/jwst/extract_1d/extract_1d_step.py
+++ b/jwst/extract_1d/extract_1d_step.py
@@ -16,6 +16,8 @@ class Extract1dStep(Step):
     # Order of polynomial fit to one column (or row if the dispersion
     # direction is vertical) of background regions.
     bkg_order = integer(default=None, min=0)
+    # Log a progress message when processing multi-integration data.
+    log_increment = integer(default=50)
     """
 
     reference_file_types = ['extract1d']
@@ -70,7 +72,8 @@ class Extract1dStep(Step):
                                       self.ref_file)
                     temp = extract.do_extract1d(model, self.ref_file,
                                                 self.smoothing_length,
-                                                self.bkg_order)
+                                                self.bkg_order,
+                                                self.log_increment)
                     # Set the step flag to complete in each MultiSpecModel
                     temp.meta.cal_step.extract_1d = 'COMPLETE'
                     result.append(temp)
@@ -87,7 +90,8 @@ class Extract1dStep(Step):
                                   self.ref_file)
                 result = extract.do_extract1d(input_model[0], self.ref_file,
                                               self.smoothing_length,
-                                              self.bkg_order)
+                                              self.bkg_order,
+                                              self.log_increment)
                 # Set the step flag to complete
                 result.meta.cal_step.extract_1d = 'COMPLETE'
             else:
@@ -106,7 +110,8 @@ class Extract1dStep(Step):
                               self.ref_file)
             result = extract.do_extract1d(input_model, self.ref_file,
                                           self.smoothing_length,
-                                          self.bkg_order)
+                                          self.bkg_order,
+                                          self.log_increment)
             # Set the step flag to complete
             result.meta.cal_step.extract_1d = 'COMPLETE'
 

--- a/jwst/pipeline/extract_1d.cfg
+++ b/jwst/pipeline/extract_1d.cfg
@@ -1,4 +1,5 @@
 name = "extract_1d"
 class = "jwst.extract_1d.Extract1dStep"
 
+log_increment = 50
 smoothing_length = 0


### PR DESCRIPTION
A verbose argument was added to a number of functions, initially set to True but reset to False after the first integration of a multi-integration exposure.  A new parameter log_increment was added to the step.  This lets the user specify how frequently INFO messages are written during processing of a multi-integration exposure.

See issue #2079.