### PR TITLE
Remove absolute file paths from ASNTABLE keyword and assocation tables

### DIFF
--- a/jwst/pipeline/calwebb_ami3.py
+++ b/jwst/pipeline/calwebb_ami3.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import logging
+import os.path as op
 
 from .. import datamodels
 from ..associations.load_as_asn import LoadAsAssociation
@@ -87,7 +88,7 @@ class Ami3Pipeline(Pipeline):
 
             # Save the LG analysis results to a file
             result.meta.asn.pool_name = asn['asn_pool']
-            result.meta.asn.table_name = asn.filename
+            result.meta.asn.table_name = op.basename(asn.filename)
             output_file = self.save_model(
                 result, output_file=input_file, suffix='ami', acid=acid,
             )
@@ -108,7 +109,7 @@ class Ami3Pipeline(Pipeline):
             # Save the results to a file, if requested
             if self.save_averages:
                 psf_avg.meta.asn.pool_name = asn['asn_pool']
-                psf_avg.meta.asn.table_name = asn.filename
+                psf_avg.meta.asn.table_name = op.basename(asn.filename)
 
                 # Perform blending of metadata for all inputs to this
                 # output file
@@ -143,7 +144,7 @@ class Ami3Pipeline(Pipeline):
             # Save the results to a file, if requested
             if self.save_averages:
                 targ_avg.meta.asn.pool_name = asn['asn_pool']
-                targ_avg.meta.asn.table_name = asn.filename
+                targ_avg.meta.asn.table_name = op.basename(asn.filename)
 
                 # Perform blending of metadata for all inputs to this
                 # output file
@@ -169,7 +170,7 @@ class Ami3Pipeline(Pipeline):
 
             # Save the result
             result.meta.asn.pool_name = asn['asn_pool']
-            result.meta.asn.table_name = asn.filename
+            result.meta.asn.table_name = op.basename(asn.filename)
 
             # Perform blending of metadata for all inputs to this output file
             self.log.info(

--- a/jwst/pipeline/calwebb_coron3.py
+++ b/jwst/pipeline/calwebb_coron3.py
@@ -1,5 +1,6 @@
 """Interface for running CALCORON3 pipeline."""
 #!/usr/bin/env python
+import os.path as op
 
 from ..stpipe import Pipeline
 from ..associations import load_asn
@@ -49,8 +50,7 @@ class Coron3Pipeline(Pipeline):
         self.log.info('Starting calwebb_coron3 ...')
 
         # Load the input association table
-        with open(input, 'r') as input_fh:
-            asn = load_asn(input_fh)
+        asn = self.load_as_level3_asn(input)
         acid = asn.get('asn_id', '')
 
         # We assume there's one final product defined by the association
@@ -165,7 +165,7 @@ class Coron3Pipeline(Pipeline):
             blendmeta.blendmodels(result, inputs=targ_files)
 
         result.meta.asn.pool_name = asn['asn_pool']
-        result.meta.asn.table_name = input
+        result.meta.asn.table_name = op.basename(input)
 
         # Save the final result
         self.save_model(result, suffix=self.suffix)

--- a/jwst/wfs_combine/wfs_combine_step.py
+++ b/jwst/wfs_combine/wfs_combine_step.py
@@ -18,7 +18,7 @@ class WfsCombineStep(Step):
 
     def process(self, input_table):
 
-        asn_table = json.load(open(input_table, 'r'))
+        asn_table = self.load_as_level2_asn(input_table)
         num_sets = len(asn_table['products'])
 
         self.log.info('Using input table: %s', input_table)


### PR DESCRIPTION
- strip abspath from ASNTABLE keyword in calwebb_ami3, calwebb_coron3
- use Step.load_as_level3_asn in calwebb_coron3
- use Step.load_as_level2_asn in wfs_combine_step