### PR TITLE
For flat_field, process 2-D NRS_BRIGHTOBJ data

### DIFF
--- a/jwst/flatfield/flat_field.py
+++ b/jwst/flatfield/flat_field.py
@@ -457,8 +457,10 @@ def NIRSpec_brightobj(output_model,
 
     slit_name = output_model.name
 
+    # The input may be either 2-D or 3-D; save `shape` for use later.
+    shape = output_model.data.shape
+    ysize, xsize = shape[-2:]
     # pixels with respect to the original image
-    n_ints, ysize, xsize = output_model.data.shape
     xstart = output_model.meta.subarray.xstart - 1
     ystart = output_model.meta.subarray.ystart - 1
     xstop = xstart + xsize
@@ -531,11 +533,15 @@ def NIRSpec_brightobj(output_model,
         else:
             interpolated_flats.wavelength = np.zeros_like(flat_2d)
 
-    flat_3d = flat_2d.reshape((1, ysize, xsize))
-    flat_dq_3d = flat_dq_2d.reshape((1, ysize, xsize))
-    output_model.data /= flat_3d
-    output_model.err /= flat_3d
-    output_model.dq |= flat_dq_3d
+    if len(shape) == 3:
+        flat_Nd = flat_2d.reshape((1, ysize, xsize))
+        flat_dq_Nd = flat_dq_2d.reshape((1, ysize, xsize))
+    else:
+        flat_Nd = flat_2d
+        flat_dq_Nd = flat_dq_2d
+    output_model.data /= flat_Nd
+    output_model.err /= flat_Nd
+    output_model.dq |= flat_dq_Nd
 
     output_model.meta.cal_step.flat_field = 'COMPLETE'
 


### PR DESCRIPTION
The flat_field step now allows NRS_BRIGHTOBJ data to be either 3-D (the "normal" case, multi-integration) or 2-D (averaged over integrations).

See issue #2080 and JIRA issue JP-318.