### PR TITLE
Switched CRDS_CONTEXT in JenkinsfileRT to jwst-edit

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -7,7 +7,7 @@ def test_env = [
     "PATH=./miniconda/bin:/bin:/usr/bin",
     "TEST_BIGDATA=/data4/jwst_test_data",
     "CRDS_SERVER_URL=https://jwst-crds.stsci.edu",
-    "CRDS_CONTEXT=jwst_0461.pmap",
+    "CRDS_CONTEXT=jwst-edit",
 ]
 
 //def python_version = ['3.5', '3.6']


### PR DESCRIPTION
The jwst-edit context tracks the last ReDCaT delivery,  currently jwst_0462.pmap.   

Also updated regression context in 

jwcalibdev:/data1/jwst_rt/pdk_environment 

to jwst-edit.