### PR TITLE
Clean up some warning messages

### DIFF
--- a/jwst/firstframe/firstframe_sub.py
+++ b/jwst/firstframe/firstframe_sub.py
@@ -45,7 +45,8 @@ def do_correction(input_model):
         log.debug("FirstFrame Sub: resetting GROUPDQ in first frame to DO_NOT_USE")
         output.meta.cal_step.firstframe = 'COMPLETE'
     else:   # too few groups
-        log.warning("FirstFrame Corr: too few groups, skipping step")
+        log.warning("Too few groups to apply correction")
+        log.warning("Step will be skipped")
         output.meta.cal_step.firstframe = 'SKIPPED'
 
     return output

--- a/jwst/group_scale/group_scale_step.py
+++ b/jwst/group_scale/group_scale_step.py
@@ -32,16 +32,18 @@ class GroupScaleStep(Step):
             # is a power of 2. If it is, rescaling isn't needed.
             if frame_divisor is None:
                 if (nframes & (nframes - 1) == 0):
-                    self.log.warning('NFRAMES={} is a power of 2'.format(nframes))
-                    self.log.warning('Step will be skipped')
+                    self.log.info('NFRAMES={} is a power of 2; ' +
+                                  'correction not needed'.format(nframes))
+                    self.log.info('Step will be skipped')
                     input_model.meta.cal_step.group_scale = 'SKIPPED'
                     return input_model
 
             # Compare NFRAMES and FRMDIVSR. If they're equal,
             # rescaling isn't needed.
             elif (nframes == frame_divisor):
-                self.log.warning('NFRAMES and FRMDIVSR are equal')
-                self.log.warning('Step will be skipped')
+                self.log.info('NFRAMES and FRMDIVSR are equal; ' +
+                              'correction not needed')
+                self.log.info('Step will be skipped')
                 input_model.meta.cal_step.group_scale = 'SKIPPED'
                 return input_model
 

--- a/jwst/lastframe/lastframe_sub.py
+++ b/jwst/lastframe/lastframe_sub.py
@@ -44,7 +44,8 @@ def do_correction(input_model):
         log.debug("LastFrame Sub: resetting GROUPDQ in last frame to DO_NOT_USE")
         output.meta.cal_step.lastframe = 'COMPLETE'
     else:   # too few groups
-        log.warning("LastFrame Sub: too few groups, skipping step")
+        log.warning("Too few groups to apply correction")
+        log.warning("Step will be skipped")
         output.meta.cal_step.lastframe = 'SKIPPED'
 
     return output

--- a/jwst/ramp_fitting/ramp_fit_step.py
+++ b/jwst/ramp_fitting/ramp_fit_step.py
@@ -51,7 +51,6 @@ class RampFitStep (Step):
             # If found, store it in the science model meta data, so that it's
             # available later in the gain_scale step, which avoids having to
             # load the gain ref file again in that step.
-            input_model.meta.exposure.gain_factor = None
             if gain_model.meta.exposure.gain_factor is not None:
                 input_model.meta.exposure.gain_factor = \
                     gain_model.meta.exposure.gain_factor

--- a/jwst/rscd/rscd_step.py
+++ b/jwst/rscd/rscd_step.py
@@ -32,9 +32,9 @@ class RSCD_Step(Step):
                 # Check that data has the minimum number of groups/int
                 sci_ngroups = input_model.data.shape[1]     # number of groups
                 min_number = 4
-                if sci_ngroups < min_number :
+                if sci_ngroups < min_number:
                     self.log.warning('Input file does not contain enough groups '
-                                     'for RSCD correctionto be applied ')
+                                     'for RSCD correction to be applied')
                     self.log.warning('RSCD step will be skipped')
                     input_model.meta.cal_step.rscd = 'SKIPPED'
                     return input_model


### PR DESCRIPTION
Fixes some typos, makes some messages more clear, makes them consistent with equivalent messages from other steps, and downgrades warnings from the group_scale step to info, because it's quite normal for that step to be not necessary. Also removed the setting of meta.exposure.gain_factor to None in the ramp_fit step, just to avoid the annoying schema validation warning.