### PR TITLE
Add a custom validator that checks for None

### DIFF
--- a/jwst/datamodels/fits_support.py
+++ b/jwst/datamodels/fits_support.py
@@ -23,6 +23,7 @@ from jsonschema import validators
 from . import properties
 from . import schema as mschema
 from . import util
+from . import validate
 
 import logging
 log = logging.getLogger(__name__)
@@ -455,13 +456,13 @@ def _load_from_schema(hdulist, schema, tree, context):
                 ctx.get('hdu_index'), known_keywords)
 
             if result is None:
-                util.validate_schema(path, result, schema,
-                                     context._pass_invalid_values,
-                                     context._strict_validation)
+                validate.value_change(path, result, schema,
+                                      context._pass_invalid_values,
+                                      context._strict_validation)
             else:
-                if util.validate_schema(path, result, schema,
-                                        context._pass_invalid_values,
-                                        context._strict_validation):
+                if validate.value_change(path, result, schema,
+                                         context._pass_invalid_values,
+                                         context._strict_validation):
                     properties.put_value(path, result, tree)
 
         elif 'fits_hdu' in schema and (
@@ -470,13 +471,13 @@ def _load_from_schema(hdulist, schema, tree, context):
                 hdulist, schema, ctx.get('hdu_index'), known_datas)
 
             if result is None:
-                util.validate_schema(path, result, schema,
-                                     context._pass_invalid_values,
-                                     context._strict_validation)
+                validate.value_change(path, result, schema,
+                                      context._pass_invalid_values,
+                                      context._strict_validation)
             else:
-                if util.validate_schema(path, result, schema,
-                                        context._pass_invalid_values,
-                                        context._strict_validation):
+                if validate.value_change(path, result, schema,
+                                         context._pass_invalid_values,
+                                         context._strict_validation):
                     properties.put_value(path, result, tree)
 
         if schema.get('type') == 'array':

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -26,6 +26,7 @@ from . import fits_support
 from . import properties
 from . import schema as mschema
 from . import util
+from . import validate
 
 from .extension import BaseExtension
 from jwst.transforms.jwextension import JWSTExtension
@@ -307,9 +308,9 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         """
         Re-validate the model instance againsst its schema
         """
-        util.validate_schema(str(self), self._instance, self._schema,
-                             self._pass_invalid_values,
-                             self._strict_validation)
+        validate.value_change(str(self), self._instance, self._schema,
+                              self._pass_invalid_values,
+                              self._strict_validation)
 
     def get_primary_array_name(self):
         """

--- a/jwst/datamodels/properties.py
+++ b/jwst/datamodels/properties.py
@@ -13,6 +13,7 @@ from asdf.tags.core import ndarray
 from asdf import tagged
 
 from . import util
+from . import validate
 
 import logging
 log = logging.getLogger(__name__)
@@ -176,8 +177,8 @@ class Node(object):
     def _validate(self):
         instance = yamlutil.custom_tree_to_tagged_tree(self._instance,
                                                        self._ctx._asdf)
-        return util.validate_schema(self._name, instance, self._schema,
-                                    False, self._ctx._strict_validation)
+        return validate.value_change(self._name, instance, self._schema,
+                                      False, self._ctx._strict_validation)
 
     @property
     def instance(self):
@@ -241,8 +242,8 @@ class ObjectNode(Node):
             del self.__dict__[attr]
         else:
             schema = _get_schema_for_property(self._schema, attr)
-            if not util.validate_schema(attr, None, schema, False,
-                                        self._ctx._strict_validation):
+            if not validate.value_change(attr, None, schema, False,
+                                          self._ctx._strict_validation):
                 return
 
             try:

--- a/jwst/datamodels/tests/test_schema.py
+++ b/jwst/datamodels/tests/test_schema.py
@@ -13,7 +13,7 @@ from numpy.testing import assert_array_equal, assert_array_almost_equal
 import jsonschema
 from astropy.io import fits
 
-from .. import util
+from .. import util, validate
 from .. import DataModel, ImageModel, RampModel, MaskModel, MultiSlitModel, AsnModel
 
 from asdf import schema as mschema
@@ -142,7 +142,7 @@ def test_invalid_fits():
     hdulist.writeto(TMP_FITS)
     hdulist.close()
 
-    with pytest.raises(util.ValidationWarning):
+    with pytest.raises(validate.ValidationWarning):
         with warnings.catch_warnings():
             os.environ['PASS_INVALID_VALUES'] = '0'
             os.environ['STRICT_VALIDATION'] = '0'
@@ -173,7 +173,7 @@ def test_invalid_fits():
     del os.environ['PASS_INVALID_VALUES']
     del os.environ['STRICT_VALIDATION']
 
-    with pytest.raises(util.ValidationWarning):
+    with pytest.raises(validate.ValidationWarning):
         with warnings.catch_warnings():
             warnings.simplefilter('error')
             model = util.open(TMP_FITS,

--- a/jwst/datamodels/validate.py
+++ b/jwst/datamodels/validate.py
@@ -1,0 +1,85 @@
+"""
+Functions that support validation of model changes
+"""
+
+import warnings
+import jsonschema
+from asdf import AsdfFile
+from asdf import schema as asdf_schema
+from asdf.util import HashableDict
+
+class ValidationWarning(Warning):
+    pass
+
+def value_change(path, value, schema, pass_invalid_values,
+                 strict_validation):
+    """
+    Validate a change in value against a schema.
+    Trap error and return a flag.
+    """
+    try:
+        _check_value(value, schema)
+        update = True
+
+    except jsonschema.ValidationError as error:
+        update = False
+        errmsg = _error_message(path, error)
+        if pass_invalid_values:
+            update = True
+        if strict_validation:
+            raise jsonschema.ValidationError(errmsg)
+        else:
+            warnings.warn(errmsg, ValidationWarning)
+    return update
+
+def _check_type(validator, types, instance, schema):
+    """
+    Callback to check data type. Skips over null values.
+    """
+    if instance is None:
+        errors = []
+    else:
+        errors = asdf_schema.validate_type(validator, types,
+                                           instance, schema)
+    return errors
+
+validator_callbacks = HashableDict(asdf_schema.YAML_VALIDATORS)
+validator_callbacks.update({'type': _check_type})
+
+validator_context = AsdfFile()
+validator_resolver = validator_context.resolver
+
+def _check_value(value, schema):
+    """
+    Perform the actual validation.
+    """
+    if value is None:
+        if schema.get('fits_required'):
+            name = schema.get("fits_keyword") or schema.get("fits_hdu")
+            raise jsonschema.ValidationError("%s is a required value"
+                                              % name)
+    else:
+        temp_schema = {
+            '$schema':
+            'http://stsci.edu/schemas/asdf-schema/0.1.0/asdf-schema'}
+        temp_schema.update(schema)
+        validator = asdf_schema.get_validator(temp_schema,
+                                              validator_context,
+                                              validator_callbacks,
+                                              validator_resolver)
+        validator.validate(value, _schema=temp_schema)
+
+def _error_message(path, error):
+    """
+    Add the path to the attribute as context for a validation error
+    """
+    if isinstance(path, list):
+        spath = [str(p) for p in path]
+        name = '.'.join(spath)
+    else:
+        name = str(path)
+
+    errfmt = "While validating {} the following error occurred:\n{}"
+    errmsg = errfmt.format(name, str(error))
+    return errmsg
+


### PR DESCRIPTION
Datamodels allows users to set a metadata keyword to None, which indicates that it should not be written to the fits header. In certain cases datamodels was checking a value of None against the type of the keyword in the schema and throwing a warning. To prevent this from happening this update adds a custom validator for type which skips validation when the keyword value is None.

This update also moves all the validation code from util.py into a new file, validate.py. The amount of validation code in datamodels was large enough to deserve its own file. This also required updating all the places where validation was called, including tests.