### PR TITLE
Reference file  specifications part I

### DIFF
--- a/docs/jwst/ami/reference_files.rst
+++ b/docs/jwst/ami/reference_files.rst
@@ -1,5 +1,6 @@
-Reference File
-==============
+Reference File Types
+====================
+
 The ``ami_analyze`` step uses a THROUGHPUT reference file, which contains
 throughput data for the filter used in the input AMI image. (The ami_average
 and ami_normalize steps do not use any reference files.)

--- a/docs/jwst/dq_init/reference_files.rst
+++ b/docs/jwst/dq_init/reference_files.rst
@@ -1,5 +1,5 @@
-Reference File
-==============
+Reference File Types
+====================
 The Data Quality Initialization step uses a MASK reference file.
 
 CRDS Selection Criteria

--- a/docs/jwst/flatfield/reference_files.rst
+++ b/docs/jwst/flatfield/reference_files.rst
@@ -13,17 +13,17 @@ For MIRI Imaging, flat-field reference files are selected based on the values of
 INSTRUME, DETECTOR, FILTER, READPATT, and SUBARRAY in the science data file.
 
 For MIRI MRS, flat-field reference files are selected based on the values of
-INSTRUME, DETECTOR, BAND, READPATT, and SUBARRAY of the science data file.
+INSTRUME, DETECTOR, BAND, READPATT, and SUBARRAY in the science data file.
 
 For NIRCam, flat-field reference files are selected based on the values of
-INSTRUME, DETECTOR, FILTER, and PUPIL of the science data file.
+INSTRUME, DETECTOR, FILTER, and PUPIL in the science data file.
 
 For NIRISS, flat-field reference files are selected based on the values of
-INSTRUME, DETECTOR, and FILTER of the science data file.
+INSTRUME, DETECTOR, and FILTER in the science data file.
 
 For NIRSpec, flat-field reference files are selected based on the values of
 INSTRUME, DETECTOR, FILTER, GRATING, and
-EXP_TYPE of the science data file.
+EXP_TYPE in the science data file.
 
 
 Reference File Formats for MIRI, NIRCAM, and NIRISS

--- a/docs/jwst/flatfield/reference_files.rst
+++ b/docs/jwst/flatfield/reference_files.rst
@@ -1,5 +1,5 @@
-Reference File
-==============
+Reference File Types
+====================
 There are four reference file types for the flat_field step.  Reftype
 FLAT is used for all data except NIRSpec.  NIRSpec data use three
 reftypes:  FFLAT (fore optics), SFLAT (spectrograph optics), and 
@@ -8,20 +8,23 @@ DFLAT (detector).
 
 CRDS Selection Criteria
 -----------------------
-Flat-field reference files are selected by the following criteria:
 
-- MIRI Imager: Match INSTRUME, DETECTOR, FILTER, READPATT, and
-  SUBARRAY of the science data file.  
+For MIRI Imaging, flat-field reference files are selected based on the values of
+INSTRUME, DETECTOR, FILTER, READPATT, and SUBARRAY in the science data file.
 
-- MIRI MRS: Match INSTRUME, DETECTOR, BAND, READPATT, and
-  SUBARRAY of the science data file.  
+For MIRI MRS, flat-field reference files are selected based on the values of
+INSTRUME, DETECTOR, BAND, READPATT, and SUBARRAY of the science data file.
 
-- NIRCam: Match INSTRUME, DETECTOR, FILTER, and PUPIL.
+For NIRCam, flat-field reference files are selected based on the values of
+INSTRUME, DETECTOR, FILTER, and PUPIL of the science data file.
 
-- NIRISS: Match INSTRUME, DETECTOR, and FILTER.
+For NIRISS, flat-field reference files are selected based on the values of
+INSTRUME, DETECTOR, and FILTER of the science data file.
 
-- NIRSpec: Match INSTRUME, DETECTOR, FILTER, GRATING, and
-  EXP_TYPE.
+For NIRSpec, flat-field reference files are selected based on the values of
+INSTRUME, DETECTOR, FILTER, GRATING, and
+EXP_TYPE of the science data file.
+
 
 Reference File Formats for MIRI, NIRCAM, and NIRISS
 ---------------------------------------------------
@@ -103,7 +106,7 @@ files.
 For the fore optics, the flat field for fixed-slit data contains just a
 FAST_VARIATION table (i.e. there is no image).  This table has five rows,
 one for each of the fixed slits.  The flat field for IFU data also contains
-just a FAST_VARIATION table, but it has only one row (with the value "ANY"
+just a FAST_VARIATION table, but it has only one row with the value "ANY"
 in the "slit_name" column.  For multi-object spectroscopic data, the flat
 field contains four sets (one for each MSA quadrant) of images, WAVELENGTH
 tables, and FAST_VARIATION tables.  The images are unique to the fore

--- a/docs/jwst/fringe/reference_files.rst
+++ b/docs/jwst/fringe/reference_files.rst
@@ -1,5 +1,6 @@
-Reference File
-==============
+Reference File Types
+====================
+
 The fringe correction step uses a FRINGE reference file, which has the same
 format as the FLAT reference file.  This correction is applied only to MIRI 
 MRS (IFU) mode exposures, which are always single full-frame 2-D images.

--- a/docs/jwst/ipc/reference_files.rst
+++ b/docs/jwst/ipc/reference_files.rst
@@ -1,5 +1,5 @@
-Reference File
-==============
+Reference File Types
+====================
 The IPC deconvolution current step uses an IPC reference file.
 
 CRDS Selection Criteria

--- a/docs/jwst/jump/reference_files.rst
+++ b/docs/jwst/jump/reference_files.rst
@@ -1,4 +1,4 @@
-Reference Files Types
+Reference File Types
 =====================
 
 The Jump step uses two reference files: GAIN and READNOISE. The gain values

--- a/docs/jwst/jump/reference_files.rst
+++ b/docs/jwst/jump/reference_files.rst
@@ -1,5 +1,6 @@
-Reference Files
-===============
+Reference Files Types
+=====================
+
 The Jump step uses two reference files: GAIN and READNOISE. The gain values
 are used to temporarily convert the pixel values from units of DN to
 electrons. The read noise values are used as part of the noise estimate for
@@ -7,27 +8,34 @@ each pixel. Both are necessary for proper computation of noise estimates.
 
 CRDS Selection Criteria
 -----------------------
-The readnoise reference file is selected by instrument, detector, readpatt and, 
+
+GAIN Reference Files
+^^^^^^^^^^^^^^^^^^^^
+The GAIN reference file is selected based on instrument, detector and,
 where necessary, subarray.
 
-The gain reference file is selected based on instrument, detector and,
-where necessary, subarray.
+READNOISE Reference Files
+^^^^^^^^^^^^^^^^^^^^^^^^^
+The READNOISE reference file is selected by instrument, detector and, where
+necessary, subarray.
 
 
-Gain Reference File Format
---------------------------
+Reference File Formats
+----------------------
+
+GAIN Reference Files
+^^^^^^^^^^^^^^^^^^^^
+
 The gain reference file is a FITS file with a single IMAGE extension,
 with ``EXTNAME=SCI``, which contains a 2-D floating-point array of gain values
 (in e/DN) per pixel. The REFTYPE value is ``GAIN``.
 
 
-Read Noise Reference File Format
---------------------------------
+READNOISE Reference Files
+^^^^^^^^^^^^^^^^^^^^^^^^^
 The read noise reference file is a FITS file with a single IMAGE extension,
-with ``EXTNAME=SCI``, which contains a 2-D floating-point array of read noise 
-values per pixel. The units of the read noise should be DN and should be the
+with ``EXTNAME=SCI``, which contains a 2-D floating-point array of read noise values
+per pixel. The units of the read noise should be electrons and should be the
 CDS (Correlated Double Sampling) read noise, i.e. the effective noise between
 any pair of non-destructive detector reads. The REFTYPE value is ``READNOISE``.
-
-
 

--- a/docs/jwst/jump/reference_files.rst
+++ b/docs/jwst/jump/reference_files.rst
@@ -34,8 +34,8 @@ with ``EXTNAME=SCI``, which contains a 2-D floating-point array of gain values
 READNOISE Reference Files
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 The read noise reference file is a FITS file with a single IMAGE extension,
-with ``EXTNAME=SCI``, which contains a 2-D floating-point array of read noise values
-per pixel. The units of the read noise should be electrons and should be the
+with ``EXTNAME=SCI``, which contains a 2-D floating-point array of read noise
+values per pixel. The units of the read noise should be DN and should be the
 CDS (Correlated Double Sampling) read noise, i.e. the effective noise between
 any pair of non-destructive detector reads. The REFTYPE value is ``READNOISE``.
 

--- a/docs/jwst/linearity/reference_files.rst
+++ b/docs/jwst/linearity/reference_files.rst
@@ -1,5 +1,5 @@
-Reference File
-==============
+Reference File Types
+====================
 
 The linearity correction step uses a LINEARITY reference file.
 
@@ -22,7 +22,7 @@ DQ       2      ncols x nrows            integer
 
 Each plane of the COEFFS data cube contains the pixel-by-pixel coefficients for
 the associated order of the polynomial. There can be any number of planes to
-accomodate a polynomial of any order.
+accommodate a polynomial of any order.
 
 The BINTABLE extension uses ``EXTNAME=DQ_DEF`` and contains the bit assignments
 of the conditions flagged in the DQ array.

--- a/docs/jwst/ramp_fitting/reference_files.rst
+++ b/docs/jwst/ramp_fitting/reference_files.rst
@@ -31,8 +31,8 @@ with ``EXTNAME=SCI``, which contains a 2-D floating-point array of gain values
 READNOISE Reference Files
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 The read noise reference file is a FITS file with a single IMAGE extension,
-with ``EXTNAME=SCI``, which contains a 2-D floating-point array of read noise values
-per pixel. The units of the read noise should be electrons and should be the
+with ``EXTNAME=SCI``, which contains a 2-D floating-point array of read noise
+values per pixel. The units of the read noise should be DN and should be the
 CDS (Correlated Double Sampling) read noise, i.e. the effective noise between
 any pair of non-destructive detector reads. The REFTYPE value is ``READNOISE``.
 

--- a/docs/jwst/ramp_fitting/reference_files.rst
+++ b/docs/jwst/ramp_fitting/reference_files.rst
@@ -6,29 +6,33 @@ electrons, and convert the results of ramp fitting back to DN.
 The read noise values are used as part of the noise estimate for
 each pixel. Both are necessary for proper computation of noise estimates.
 
-
-CRDS Selection Criteria
------------------------
-The readnoise reference file is selected by instrument, detector and, where
-necessary, subarray.
-
-The gain reference file is selected based on instrument, detector and,
+GAIN Reference Files
+^^^^^^^^^^^^^^^^^^^^
+The GAIN reference file is selected based on instrument, detector and,
 where necessary, subarray.
 
+READNOISE Reference Files
+^^^^^^^^^^^^^^^^^^^^^^^^^
+The READNOISE reference file is selected by instrument, detector and, where
+necessary, subarray.
 
-Gain Reference File Format
---------------------------
+
+Reference File Formats
+----------------------
+
+GAIN Reference Files
+^^^^^^^^^^^^^^^^^^^^
+
 The gain reference file is a FITS file with a single IMAGE extension,
 with ``EXTNAME=SCI``, which contains a 2-D floating-point array of gain values
 (in e/DN) per pixel. The REFTYPE value is ``GAIN``.
 
 
-Read Noise Reference File Format
---------------------------------
+READNOISE Reference Files
+^^^^^^^^^^^^^^^^^^^^^^^^^
 The read noise reference file is a FITS file with a single IMAGE extension,
-with ``EXTNAME=SCI``, which contains a 2-D floating-point array of read noise 
-values per pixel. The units of the read noise should be DN and should be the 
+with ``EXTNAME=SCI``, which contains a 2-D floating-point array of read noise values
+per pixel. The units of the read noise should be electrons and should be the
 CDS (Correlated Double Sampling) read noise, i.e. the effective noise between
 any pair of non-destructive detector reads. The REFTYPE value is ``READNOISE``.
-
 

--- a/docs/jwst/refpix/reference_files.rst
+++ b/docs/jwst/refpix/reference_files.rst
@@ -15,7 +15,8 @@ Refpix reference files are selected by DETECTOR and READPATT.
 Reference File Format
 ---------------------
 
-A single IRS2 extension provides the complex coefficients for the correction,
+A single extension, with a EXTNAME keyword of 'IRS2', 
+provides the complex coefficients for the correction,
 and contains 8 columns ALPHA_0, ALPHA_1, ALPHA_2, ALPHA_3, BETA_0, BETA_1,
 BETA_2, and BETA_3.  The ALPHA arrays contains correction multipliers to the
 data, and the BETA arrays contains correction multiplier to the reference

--- a/docs/jwst/refpix/reference_files.rst
+++ b/docs/jwst/refpix/reference_files.rst
@@ -1,6 +1,22 @@
-Reference File
-==============
+Reference File Types
+====================
+
 The refpix step only uses the refpix reference file when processing
 NIRSpec exposures that have been acquired using an IRS2 readout
 pattern. No other instruments or exposure modes require a reference
 file for this step.
+
+
+CRDS Selection Criteria
+-----------------------
+Refpix reference files are selected by DETECTOR and READPATT.
+
+
+Reference File Format
+---------------------
+
+A single IRS2 extension provides the complex coefficients for the correction,
+and contains 8 columns ALPHA_0, ALPHA_1, ALPHA_2, ALPHA_3, BETA_0, BETA_1,
+BETA_2, and BETA_3.  The ALPHA arrays contains correction multipliers to the
+data, and the BETA arrays contains correction multiplier to the reference
+output. Both arrays have 4 components - one for each sector.

--- a/docs/jwst/reset/reference_files.rst
+++ b/docs/jwst/reset/reference_files.rst
@@ -1,5 +1,5 @@
-Reference File
-==============
+Reference File Types
+====================
 The reset correction step uses a RESET reference file.
 
 CRDS Selection Criteria

--- a/docs/jwst/rscd/reference_files.rst
+++ b/docs/jwst/rscd/reference_files.rst
@@ -1,21 +1,35 @@
-Reference File
-==============
-The RSCD correction step uses an RSCD reference file. This correction is only applied to integration > 1. 
+Reference File Types
+====================
+
+The RSCD correction step uses an RSCD reference file. 
+
+
+Description
+-----------
+
+This correction is only applied to integration > 1. 
 The correction to be added to the input data has the form::
 
     corrected data = input data data + dn_accumulated * scale * exp(-T / tau)
 
 where, dn_accumulated is the DN level that was accumulated for the pixel from the previous integration. 
 In case where the dn_accumulated does not saturate the scale factor is determined as follows:
-       :math:`scale = b{1}* [Counts{2}^b{2} * [1/exp(Counts{2}/b{3}) -1]`
-    where :math:'b{1} = ascale * (illum_zpt + illum_slope*N + illum2* N^2` (N is the number of groups per integration)
-    and :math:`Counts{2}` = Final DN in last frame in last integration - Crossover Point (found in the reference file).
-If the previous integration saturates, :math:`scale` is modified in the following manner:
-   :math:` scale_\text{sat} = slope * Counts{3} + sat_\text{mzp}`, where :math:`Counts{3}' = extrapolated counts past 
-   saturation * sat_scale and :math: 'slope = sat_zp + sat_slope * N + sat_2*N^2 + evenrow_corrections'
 
-All fourteen  parameters :math:` tau, b{1},b{2},b{3},illum_zpt,illum_slope,illum2, Crossover Point, sat_zp, sat_slope, sat_2,
-    sat_scale, sat_\text{mzp} and evenrow_corrections` are found in the RSCD reference files.
+       :math:`scale = b{1}* [Counts{2}^{b{2}} * [1/exp(Counts{2}/b{3}) -1]`
+    
+where :math:`b{1} = ascale * (illum_{zpt} + illum_{slope}*N + illum2* N^2)` (N is the number of groups per integration)
+and :math:`Counts{2}` = Final DN in the last frame in the last integration - Crossover Point (found in the reference file).
+
+If the previous integration saturates, :math:`scale` is modified in the following manner:
+
+   :math:`scale_\text{sat} = slope * Counts{3} + sat_\text{mzp}`, 
+   
+where :math:`Counts{3}` = extrapolated counts past saturation * sat_scale and :math:`slope = sat_{zp} + sat_{slope} * N + sat_2*N^2 + evenrow_{corrections}`.
+
+
+All fourteen  parameters :math:`tau`, :math:`b{1}`, :math:`b{2}`, :math:`b{3}`, :math:`illum_{zpt}`,
+:math:`illum_{slope}`, :math:`illum2`, :math:`Crossover Point`, :math:`sat_{zp}`, :math:`sat_{slope}`, :math:`sat_2`,
+:math:`sat_{scale}`, :math:`sat_\text{mzp}`, and :math:`evenrow_{corrections}` are found in the RSCD reference files.
 
 CRDS Selection Criteria
 -----------------------
@@ -43,7 +57,7 @@ It uses ``EXTNAME=RSCD`` and contains seventeen columns:
 * ILLUM_ZP: float
 * ILLUM_SLOPE: float
 * ILLUM2: float
-* PARAM3: :math:`b{3}' in equation
+* PARAM3: :math:`b{3}` in equation
 * CROSSOPT: float, crossover point
 * SAT_ZP: float
 * SAT_SLOPE: float

--- a/docs/jwst/straylight/index.rst
+++ b/docs/jwst/straylight/index.rst
@@ -6,7 +6,7 @@ Stray Light Correction
    :maxdepth: 2
 
    main.rst
-   reference.rst
+   reference_files.rst
    arguments.rst
 
 .. automodapi:: jwst.straylight

--- a/docs/jwst/straylight/reference_files.rst
+++ b/docs/jwst/straylight/reference_files.rst
@@ -1,5 +1,5 @@
-Reference File
-==============
+Reference File Types
+====================
 The default algorithm  in the MIRI MRS stray-light correction step uses information contained
 in the  meta data of the input image which maps each pixels to a slice or the  region between the
 slices, also known as the slice gaps. This information was previously loaded from a reference file into the meta data by the assign_wcs

--- a/docs/jwst/superbias/reference_files.rst
+++ b/docs/jwst/superbias/reference_files.rst
@@ -1,5 +1,5 @@
-Reference File
-==============
+Reference File Types
+====================
 The superbias subtraction step uses a SUPERBIAS reference file.
 
 CRDS Selection Criteria


### PR DESCRIPTION
This is the first pull request to move the reference file specifications back into the JWST pipeline documentation from http://jwst-reffiles.stsci.edu/index.html.   These updates are minor and take the following forms:
* format changes 
* adding additional text that appeared in the jwst-reffiles especially referring to files using gain
* fixing the latex in the RCSD reference file

@hbushouse @rizeladiaz @jemorrison @dmggh 

