### PR TITLE
step.input_dir from step.process()

### DIFF
--- a/jwst/assign_wcs/assign_wcs_step.py
+++ b/jwst/assign_wcs/assign_wcs_step.py
@@ -1,4 +1,5 @@
 #! /usr/bin/env python
+import os.path
 from ..stpipe import Step
 from .. import datamodels
 import logging
@@ -65,7 +66,8 @@ class AssignWcsStep(Step):
             # Get the MSA metadata file if needed and add to reffiles
             msa_metadata_file = input_model.meta.instrument.msa_metadata_file
             if msa_metadata_file is not None:
-                msa_metadata_file = self.make_input_path(msa_metadata_file)
+                input_dir = os.path.split(self.make_input_path(input))[0]
+                msa_metadata_file = os.path.join(input_dir, msa_metadata_file)
                 reference_file_names['msametafile'] = msa_metadata_file
 
             result = load_wcs(input_model, reference_file_names)

--- a/jwst/assign_wcs/assign_wcs_step.py
+++ b/jwst/assign_wcs/assign_wcs_step.py
@@ -66,8 +66,8 @@ class AssignWcsStep(Step):
             # Get the MSA metadata file if needed and add to reffiles
             msa_metadata_file = input_model.meta.instrument.msa_metadata_file
             if msa_metadata_file is not None:
-                input_dir = os.path.split(self.make_input_path(input))[0]
-                msa_metadata_file = os.path.join(input_dir, msa_metadata_file)
+                self._set_input_dir(input))
+                msa_metadata_file = self.make_input_path(msa_metadata_file)
                 reference_file_names['msametafile'] = msa_metadata_file
 
             result = load_wcs(input_model, reference_file_names)

--- a/jwst/assign_wcs/assign_wcs_step.py
+++ b/jwst/assign_wcs/assign_wcs_step.py
@@ -66,7 +66,8 @@ class AssignWcsStep(Step):
             # Get the MSA metadata file if needed and add to reffiles
             msa_metadata_file = input_model.meta.instrument.msa_metadata_file
             if msa_metadata_file is not None:
-                self._set_input_dir(input))
+                if isinstance(input, str):
+                    self._set_input_dir([os.path.abspath(input)])
                 msa_metadata_file = self.make_input_path(msa_metadata_file)
                 reference_file_names['msametafile'] = msa_metadata_file
 

--- a/jwst/stpipe/step.py
+++ b/jwst/stpipe/step.py
@@ -936,6 +936,8 @@ class Step():
         if isinstance(file_path, str):
             original_path, file_name = split(file_path)
             if not len(original_path):
+                if self.input_dir is None:
+                    self._set_input_dir([file_path])
                 full_path = join(self.input_dir, file_name)
 
         return full_path

--- a/jwst/stpipe/step.py
+++ b/jwst/stpipe/step.py
@@ -935,9 +935,7 @@ class Step():
         full_path = file_path
         if isinstance(file_path, str):
             original_path, file_name = split(file_path)
-            if not len(original_path):
-                if self.input_dir is None:
-                    self._set_input_dir([file_path])
+            if not len(original_path) and self.input_dir is not None:
                 full_path = join(self.input_dir, file_name)
 
         return full_path

--- a/jwst/stpipe/tests/test_input.py
+++ b/jwst/stpipe/tests/test_input.py
@@ -76,7 +76,7 @@ def test_input_dir_from_step_process(mk_tmp_dirs):
     input_file = t_path('data/flat.fits')
 
     step = StepWithModel()
-    step.process(input_file)
+    step._set_input_dir([input_file])
 
     # Check that `input_dir` is set.
     input_path = path.split(input_file)[0]

--- a/jwst/stpipe/tests/test_input.py
+++ b/jwst/stpipe/tests/test_input.py
@@ -71,7 +71,7 @@ def test_input_dir_with_model(mk_tmp_dirs):
     assert step.input_dir == ''
 
 
-def test_input_dir_from_step_process(mk_tmp_dirs):
+def test_set_input_dir_1(mk_tmp_dirs):
     """ Test that input_dir is set when calling step.process. """
     input_file = t_path('data/flat.fits')
 

--- a/jwst/stpipe/tests/test_input.py
+++ b/jwst/stpipe/tests/test_input.py
@@ -69,3 +69,15 @@ def test_input_dir_with_model(mk_tmp_dirs):
     step.run(model)
 
     assert step.input_dir == ''
+
+
+def test_input_dir_from_step_process(mk_tmp_dirs):
+    """ Test that input_dir is set when calling step.process. """
+    input_file = t_path('data/flat.fits')
+
+    step = StepWithModel()
+    step.process(input_file)
+
+    # Check that `input_dir` is set.
+    input_path = path.split(input_file)[0]
+    assert step.input_dir == input_path


### PR DESCRIPTION
`Step.input_dir` is not set when the step is run in an interactive session using `Step.process(input)`.
This PR fixes the immediate issue by calling `_set_input_dir` within `assign_wcs.process`.

Consider making `step._set_input_dir` public.