### PR TITLE
Do not write asdf extension when saving reference files

### DIFF
--- a/jwst/datamodels/barshadow.py
+++ b/jwst/datamodels/barshadow.py
@@ -1,9 +1,9 @@
-from . import model_base
+from .reference import ReferenceFileModel
 
 __all__ = ['BarshadowModel']
 
 
-class BarshadowModel(model_base.DataModel):
+class BarshadowModel(ReferenceFileModel):
     """
     A data model for Bar Shadow correction information.
 

--- a/jwst/datamodels/dark.py
+++ b/jwst/datamodels/dark.py
@@ -1,10 +1,10 @@
-from . import model_base
+from .reference import ReferenceFileModel
 from .dynamicdq import dynamic_mask
 
 __all__ = ['DarkModel']
 
 
-class DarkModel(model_base.DataModel):
+class DarkModel(ReferenceFileModel):
     """
     A data model for dark reference files.
 

--- a/jwst/datamodels/darkMIRI.py
+++ b/jwst/datamodels/darkMIRI.py
@@ -1,10 +1,10 @@
-from . import model_base
+from .reference import ReferenceFileModel
 from .dynamicdq import dynamic_mask
 
 __all__ = ['DarkMIRIModel']
 
 
-class DarkMIRIModel(model_base.DataModel):
+class DarkMIRIModel(ReferenceFileModel):
     """
     A data model for dark MIRI reference files.
 

--- a/jwst/datamodels/drizpars.py
+++ b/jwst/datamodels/drizpars.py
@@ -1,9 +1,9 @@
-from . import model_base
+from .reference import ReferenceFileModel
 
 __all__ = ['DrizParsModel', 'NircamDrizParsModel', 'MiriImgDrizParsModel']
 
 
-class DrizParsModel(model_base.DataModel):
+class DrizParsModel(ReferenceFileModel):
     """
     A data model for drizzle parameters reference tables.
     """

--- a/jwst/datamodels/flat.py
+++ b/jwst/datamodels/flat.py
@@ -1,11 +1,11 @@
-from . import model_base
+from .reference import ReferenceFileModel
 from .dynamicdq import dynamic_mask
 
 
 __all__ = ['FlatModel']
 
 
-class FlatModel(model_base.DataModel):
+class FlatModel(ReferenceFileModel):
     """
     A data model for 2D flat-field images.
 

--- a/jwst/datamodels/fringe.py
+++ b/jwst/datamodels/fringe.py
@@ -1,11 +1,11 @@
-from . import model_base
+from .reference import ReferenceFileModel
 from .dynamicdq import dynamic_mask
 
 
 __all__ = ['FringeModel']
 
 
-class FringeModel(model_base.DataModel):
+class FringeModel(ReferenceFileModel):
     """
     A data model for 2D fringe correction images.
 

--- a/jwst/datamodels/gain.py
+++ b/jwst/datamodels/gain.py
@@ -1,10 +1,10 @@
-from . import model_base
+from .reference import ReferenceFileModel
 
 
 __all__ = ['GainModel']
 
 
-class GainModel(model_base.DataModel):
+class GainModel(ReferenceFileModel):
     """
     A data model for 2D gain.
 

--- a/jwst/datamodels/ifucubepars.py
+++ b/jwst/datamodels/ifucubepars.py
@@ -1,9 +1,9 @@
-from . import model_base
+from .reference import ReferenceFileModel
 
 __all__ = ['IFUCubeParsModel']
 
 
-class IFUCubeParsModel(model_base.DataModel):
+class IFUCubeParsModel(ReferenceFileModel):
     """
     A data model for IFU Cube  parameters reference tables.
     """
@@ -25,7 +25,7 @@ class NirspecIFUCubeParsModel(IFUCubeParsModel):
     """
     schema_url = "nirspec_ifucubepars.schema.yaml"
 
-    def __init__(self, init=None, ifucubepars_table=None, 
+    def __init__(self, init=None, ifucubepars_table=None,
                  ifucubepars_msn_table=None,
                  ifucubepars_prism_wavetable=None,
                  ifucubepars_med_wavetable=None,
@@ -53,7 +53,7 @@ class MiriIFUCubeParsModel(IFUCubeParsModel):
     """
     schema_url = "miri_ifucubepars.schema.yaml"
 
-    def __init__(self, init=None, ifucubepars_table=None, 
+    def __init__(self, init=None, ifucubepars_table=None,
                  ifucubepars_msn_table=None,
                  ifucubepars_multichannel_wavetable=None,**kwargs):
         super(MiriIFUCubeParsModel, self).__init__(init=init, **kwargs)

--- a/jwst/datamodels/ipc.py
+++ b/jwst/datamodels/ipc.py
@@ -1,8 +1,8 @@
-from . import model_base
+from .reference import ReferenceFileModel
 
 __all__ = ['IPCModel']
 
-class IPCModel(model_base.DataModel):
+class IPCModel(ReferenceFileModel):
     """
     A data model for IPC kernel checking information.
 

--- a/jwst/datamodels/lastframe.py
+++ b/jwst/datamodels/lastframe.py
@@ -1,10 +1,10 @@
-from . import model_base
+from .reference import ReferenceFileModel
 from .dynamicdq import dynamic_mask
 
 __all__ = ['LastFrameModel']
 
 
-class LastFrameModel(model_base.DataModel):
+class LastFrameModel(ReferenceFileModel):
     """
     A data model for Last frame correction reference files.
 

--- a/jwst/datamodels/linearity.py
+++ b/jwst/datamodels/linearity.py
@@ -1,11 +1,11 @@
-from . import model_base
+from .reference import ReferenceFileModel
 from .dynamicdq import dynamic_mask
 
 
 __all__ = ['LinearityModel']
 
 
-class LinearityModel(model_base.DataModel):
+class LinearityModel(ReferenceFileModel):
     """
     A data model for linearity correction information.
 

--- a/jwst/datamodels/mask.py
+++ b/jwst/datamodels/mask.py
@@ -1,10 +1,10 @@
-from . import model_base
+from .reference import ReferenceFileModel
 from .dynamicdq import dynamic_mask
 
 __all__ = ['MaskModel']
 
 
-class MaskModel(model_base.DataModel):
+class MaskModel(ReferenceFileModel):
     """
     A data model for 2D masks.
 

--- a/jwst/datamodels/model_base.py
+++ b/jwst/datamodels/model_base.py
@@ -180,6 +180,9 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         self._instance = asdf.tree
         self._asdf = asdf
 
+        # Initalize class dependent hidden fields
+        self._no_asdf_extension = False
+
         # Instantiate the primary array of the image
         if is_array:
             primary_array = self.get_primary_array_name()
@@ -290,6 +293,7 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
         target._files_to_close = []
         target._shape = source._shape
         target._ctx = target
+        target._no_asdf_extension = source._no_asdf_extension
 
     def copy(self, memo=None):
         """
@@ -466,7 +470,10 @@ class DataModel(properties.ObjectNode, ndmodel.NDModel):
                                   extensions=self._extensions) as ff:
             with warnings.catch_warnings():
                 warnings.filterwarnings('ignore', message='Card is too long')
-                ff.write_to(init, *args, **kwargs)
+                if self._no_asdf_extension:
+                    ff._hdulist.writeto(init, *args, **kwargs)
+                else:
+                    ff.write_to(init, *args, **kwargs)
 
     @property
     def shape(self):

--- a/jwst/datamodels/multiextract1d.py
+++ b/jwst/datamodels/multiextract1d.py
@@ -1,11 +1,11 @@
-from . import model_base
+from .reference import ReferenceFileModel
 from .extract1dimage import Extract1dImageModel
 
 
 __all__ = ['MultiExtract1dImageModel']
 
 
-class MultiExtract1dImageModel(model_base.DataModel):
+class MultiExtract1dImageModel(ReferenceFileModel):
     """
     A data model for extract_1d reference images.
 

--- a/jwst/datamodels/nirspec_flat.py
+++ b/jwst/datamodels/nirspec_flat.py
@@ -1,9 +1,9 @@
-from . import model_base
+from .reference import ReferenceFileModel
 from .dynamicdq import dynamic_mask
 
 __all__ = ['NRSFlatModel']
 
-class NRSFlatModel(model_base.DataModel):
+class NRSFlatModel(ReferenceFileModel):
     """A base class for NIRSpec flat-field reference file models."""
 
     schema_url = "nirspec.flat.schema.yaml"

--- a/jwst/datamodels/outlierpars.py
+++ b/jwst/datamodels/outlierpars.py
@@ -1,9 +1,9 @@
-from . import model_base
+from .reference import ReferenceFileModel
 
 __all__ = ['OutlierParsModel']
 
 
-class OutlierParsModel(model_base.DataModel):
+class OutlierParsModel(ReferenceFileModel):
     """
     A data model for outlier detection parameters reference tables.
     """

--- a/jwst/datamodels/pathloss.py
+++ b/jwst/datamodels/pathloss.py
@@ -1,11 +1,11 @@
-from . import model_base
+from .reference import ReferenceFileModel
 from .dynamicdq import dynamic_mask
 
 
 __all__ = ['PathlossModel']
 
 
-class PathlossModel(model_base.DataModel):
+class PathlossModel(ReferenceFileModel):
     """
     A data model for pathloss correction information.
 

--- a/jwst/datamodels/persat.py
+++ b/jwst/datamodels/persat.py
@@ -1,9 +1,9 @@
-from . import model_base
+from .reference import ReferenceFileModel
 from .dynamicdq import dynamic_mask
 
 __all__ = ['PersistenceSatModel']
 
-class PersistenceSatModel(model_base.DataModel):
+class PersistenceSatModel(ReferenceFileModel):
     """
     A data model for the persistence saturation value (full well).
 

--- a/jwst/datamodels/photom.py
+++ b/jwst/datamodels/photom.py
@@ -1,10 +1,10 @@
-from . import model_base
+from .reference import ReferenceFileModel
 from .dynamicdq import dynamic_mask
 
 __all__ = ['PhotomModel']
 
 
-class PhotomModel(model_base.DataModel):
+class PhotomModel(ReferenceFileModel):
     """
     A base class for photometric reference file models.
     """

--- a/jwst/datamodels/pixelarea.py
+++ b/jwst/datamodels/pixelarea.py
@@ -1,11 +1,11 @@
-from . import model_base
+from .reference import ReferenceFileModel
 
 
 __all__ = ['PixelAreaModel', 'NirspecSlitAreaModel', 'NirspecMosAreaModel',
            'NirspecIfuAreaModel']
 
 
-class PixelAreaModel(model_base.DataModel):
+class PixelAreaModel(ReferenceFileModel):
     """
     A data model for the pixel area map
     """
@@ -18,7 +18,7 @@ class PixelAreaModel(model_base.DataModel):
             self.data = data
 
 
-class NirspecSlitAreaModel(model_base.DataModel):
+class NirspecSlitAreaModel(ReferenceFileModel):
     """
     A data model for the NIRSpec fixed-slit pixel area reference file
 
@@ -43,7 +43,7 @@ class NirspecSlitAreaModel(model_base.DataModel):
         if area_table is not None:
             self.area_table = area_table
 
-class NirspecMosAreaModel(model_base.DataModel):
+class NirspecMosAreaModel(ReferenceFileModel):
     """
     A data model for the NIRSpec MOS pixel area reference file
 
@@ -70,7 +70,7 @@ class NirspecMosAreaModel(model_base.DataModel):
         if area_table is not None:
             self.area_table = area_table
 
-class NirspecIfuAreaModel(model_base.DataModel):
+class NirspecIfuAreaModel(ReferenceFileModel):
     """
     A data model for the NIRSpec IFU pixel area reference file
 

--- a/jwst/datamodels/psfmask.py
+++ b/jwst/datamodels/psfmask.py
@@ -1,10 +1,10 @@
-from . import model_base
+from .reference import ReferenceFileModel
 
 
 __all__ = ['PsfMaskModel']
 
 
-class PsfMaskModel(model_base.DataModel):
+class PsfMaskModel(ReferenceFileModel):
     """
     A data model for coronagraphic 2D PSF mask reference files
 

--- a/jwst/datamodels/readnoise.py
+++ b/jwst/datamodels/readnoise.py
@@ -1,10 +1,10 @@
-from . import model_base
+from .reference import ReferenceFileModel
 
 
 __all__ = ['ReadnoiseModel']
 
 
-class ReadnoiseModel(model_base.DataModel):
+class ReadnoiseModel(ReferenceFileModel):
     """
     A data model for 2D readnoise.
 

--- a/jwst/datamodels/reference.py
+++ b/jwst/datamodels/reference.py
@@ -1,10 +1,10 @@
-from . import model_base
+from .model_base import DataModel
 
 
-__all__ = ['ReferencefileModel']
+__all__ = ['ReferenceFileModel']
 
 
-class ReferenceFileModel(model_base.DataModel):
+class ReferenceFileModel(DataModel):
     """
     A data model for reference tables
 
@@ -17,6 +17,7 @@ class ReferenceFileModel(model_base.DataModel):
 
     def __init__(self, init=None, **kwargs):
         super(ReferenceFileModel, self).__init__(init=init, **kwargs)
+        self._no_asdf_extension = True
         self.meta.telescope = "JWST"
 
     def validate(self):
@@ -32,8 +33,10 @@ class ReferenceFileModel(model_base.DataModel):
         assert self.meta.useafter is not None
         assert self.meta.instrument.name is not None
 
+        super(ReferenceFileModel, self).validate()
 
-class ReferenceImageModel(model_base.DataModel):
+
+class ReferenceImageModel(ReferenceFileModel):
     """
     A data model for 2D reference images
 
@@ -70,7 +73,7 @@ class ReferenceImageModel(model_base.DataModel):
         self.err = self.err
 
 
-class ReferenceCubeModel(model_base.DataModel):
+class ReferenceCubeModel(ReferenceFileModel):
     """
     A data model for 3D reference images
 
@@ -106,7 +109,7 @@ class ReferenceCubeModel(model_base.DataModel):
         self.dq = self.dq
         self.err = self.err
 
-class ReferenceQuadModel(model_base.DataModel):
+class ReferenceQuadModel(ReferenceFileModel):
     """
     A data model for 4D reference images
 

--- a/jwst/datamodels/reset.py
+++ b/jwst/datamodels/reset.py
@@ -1,10 +1,10 @@
-from . import model_base
+from .reference import ReferenceFileModel
 from .dynamicdq import dynamic_mask
 
 __all__ = ['ResetModel']
 
 
-class ResetModel(model_base.DataModel):
+class ResetModel(ReferenceFileModel):
     """
     A data model for reset correction reference files.
 

--- a/jwst/datamodels/resolution.py
+++ b/jwst/datamodels/resolution.py
@@ -1,9 +1,9 @@
-from . import model_base
+from .reference import ReferenceFileModel
 
 __all__ = ['ResolutionModel', 'MiriResolutionModel']
 
 
-class ResolutionModel(model_base.DataModel):
+class ResolutionModel(ReferenceFileModel):
     """
     A data model for Spectral Resolution  parameters reference tables.
     """
@@ -19,7 +19,7 @@ class ResolutionModel(model_base.DataModel):
 class MiriResolutionModel(ResolutionModel):
     """
     A data model for MIRI Resolution reference files.
-    
+
     Parameters
     ----------
     init : any

--- a/jwst/datamodels/rscd.py
+++ b/jwst/datamodels/rscd.py
@@ -1,10 +1,10 @@
-from . import model_base
+from .reference import ReferenceFileModel
 
 
 __all__ = ['RSCDModel']
 
 
-class RSCDModel(model_base.DataModel):
+class RSCDModel(ReferenceFileModel):
     """
     A data model for the RSCD reference file.
 

--- a/jwst/datamodels/saturation.py
+++ b/jwst/datamodels/saturation.py
@@ -1,9 +1,9 @@
-from . import model_base
+from .reference import ReferenceFileModel
 from .dynamicdq import dynamic_mask
 
 __all__ = ['SaturationModel']
 
-class SaturationModel(model_base.DataModel):
+class SaturationModel(ReferenceFileModel):
     """
     A data model for saturation checking information.
 

--- a/jwst/datamodels/straylight.py
+++ b/jwst/datamodels/straylight.py
@@ -1,10 +1,10 @@
-from . import model_base
+from .reference import ReferenceFileModel
 
 
 __all__ = ['StrayLightModel']
 
 
-class StrayLightModel(model_base.DataModel):
+class StrayLightModel(ReferenceFileModel):
     """
     A data model for 2D straylight mask.
 

--- a/jwst/datamodels/superbias.py
+++ b/jwst/datamodels/superbias.py
@@ -1,11 +1,11 @@
-from . import model_base
+from .reference import ReferenceFileModel
 from .dynamicdq import dynamic_mask
 
 
 __all__ = ['SuperBiasModel']
 
 
-class SuperBiasModel(model_base.DataModel):
+class SuperBiasModel(ReferenceFileModel):
     """
     A data model for 2D super-bias images.
     """

--- a/jwst/datamodels/throughput.py
+++ b/jwst/datamodels/throughput.py
@@ -1,10 +1,10 @@
-from . import model_base
+from .reference import ReferenceFileModel
 
 
 __all__ = ['ThroughputModel']
 
 
-class ThroughputModel(model_base.DataModel):
+class ThroughputModel(ReferenceFileModel):
     """
     A data model for filter throughput.
     """

--- a/jwst/datamodels/trapdensity.py
+++ b/jwst/datamodels/trapdensity.py
@@ -1,9 +1,9 @@
-from . import model_base
+from .reference import ReferenceFileModel
 from .dynamicdq import dynamic_mask
 
 __all__ = ['TrapDensityModel']
 
-class TrapDensityModel(model_base.DataModel):
+class TrapDensityModel(ReferenceFileModel):
     """
     A data model for the trap density of a detector, for persistence.
 

--- a/jwst/datamodels/trappars.py
+++ b/jwst/datamodels/trappars.py
@@ -1,10 +1,10 @@
-from . import model_base
+from .reference import ReferenceFileModel
 
 
 __all__ = ['TrapParsModel']
 
 
-class TrapParsModel(model_base.DataModel):
+class TrapParsModel(ReferenceFileModel):
     """
     A data model for trap capture and decay parameters.
 

--- a/jwst/datamodels/wfssbkg.py
+++ b/jwst/datamodels/wfssbkg.py
@@ -1,11 +1,11 @@
-from . import model_base
+from .reference import ReferenceFileModel
 from .dynamicdq import dynamic_mask
 
 
 __all__ = ['WfssBkgModel']
 
 
-class WfssBkgModel(model_base.DataModel):
+class WfssBkgModel(ReferenceFileModel):
     """
     A data model for 2D WFSS master background reference files.
 


### PR DESCRIPTION
The asdf format has had compatibility problems between software
versions that has complicated the handling of reference files. So
datamodels this code change updates datamodels to not write an asdf
extension to reference files. There are three changes:

Datamodels has a new attribute, _no_asdf_extension. It is set to True
for reference files and False for other files. When a datamodel is
saved to a file, the code checks this attribute and calls the fitsio
writeto method if it is True and asdf write_to method if it is False.

All reference file model types are now subclassed from
ReferenceFileModel, which sets _no_asdf_extension to True.

The validate method in ReferenceFileModel now calls the validate
method in the base class of Datamodels so that full validation is done
when updating reference files.