### PR TITLE
NRS: fix input units to meters when filter=OPAQUE

### DIFF
--- a/jwst/assign_wcs/nirspec.py
+++ b/jwst/assign_wcs/nirspec.py
@@ -722,8 +722,10 @@ def gwa_to_ifuslit(slits, input_model, disperser, reference_files):
     # The wavelength units up to this point are
     # meters as required by the pipeline but the desired output wavelength units is microns.
     # So we are going to Scale the spectral units by 1e6 (meters -> microns)
+    # and by e-6 (microns --> meters) in the inverse transform.
     if input_model.meta.instrument.filter == 'OPAQUE':
         lgreq = lgreq | Scale(1e6)
+        agreq = Scale(1e-6) & Identity(3) | agreq
 
     lam_cen = 0.5 * (input_model.meta.wcsinfo.waverange_end -
                      input_model.meta.wcsinfo.waverange_start
@@ -745,7 +747,7 @@ def gwa_to_ifuslit(slits, input_model, disperser, reference_files):
         msa2gwa = ifuslicer_transform & Const1D(lam_cen) | ifupost_transform | collimator2gwa
         gwa2slit = gwa_to_ymsa(msa2gwa, lam_cen)# TODO: Use model sets here
 
-        # The commnts below list the input coordinates.
+        # The comments below list the input coordinates.
         bgwa2msa = (
             # (alpha_out, beta_out, gamma_out), angles at the GWA, coming from the camera
             # (0, - beta_out, alpha_out, beta_out)
@@ -803,8 +805,10 @@ def gwa_to_slit(open_slits, input_model, disperser, reference_files):
     # The wavelength units up to this point are
     # meters as required by the pipeline but the desired output wavelength units is microns.
     # So we are going to Scale the spectral units by 1e6 (meters -> microns)
+    # and by e-6 (microns --> meters) in the inverse transform
     if input_model.meta.instrument.filter == 'OPAQUE':
         lgreq = lgreq | Scale(1e6)
+        agreq = Scale(1e-6) & Identity(3) | agreq
 
     msa = MSAModel(reference_files['msa'])
     slit_models = []


### PR DESCRIPTION
When a limited WCS pipeline is run (fitler="OPAQUE") the input is in units of microns and should be converted to meters.