### PR TITLE
Purge unused dependencies

### DIFF
--- a/.rtd-environment.yml
+++ b/.rtd-environment.yml
@@ -1,6 +1,6 @@
 channels:
   - http://ssb.stsci.edu/astroconda-dev
-  
+
 dependencies:
   - python>=3
   - setuptools
@@ -9,7 +9,6 @@ dependencies:
   - crds
   - dask
   - drizzle
-  - drizzlepac
   - gwcs
   - jsonschema
   - jplephem

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ env:
                               crds
                               dask
                               drizzle
-                              fitsblender
                               flake8
                               gwcs
                               jsonschema

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,6 @@ def CONDA_DEPS = "asdf \
                   crds \
                   dask \
                   drizzle \
-                  fitsblender \
                   flake8 \
                   gwcs \
                   jsonschema \

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -18,7 +18,6 @@ def CONDA_DEPS = "asdf \
                   crds \
                   dask \
                   drizzle \
-                  fitsblender \
                   flake8 \
                   gwcs \
                   jsonschema \


### PR DESCRIPTION
This prevents `drizzlepac` and `fitsblender` from getting used by RTD, Travis, and Jenkins.

Here's a PR to do the same thing to our `astroconda-dev` recipe:
https://github.com/astroconda/astroconda-dev/pull/137