### PR TITLE
fix for save_catalog bug introduced in #2097

### DIFF
--- a/jwst/source_catalog/source_catalog_step.py
+++ b/jwst/source_catalog/source_catalog_step.py
@@ -25,6 +25,7 @@ class SourceCatalogStep(Step):
         deblend = boolean(default=False)      # deblend sources?
         output_ext = string(default='.ecsv')  # Default type of output
         suffix = string(default='cat')        # Default suffix for output files
+        save_results = boolean(default=True)  # Save the output catalog
     """
 
     def process(self, input):
@@ -48,7 +49,7 @@ class SourceCatalogStep(Step):
             self.log.info('Detected {0} sources'.format(len(catalog)))
 
             if self.save_results:
-                cat_filepath = self.make_output_path()
+                cat_filepath = self.make_output_path(basepath=model.meta.filename)
                 catalog.write(
                     cat_filepath, format='ascii.ecsv', overwrite=True
                 )


### PR DESCRIPTION
This updates the configspec for `source_catalog` to set save_results to true, the default in `stpipe` is false and this step has no `output_file` spec. There may be a better way to do this, @stscieisenhamer should verify this fix.

I also added the datamodel filename as the the root for the output. 

Testing this locally with my wfss data give results I would expect. 