### PR TITLE
white_light should handle segmented data and data with multiple orders

### DIFF
--- a/jwst/white_light/white_light.py
+++ b/jwst/white_light/white_light.py
@@ -14,12 +14,39 @@ log.setLevel(logging.DEBUG)
 
 def white_light(input):
 
-    nints = input.meta.exposure.nints
+    ntables = len(input.spec)
     fluxsums = []
     times = []
 
+    # The input should contain one row per integration for each spectral
+    # order.  NIRISS SOSS data can contain up to three orders.
+    norders = 0                 # number of different spectral orders
+    sporders = []               # list of spectral order numbers
+    ntables_order = []          # number of tables for each spectral order
+    prev_spectral_order = -999
+    for i in range(ntables):
+        # The following assumes that all rows for a given spectral order
+        # are contiguous.
+        spectral_order = input.spec[i].spectral_order
+        if spectral_order is None:
+            norders = 1
+            sporders = [0]
+            ntables_order = [ntables]
+            break
+        if spectral_order != prev_spectral_order:
+            sporders.append(spectral_order)
+            prev_spectral_order = spectral_order
+            ntables_order.append(1)
+            norders = len(sporders)
+        else:
+            ntables_order[norders - 1] += 1
+
+    nints = max(ntables_order)
+    log.debug("norders = %d, sporders = %s, ntables_order = %s",
+              norders, str(sporders), str(ntables_order))
+
     # Compute the flux sum for each integration in the input
-    for i in np.arange(nints):
+    for i in range(ntables):
         fluxsums.append(input.spec[i].spec_table['FLUX'].sum())
 
     # Populate meta data for the output table
@@ -37,11 +64,19 @@ def white_light(input):
     tbl = QTable(meta=tbl_meta)
 
     # Compute the delta time of each integration
+    dt_arr = np.zeros(ntables, dtype=np.float64)
     dt = (input.meta.exposure.group_time * (input.meta.exposure.ngroups + 1))
-    dt_arr = (np.arange(1, 1 + input.meta.exposure.nints) * dt - (dt / 2.))
+    j0 = 0
+    for k in range(norders):
+        ntables_current = ntables_order[k]
+        j1 = j0 + ntables_current
+        dt_arr[j0 : j1] = np.arange(1, 1 + ntables_current) * dt - (dt / 2.)
+        j0 += ntables_current
     int_dt = TimeDelta(dt_arr, format='sec')
 
     # Compute the absolute time at the mid-point of each integration
+    # Note that this won't be correct if the input has been segmented and
+    # the current file is not the first segment.
     int_times = (Time(input.meta.exposure.start_time, format='mjd') + int_dt)
 
     # Store the times and flux sums in the table


### PR DESCRIPTION
The `white_light` step failed because the original file had been segmented and the code was using `input.meta.exposure.nints` for the number of integrations.  Furthermore, the input can contain several (up to three) tables for each integration, i.e. one for each spectral order.  The section of the code that computes the time for each integration was modified to take into account the possibility that the input contained more than one spectral order.  The number of tables for each spectral order is determined from the input tables, rather than relying on the NINTS keyword.  See issue #2148.

While testing the above change using NIRISS SOSS data, it was noticed that the `extract_1d` step was printing a warning message for every integration (for spectral orders 2 and 3), e.g. "Using RELSENS, 736 elements were extrapolated; these values will be set to 1."  This should only have been printed for the first integration (see issue #2079).  This was printed by function `interpolate_response`, so a `verbose` argument was added to that function, and verbose is set to False after the first integration.