### PR TITLE
fix for NRS prism 

### DIFF
--- a/jwst/assign_wcs/nirspec.py
+++ b/jwst/assign_wcs/nirspec.py
@@ -18,6 +18,7 @@ from ..transforms.models import (Rotation3DToGWA, DirCos2Unitless, Slit2Msa,
                                  AngleFromGratingEquation, WavelengthFromGratingEquation,
                                  Gwa2Slit, Unitless2DirCos, Logical, Slit, Snell,
                                  RefractionIndexFromPrism)
+
 from .util import not_implemented_mode
 from . import pointing
 from ..datamodels import (CollimatorModel, CameraModel, DisperserModel, FOREModel,
@@ -881,11 +882,7 @@ def wavelength_from_disperser(disperser, input_model):
                                               sporder, name='lambda_from_gratingeq')
         return lgreq
     else:
-        lmin = input_model.meta.wcsinfo.waverange_start
-        lmax = input_model.meta.wcsinfo.waverange_end
-        step = 1e-10
-        nsteps = (lmax - lmin) // step
-        lam = np.linspace(lmin, lmax, nsteps)
+        lam = np.arange(0.5, 6.005, 0.005) * 1e-6
         system_temperature = input_model.meta.instrument.gwa_tilt
         if system_temperature is None:
             message = "Missing reference temperature (keyword GWA_TILT)."


### PR DESCRIPTION
Change the interpolation points in the wavelength interpolation to match those in the IDT code.
This fixes the mismatch in the wavelength calibration for the prism.