### PR TITLE
process NRS_AUTOFLAT as a MOS observation

### DIFF
--- a/jwst/assign_wcs/assign_wcs.py
+++ b/jwst/assign_wcs/assign_wcs.py
@@ -50,7 +50,7 @@ def load_wcs(input_model, reference_files={}):
         output_model.meta.cal_step.assign_wcs = 'COMPLETE'
         exclude_types = ['NRS_FIXEDSLIT', 'NRS_BRIGHTOBJ', 'NRS_IFU',
                          'NRS_MSASPEC', 'NRS_LAMP', 'MIR_MRS', 'NIS_SOSS',
-                         'NRC_WFSS', 'NRC_TSGRISM', 'NIS_WFSS']
+                         'NRC_WFSS', 'NRC_TSGRISM', 'NIS_WFSS', 'NRS_AUTOFLAT']
 
         if output_model.meta.exposure.type not in exclude_types:
             orig_s_region = output_model.meta.wcsinfo.s_region.strip()

--- a/jwst/assign_wcs/nirspec.py
+++ b/jwst/assign_wcs/nirspec.py
@@ -317,7 +317,7 @@ def get_open_slits(input_model, reference_files=None):
     """Return the opened slits/shutters in a MOS or Fixed Slits exposure.
     """
     exp_type = input_model.meta.exposure.type.lower()
-    if exp_type == "nrs_msaspec":
+    if exp_type in ["nrs_msaspec", "nrs_autoflat"]:
         msa_metadata_file, msa_metadata_id = get_msa_metadata(input_model, reference_files)
         slits = get_open_msa_slits(msa_metadata_file, msa_metadata_id)
     elif exp_type == "nrs_fixedslit":
@@ -1536,7 +1536,7 @@ exp_type2transform = {'nrs_tacq': imaging,
                       'nrs_focus': imaging,
                       'nrs_mimf': imaging,
                       'nrs_bota': imaging,
-                      'nrs_autoflat': not_implemented_mode,
+                      'nrs_autoflat': slits_wcs,
                       'nrs_autowave': not_implemented_mode,
                       'nrs_lamp': slits_wcs,
                       'nrs_brightobj': slits_wcs,

--- a/jwst/extract_2d/extract_2d.py
+++ b/jwst/extract_2d/extract_2d.py
@@ -29,7 +29,8 @@ def extract2d(input_model, slit_name=None, apply_wavecorr=False, reference_files
         A list of grism objects.
     """
 
-    nrs_modes = ['NRS_FIXEDSLIT', 'NRS_MSASPEC', 'NRS_BRIGHTOBJ', 'NRS_LAMP']
+    nrs_modes = ['NRS_FIXEDSLIT', 'NRS_MSASPEC', 'NRS_BRIGHTOBJ',
+                 'NRS_LAMP', 'NRS_AUTOFLAT']
     grism_modes = ['NIS_WFSS', 'NRC_WFSS']
 
     exp_type = input_model.meta.exposure.type.upper()

--- a/jwst/extract_2d/nirspec.py
+++ b/jwst/extract_2d/nirspec.py
@@ -35,7 +35,8 @@ def nrs_extract2d(input_model, slit_name=None, apply_wavecorr=False, reference_f
     """
     exp_type = input_model.meta.exposure.type.upper()
 
-    wavecorr_supported_modes = ['NRS_FIXEDSLIT', 'NRS_MSASPEC', 'NRS_BRIGHTOBJ']
+    wavecorr_supported_modes = ['NRS_FIXEDSLIT', 'NRS_MSASPEC', 'NRS_BRIGHTOBJ',
+                                'NRS_AUTOFLAT']
 
     if exp_type in wavecorr_supported_modes:
         reffile = reference_files['wavecorr']
@@ -158,7 +159,7 @@ def set_slit_attributes(output_model, slit, xlo, xhi, ylo, yhi):
     output_model.xsize = (xhi_ind - xlo_ind) + 1
     output_model.ystart = ylo_ind + 1
     output_model.ysize = (yhi_ind - ylo_ind) + 1
-    if output_model.meta.exposure.type.lower() == 'nrs_msaspec':
+    if output_model.meta.exposure.type.lower() in ['nrs_msaspec', 'nrs_autoflat']:
         output_model.source_id = int(slit.source_id)
         output_model.source_name = slit.source_name
         output_model.source_alias = slit.source_alias


### PR DESCRIPTION
 Needs rmaps update to include NRS_AUTOFLAT in order to pick the reference files.
Code was tested local reference files.
**Alternatively**, we can merge this and let the INS team use local reference files during their tests.

The INS team indicates that NRS_AUTOFLAT observations should be processed by assign_wcs and extract_2d as MOS observations.

Fixes #1984.