### PR TITLE
Ensure calwebb_spec2 fails when `assign_wcs` fails or is skipped

### DIFF
--- a/jwst/pipeline/calwebb_spec2.py
+++ b/jwst/pipeline/calwebb_spec2.py
@@ -168,11 +168,18 @@ class Spec2Pipeline(Pipeline):
 
         # If assign_wcs was skipped, abort the rest of processing,
         # because so many downstream steps depend on the WCS
-        if input.meta.cal_step.assign_wcs == 'SKIPPED':
-            self.log.error('Assign_wcs processing was skipped')
-            self.log.error('Aborting remaining processing for this exposure')
-            self.log.error('No output product will be created')
-            return input
+        if input.meta.cal_step.assign_wcs != 'COMPLETE':
+            message = (
+                'Assign_wcs processing was skipped.'
+                '\nAborting remaining processing for this exposure.'
+                '\nNo output product will be created.'
+            )
+            if self.assign_wcs.skip:
+                self.log.warning(message)
+                return
+            else:
+                self.log.error(message)
+                raise RuntimeError('Cannot determine WCS.')
 
         # Apply NIRSpec MSA imprint subtraction
         # Technically there should be just one.

--- a/jwst/pipeline/tests/test_calwebb_spec2_nrs_msa.py
+++ b/jwst/pipeline/tests/test_calwebb_spec2_nrs_msa.py
@@ -22,6 +22,55 @@ DATAPATH = abspath(
 )
 
 
+@require_bigdata
+def test_msa_missing(mk_tmp_dirs):
+    """Test MSA missing failure"""
+    tmp_current_path, tmp_data_path, tmp_config_path = mk_tmp_dirs
+
+    # Copy necessary data to the tmp_data_path
+    input_file = 'F170LP-G235M_MOS_observation-6-c0e0_001_DN_NRS1_mod.fits'
+    file_copy(
+        path.join(
+            DATAPATH,
+            'level2a_twoslit',
+            input_file
+        ),
+        tmp_data_path
+    )
+    args = [
+        path.join(SCRIPT_DATA_PATH, 'calwebb_spec2_basic.cfg'),
+        path.join(tmp_data_path, input_file)
+    ]
+
+    with pytest.raises(Exception):
+        Step.from_cmdline(args)
+
+
+@require_bigdata
+def test_msa_missing_skip(mk_tmp_dirs):
+    """Test MSA missing failure"""
+    tmp_current_path, tmp_data_path, tmp_config_path = mk_tmp_dirs
+
+    # Copy necessary data to the tmp_data_path
+    input_file = 'F170LP-G235M_MOS_observation-6-c0e0_001_DN_NRS1_mod.fits'
+    file_copy(
+        path.join(
+            DATAPATH,
+            'level2a_twoslit',
+            input_file
+        ),
+        tmp_data_path
+    )
+    args = [
+        path.join(SCRIPT_DATA_PATH, 'calwebb_spec2_basic.cfg'),
+        path.join(tmp_data_path, input_file),
+        '--steps.assign_wcs.skip=true'
+    ]
+
+    with pytest.raises(Exception):
+        Step.from_cmdline(args)
+
+
 @runslow
 @require_bigdata
 def test_run_msaflagging(mk_tmp_dirs, caplog):

--- a/jwst/pipeline/tests/test_calwebb_spec2_nrs_msa.py
+++ b/jwst/pipeline/tests/test_calwebb_spec2_nrs_msa.py
@@ -23,7 +23,7 @@ DATAPATH = abspath(
 
 
 @require_bigdata
-def test_msa_missing(mk_tmp_dirs):
+def test_msa_missing(mk_tmp_dirs, caplog):
     """Test MSA missing failure"""
     tmp_current_path, tmp_data_path, tmp_config_path = mk_tmp_dirs
 
@@ -45,9 +45,37 @@ def test_msa_missing(mk_tmp_dirs):
     with pytest.raises(Exception):
         Step.from_cmdline(args)
 
+    assert 'Aborting remaining processing for this exposure.' in caplog.text
+
 
 @require_bigdata
-def test_msa_missing_skip(mk_tmp_dirs):
+def test_msa_missing_nofail(mk_tmp_dirs, caplog):
+    """Test MSA missing failure"""
+    tmp_current_path, tmp_data_path, tmp_config_path = mk_tmp_dirs
+
+    # Copy necessary data to the tmp_data_path
+    input_file = 'F170LP-G235M_MOS_observation-6-c0e0_001_DN_NRS1_mod.fits'
+    file_copy(
+        path.join(
+            DATAPATH,
+            'level2a_twoslit',
+            input_file
+        ),
+        tmp_data_path
+    )
+    args = [
+        path.join(SCRIPT_DATA_PATH, 'calwebb_spec2_basic.cfg'),
+        path.join(tmp_data_path, input_file),
+        '--fail_on_exception=false'
+    ]
+
+    Step.from_cmdline(args)
+
+    assert 'Aborting remaining processing for this exposure.' in caplog.text
+
+
+@require_bigdata
+def test_msa_missing_skip(mk_tmp_dirs, caplog):
     """Test MSA missing failure"""
     tmp_current_path, tmp_data_path, tmp_config_path = mk_tmp_dirs
 
@@ -67,8 +95,9 @@ def test_msa_missing_skip(mk_tmp_dirs):
         '--steps.assign_wcs.skip=true'
     ]
 
-    with pytest.raises(Exception):
-        Step.from_cmdline(args)
+    Step.from_cmdline(args)
+
+    assert 'Aborting remaining processing for this exposure.' in caplog.text
 
 
 @runslow


### PR DESCRIPTION
Ensure that `calwebb_spec2` raises an exception for a failed or skipped `assign_wcs` step.

Resolves #2151 