### PR TITLE
Update data models and steps for the integration times table.

### DIFF
--- a/jwst/datamodels/cube.py
+++ b/jwst/datamodels/cube.py
@@ -28,6 +28,9 @@ class CubeModel(model_base.DataModel):
     relsens: numpy array
         The relative sensitivity array.
 
+    int_times : table
+        The int_times table
+
     area: numpy array
         The pixel area array.  2-D
 
@@ -43,8 +46,8 @@ class CubeModel(model_base.DataModel):
     schema_url = "cube.schema.yaml"
 
     def __init__(self, init=None, data=None, dq=None, err=None, zeroframe=None,
-                 relsens=None, area=None, wavelength=None, var_poisson=None, 
-                 var_rnoise=None, **kwargs):
+                 relsens=None, int_times=None, area=None, wavelength=None,
+                 var_poisson=None, var_rnoise=None, **kwargs):
       
         super(CubeModel, self).__init__(init=init, **kwargs)
 
@@ -62,6 +65,9 @@ class CubeModel(model_base.DataModel):
 
         if relsens is not None:
             self.relsens = relsens
+
+        if int_times is not None:
+            self.int_times = int_times
 
         if area is not None:
             self.area = area

--- a/jwst/datamodels/level1b.py
+++ b/jwst/datamodels/level1b.py
@@ -26,11 +26,14 @@ class Level1bModel(model_base.DataModel):
     group : table
         The group parameters table
 
+    int_times : table
+        The int_times table
+
     """
     schema_url = "level1b.schema.yaml"
 
     def __init__(self, init=None, data=None, refout=None, zeroframe=None,
-                 group=None, **kwargs):
+                 group=None, int_times=None, **kwargs):
         super(Level1bModel, self).__init__(init=init, **kwargs)
 
         if data is not None:
@@ -44,6 +47,9 @@ class Level1bModel(model_base.DataModel):
 
         if group is not None:
             self.group = group
+
+        if int_times is not None:
+            self.int_times = int_times
 
         # zeroframe is a lower dimensional array than
         # the science data. However, its dimensions are not

--- a/jwst/datamodels/multispec.py
+++ b/jwst/datamodels/multispec.py
@@ -43,7 +43,8 @@ class MultiSpecModel(model_base.DataModel):
     """
     schema_url = "multispec.schema.yaml"
 
-    def __init__(self, init=None, **kwargs):
+    def __init__(self, init=None, int_times=None, **kwargs):
+
         if isinstance(init, SpecModel):
             super(MultiSpecModel, self).__init__(init=None, **kwargs)
             self.spec.append(self.spec.item())
@@ -51,3 +52,6 @@ class MultiSpecModel(model_base.DataModel):
             return
 
         super(MultiSpecModel, self).__init__(init=init, **kwargs)
+
+        if int_times is not None:
+            self.int_times = int_times

--- a/jwst/datamodels/ramp.py
+++ b/jwst/datamodels/ramp.py
@@ -28,11 +28,15 @@ class RampModel(model_base.DataModel):
     group : table
         The group parameters table
 
+    int_times : table
+        The int_times table
+
     """
     schema_url = "ramp.schema.yaml"
 
     def __init__(self, init=None, data=None, pixeldq=None, groupdq=None,
-                 err=None, zeroframe=None, group=None, **kwargs):
+                 err=None, zeroframe=None, group=None, int_times=None,
+                 **kwargs):
         super(RampModel, self).__init__(init=init, **kwargs)
 
         if data is not None:
@@ -52,6 +56,9 @@ class RampModel(model_base.DataModel):
 
         if group is not None:
             self.group = group
+
+        if int_times is not None:
+            self.int_times = int_times
 
         # Implicitly create arrays
         self.pixeldq = self.pixeldq

--- a/jwst/datamodels/schemas/image.schema.yaml
+++ b/jwst/datamodels/schemas/image.schema.yaml
@@ -38,8 +38,6 @@ allOf:
       fits_hdu: RELSENS2D
       default: 1.0
       datatype: float32
-    int_times:
-      $ref: int_times.schema.yaml
     var_poisson:
       title: variance due to poisson noise
       fits_hdu: VAR_POISSON

--- a/jwst/datamodels/schemas/level1b.schema.yaml
+++ b/jwst/datamodels/schemas/level1b.schema.yaml
@@ -25,4 +25,6 @@ allOf:
       datatype: uint16
     group:
       $ref: group.schema.yaml
+    int_times:
+      $ref: int_times.schema.yaml
 $schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/multislit.schema.yaml
+++ b/jwst/datamodels/schemas/multislit.schema.yaml
@@ -2,8 +2,6 @@ allOf:
 - $ref: core.schema.yaml
 - type: object
   properties:
-    int_times:
-      $ref: int_times.schema.yaml
     slits:
       type: array
       title: An array of slits

--- a/jwst/datamodels/schemas/multispec.schema.yaml
+++ b/jwst/datamodels/schemas/multispec.schema.yaml
@@ -2,6 +2,8 @@ allOf:
 - $ref: core.schema.yaml
 - type: object
   properties:
+    int_times:
+      $ref: int_times.schema.yaml
     spec:
       type: array
       title: An array of spectra

--- a/jwst/datamodels/schemas/ramp.schema.yaml
+++ b/jwst/datamodels/schemas/ramp.schema.yaml
@@ -36,4 +36,6 @@ allOf:
       datatype: float32
     group:
       $ref: group.schema.yaml
+    int_times:
+      $ref: int_times.schema.yaml
 $schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/slit.py
+++ b/jwst/datamodels/slit.py
@@ -119,6 +119,9 @@ class SlitModel(model_base.DataModel):
     relsens : numpy array
         The relative sensitivity table.
 
+    int_times : table
+        The int_times table
+
     """
     schema_url = "slit.schema.yaml"
 
@@ -128,7 +131,8 @@ class SlitModel(model_base.DataModel):
                  xsize=None, ystart=None, ysize=None, slitlet_id=None,
                  source_id=None, source_name=None, source_alias=None,
                  stellarity=None, source_type=None, source_xpos=None, source_ypos=None,
-                 shutter_state=None, area=None, relsens=None, barshadow=None,
+                 shutter_state=None, area=None, relsens=None,
+                 int_times=None, barshadow=None,
                  wavelength_pointsource=None, pathloss_pointsource=None,
                  wavelength_uniformsource=None, pathloss_uniformsource=None,
                  **kwargs):
@@ -147,6 +151,8 @@ class SlitModel(model_base.DataModel):
                 self.var_poisson = init.var_poisson
             if hasattr(init, 'var_rnoise'):
                 self.var_rnoise = init.var_rnoise
+            if hasattr(init, 'int_times'):
+                self.int_times = init.int_times
             if hasattr(init.meta, 'wcs'):
                 self.meta.wcs = init.meta.wcs
             else:
@@ -172,6 +178,9 @@ class SlitModel(model_base.DataModel):
 
         if var_rnoise is not None:
             self.var_rnoise = var_rnoise
+
+        if int_times is not None:
+            self.int_times = int_times
 
         if dq is not None:
             self.dq = dq

--- a/jwst/ramp_fitting/ramp_fit.py
+++ b/jwst/ramp_fitting/ramp_fit.py
@@ -19,6 +19,7 @@ import numpy as np
 
 from .. import datamodels
 from ..datamodels import dqflags
+from ..lib import pipe_utils
 
 from . import gls_fit           # used only if algorithm is "GLS"
 from . import utils
@@ -540,8 +541,12 @@ def ols_ramp_fit(model, buffsize, save_opt, readnoise_model, gain_model,
     # For multiple-integration datasets, will output integration-specific
     #    results to separate file named <basename> + '_integ.fits'
     if n_int > 1:
+        if pipe_utils.is_tso(model) and hasattr(model, 'int_times'):
+            int_times = model.int_times
+        else:
+            int_times = None
         int_model = utils.output_integ(model, slope_int, dq_int, effintim,
-                                       var_p3, var_r3, var_both3)
+                                       var_p3, var_r3, var_both3, int_times)
     else:
         int_model = None
 

--- a/jwst/ramp_fitting/utils.py
+++ b/jwst/ramp_fitting/utils.py
@@ -622,7 +622,8 @@ def calc_pedestal(num_int, slope_int, firstf_int, dq_cube, nframes, groupgap,
     return ped
 
 
-def output_integ(model, slope_int, dq_int, effintim, var_p3, var_r3, var_both3):
+def output_integ(model, slope_int, dq_int, effintim, var_p3, var_r3, var_both3,
+                 int_times):
 
     """
     Short Summary
@@ -655,6 +656,9 @@ def output_integ(model, slope_int, dq_int, effintim, var_p3, var_r3, var_both3):
         Cube of integration-specific values for the slope variance due to
         read noise and Poisson noise
 
+    int_times: bintable, or None
+        The INT_TIMES table, if it exists in the input, else None
+
     Returns
     -------
     cubemod: Data Model object
@@ -670,6 +674,8 @@ def output_integ(model, slope_int, dq_int, effintim, var_p3, var_r3, var_both3):
 
     cubemod.var_poisson = var_p3
     cubemod.var_rnoise = var_r3
+
+    cubemod.int_times = int_times
 
     cubemod.update(model) # keys from input needed for photom step
 

--- a/jwst/tso_photometry/tso_photometry.py
+++ b/jwst/tso_photometry/tso_photometry.py
@@ -90,13 +90,51 @@ def tso_aperture_photometry(datamodel, xcenter, ycenter, radius, radius_inner,
 
     tbl = QTable(meta=meta)
 
-    dt = (datamodel.meta.exposure.group_time *
-          (datamodel.meta.exposure.ngroups + 1))
-    dt_arr = (np.arange(1, 1 + datamodel.meta.exposure.nints) *
-              dt - (dt / 2.))
-    int_dt = TimeDelta(dt_arr, format='sec')
-    int_times = (Time(datamodel.meta.exposure.start_time, format='mjd') +
-                 int_dt)
+    if hasattr(datamodel, 'int_times') and datamodel.int_times is not None:
+        nrows = len(datamodel.int_times)
+    else:
+        nrows = 0
+    if nrows == 0:
+        log.warning("There is no INT_TIMES table in the input file.")
+
+    if nrows > 0:
+        shape = datamodel.data.shape
+        if len(shape) == 2:
+            num_integ = 1
+        else:                                   # len(shape) == 3
+            num_integ = shape[0]
+        int_start = datamodel.meta.exposure.integration_start
+        if int_start is None:
+            int_start = 1
+            log.warning("INTSTART not found; assuming a value of %d",
+                        int_start)
+
+        # Columns of integration numbers & times of integration from the
+        # INT_TIMES table.
+        int_num = datamodel.int_times['integration_number']
+        mid_utc = datamodel.int_times['int_mid_MJD_UTC']
+        offset = int_start - int_num[0]                 # both are one-indexed
+        if offset < 0:
+            log.warning("Range of integration numbers in science data extends "
+                        "outside the range in INT_TIMES table.")
+            log.warning("Can't use INT_TIMES table.")
+            del int_num, mid_utc
+            nrows = 0                   # flag as bad
+        else:
+            log.debug("Times are from the INT_TIMES table.")
+            time_arr = mid_utc[offset : offset + num_integ]
+            int_times = Time(time_arr, format='mjd', scale='utc')
+    else:
+        log.debug("Times were computed from EXPSTART and TGROUP.")
+
+        dt = (datamodel.meta.exposure.group_time *
+              (datamodel.meta.exposure.ngroups + 1))
+        dt_arr = (np.arange(1, 1 + datamodel.meta.exposure.nints) *
+                  dt - (dt / 2.))
+        int_dt = TimeDelta(dt_arr, format='sec')
+        int_times = (Time(datamodel.meta.exposure.start_time, format='mjd') +
+                     int_dt)
+
     tbl['MJD'] = int_times.mjd
 
     tbl['aperture_sum'] = aperture_sum


### PR DESCRIPTION
The `extract_1d` step was modified to copy the times from the input INT_TIMES table to metadata for the output spectra, but only for TSO data, and only if there is an INT_TIMES table in the input.  PR #1987 included changes to extract_1d, but the current commit fixes some bugs in the earlier version and adds a check for TSO data.

The `ramp_fit` step has been modified to copy the input INT_TIMES table to the output model for integration-specific results for TSO data, and the `extract_2d` step has been modified to copy the input INT_TIMES table to the output model for 3-D NIRSpec NRS_BRIGHTOBJ data.

The `tso_photometry` and `white_light` steps have been modified to copy the times from the INT_TIMES table (if it is present in the input) instead of computing the times directly.

Some of the data models and schemas were modified to include an `int_times` attribute.  Some had been modified earlier, in PR #1987, but further updates were needed.  The following data models now include an `int_times` attribute:  `Level1bModel`, `RampModel`, `CubeModel`, `SlitModel`, and `MultiSpecModel`.