### PR TITLE
ModelContainer, Level 3 schema cleanup; resample output metadata updates

### DIFF
--- a/jwst/datamodels/schemas/container.schema.yaml
+++ b/jwst/datamodels/schemas/container.schema.yaml
@@ -4,10 +4,6 @@ properties:
     title: Level 3 Schema Metadata
     type: object
     properties:
-      date:
-        title: Date this file was created (UTC)
-        type: string
-        fits_keyword: DATE
       table_name:
         title: Name of ASN table 
         type: string
@@ -16,22 +12,6 @@ properties:
         title: Name of ASN pool used to generate this table
         type: string
         fits_keyword: ASNPOOL
-      targname:
-        title: Name of target specified in ASN table
-        type: string
-        fits_keyword: ASNTARG
-      program:
-        title: Program ID for observations in ASN table
-        type: string
-        fits_keyword: ASNPROG
-      asn_type:
-        title: Type of ASN 
-        type: string
-        fits_keyword: ASNTYPE
-      asn_rule:
-        title: Rule used to generate ASN table from ASN Pool
-        type: string
-        fits_keyword: ASNRULE
       resample:
         title: Information needed for Resampling multiple exposures
         type: object

--- a/jwst/datamodels/schemas/container.schema.yaml
+++ b/jwst/datamodels/schemas/container.schema.yaml
@@ -1,7 +1,6 @@
 type: object
 properties:
   meta:
-    title: Level 3 Schema Metadata
     type: object
     properties:
       table_name:
@@ -19,9 +18,7 @@ properties:
           output:
             title: Name of resampling output file
             type: string
-            fits_keyword: DRIZZOUT
           pointings:
             title: Number of pointings
             type: integer
-            fits_keyword: NDRIZ
 $schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/datamodels/schemas/lev3_prod.schema.yaml
+++ b/jwst/datamodels/schemas/lev3_prod.schema.yaml
@@ -4,238 +4,35 @@ properties:
     title: Level 3 Schema Metadata
     type: object
     properties:
-      asn:
-        title: Association Information
-        type: object
-        properties:
-          targname:
-            title: Name of target specified in ASN table
-            type: string
-            fits_keyword: ASNTARG
-          program:
-            title: Name of Program specified in ASN table
-            type: string
-            fits_keyword: ASNPROG
-          asn_type:
-            title: Type of ASN specified in ASN table
-            type: string
-            fits_keyword: ASNTYPE
-          asn_rule:
-            title: Rule used to create ASN table from ASN Pool
-            type: string
-            fits_keyword: ASNRULE 
       resample:
           title: Metadata describing resampling done using this data
           type: object
           properties:
             pointings:
-              title: Number of groups/pointings included in resampled product
+              title: Number of pointings included in resampled product
               type: integer
               fits_keyword:  NDRIZ
             product_exposure_time:
               title: Total exposure time for product
               type: number
               fits_keyword: TEXPTIME
-            product_data_extname:
-              title: Extname of SCI extension
-              type: string
-              fits_keyword: SCIEXT
-            product_context_extname:
-              title: Extname of CON extension
-              type: string
-              fits_keyword: CONEXT
-            product_weight_extname:
-              title: Extname of WHT extension
-              type: string
-              fits_keyword: WHTEXT
-            drizzle_fill_value:
-              title: Value used in pixels without any valid input data
-              type: string
-              fits_keyword: DFVAL
-            drizzle_pixel_fraction:
-              title: Drizzle pixel fraction used to create resampled product
-              type: number
-              fits_keyword: DPIXFR
-            drizzle_kernel:
-              title: Drizzle kernel used to create resampled product
-              type: string
-              fits_keyword: DKERN
-            drizzle_output_units:
-              title: Units for resampled output product as cps or counts
-              type: string
-              fits_keyword: DOUTUN
-            drizzle_weight_scale:
-              title: Drizzle weight scale used to create resampled product
-              type: string
-              fits_keyword: DWTSCL
-            resample_bits:
-              title: Bit values to consider good when interpreting input DQ arrays
-              type: integer
-              fits_keyword: RESBITS
             weight_type:
               title: Type of drizzle weighting to use in resampling input
               type: string
               enum: ['exptime','error']
-              fits_keyword: RESWHT
-      median:
-          title: Parameters used to perform median combination on input data
-          type: object
-          properties:
-            ignore_nlow:
-              title: Number of low pixel values to ignore when performing median
-              type: integer
-              fits_keyword: MEDNLOW
-            ignore_nhigh:
-              title: Number of high pixel values to ignore when performing median
-              type: integer
-              fits_keyword: MEDNHI
-            low_threshold:
-              title: Lower value for pixels included when computing median
-              type: [number, ' ']
-              fits_keyword: MEDLTHR
-            high_threshold:
-              title: Upper value for pixels included when computing median
-              type: [number, ' ']
-              fits_keyword: MEDHTHR
-            mask_percent:
-              title: Lower limit in percent of weight array used for creating weight mask
-              type: number
-              fits_keyword: MEDMSKPT
-            nsigma:
-              title: Sigma limits to apply when computing minimum-median result
-              type: string
-              fits_keyword: MEDNSIG
-      find_cr:
-          title: Parameters used to find bad-pixels/cosmic-rays in input data
-          type: object
-          properties:
-            grow:
-              title: Number of pixels to expand CR to look for neighboring CR pixels
-              type: integer
-              fits_keyword: FCRGROW
-            cte_grow:
-              title: Number of pixels to look for CTE effects
-              type: integer
-              fits_keyword: FCRCGROW
-            signal_noise:
-              title: Signal-to-noise ratios to use in detecting CR pixels
-              type: string
-              fits_keyword: FCRSNR
-            scale:
-              title: scaling factor applied to the derivative when detecting CR pixels
-              type: string
-              fits_keyword: FCRSCL
-            background:
-              title: Background or sky value used to detect CR pixels
-              type: number
-              fits_keyword: FCRBACKG
-      skymatch:
-          title: Parameters used to perform sky matching across all input data
-          type: object
-          properties:
-            skymethod:
-              title: Sky computation method
-              type: string
-              enum: ['local', 'global', 'match', 'global+match']
-              fits_keyword: SKYMETH
-            match_down:
-              title: Flag to specify whether sky values adjusted to lowest measured value
-              type: boolean
-              fits_keyword: SKYDOWN
-            subtract:
-              title: Flag to specify whether sky values subtracted from SCI data
-              type: boolean
-              fits_keyword: SKYSUB
-            stepsize:
-              title: Maximum vertex separation
-              type: number
-              fits_keyword: SKYSTEP
-            skystat:
-              title: Form of statistics to use in computing sky values
-              type: string
-              enum: ['mode', 'median', 'mode', 'midpt']
-              fits_keyword: SKYSTAT
-            dqbits:
-              title: Integer value of DQ bits considered valid
-              type: integer
-              fits_keyword: SKYBITS
-            lower:
-              title: Lower limit of good pixel values
-              type: [number or ' ']
-              fits_keyword: SKYLOW
-            upper:
-              title: Upper limit of good pixel values
-              type: [number or ' ']
-              fits_keyword: SKYUPPER
-            nclip:
-              title: Number of clipping iterations used to compute the sky value
-              type: integer
-              fits_keyword: SKYNCLIP
-            lsigma:
-              title: Lower clipping limit, in sigma
-              type: number
-              fits_keyword: SKYLSIG
-            usigma:
-              title: Upper clipping limit, in sigma
-              type: number
-              fits_keyword: SKYUSIG
-            binwidth:
-              title: Bin width for mode and midpt statistics, in sigma
-              type: number
-              fits_keyword: SKYBINW
+              fits_keyword: WHT_TYPE
       tweakreg_catalog:
-          title: Parameters used in generating tweakreg source catalogs
           type: object
           properties:
             filename:
               title: Output tweakreg catalog filename
               type: string
               fits_keyword: TCATFILE
-            format:
-              title: Format used to write out catalog
-              type: string
-              enum: ['ecsv', 'fits']
-              fits_keyword: TCATFMT
-            kernel_fwhm:
-              title: Gaussian kernel FWHM in pixels
-              type: number
-              fits_keyword: TCATFWHM
-            snr_threshold:
-              title: SNR threshold above the background for source finding
-              type: number
-              fits_keyword: TCATSNR
       source_catalog:
-          title: Parameters used in generating source catalogs
           type: object
           properties:
             filename:
               title: Output source catalog filename
               type: string
               fits_keyword: SCATFILE
-            format:
-              title: Format used to write out catalog
-              type: string
-              enum: ['ecsv', 'fits']
-              fits_keyword: SCATFMT
-            kernel_fwhm:
-              title: Gaussian kernel FWHM in pixels
-              type: number
-              fits_keyword: SCATFWHM
-            kernel_xsize:
-              title: Kernel x size in pixels
-              type: number
-              fits_keyword: SCATXSZ
-            kernel_ysize:
-              title: Kernel y size in pixels
-              type: number
-              fits_keyword: SCATYSZ
-            snr_threshold:
-              title: SNR threshold above the background for source finding
-              type: number
-              fits_keyword: SCATSNR
-            npixels:
-              title: min number of pixels in source
-              type: number
-              fits_keyword: SCATNPIX
-
 $schema: http://stsci.edu/schemas/fits-schema/fits-schema

--- a/jwst/resample/gwcs_drizzle.py
+++ b/jwst/resample/gwcs_drizzle.py
@@ -58,7 +58,6 @@ class GWCSDrizzle:
         """
 
         # Initialize the object fields
-
         self.outsci = None
         self.outwht = None
         self.outcon = None
@@ -69,7 +68,7 @@ class GWCSDrizzle:
         self.wt_scl = wt_scl
         self.kernel = kernel
         self.fillval = fillval
-        self.pixfrac = float(pixfrac)
+        self.pixfrac = pixfrac
 
         self.sciext = "SCI"
         self.whtext = "WHT"
@@ -78,19 +77,6 @@ class GWCSDrizzle:
         out_units = "cps"
 
         self.outexptime = product.meta.resample.product_exposure_time or 0.0
-
-        self.uniqid = product.meta.resample.pointings or 0
-
-        self.sciext = product.meta.resample.product_data_extname or "SCI"
-        self.whtext = product.meta.resample.product_weight_extname or "WHT"
-        self.conext = product.meta.resample.product_context_extname or "CON"
-
-        self.wt_scl = product.meta.resample.drizzle_weight_scale or wt_scl
-        self.kernel = product.meta.resample.drizzle_kernel or kernel
-        self.fillval = product.meta.resample.drizzle_fill_value or fillval
-        self.pixfrac = product.meta.resample.drizzle_pixel_fraction or pixfrac
-
-        self.out_units = out_units = product.meta.resample.drizzle_output_units or "cps"
 
         self.outsci = product.data
         if outwcs:
@@ -120,12 +106,12 @@ class GWCSDrizzle:
         if util.is_blank(self.wt_scl):
             self.wt_scl = ''
         elif self.wt_scl != "exptime" and self.wt_scl != "expsq":
-            raise ValueError("Illegal value for wt_scl: %s" % out_units)
+            raise ValueError("Illegal value for wt_scl: %s" % self.wt_scl)
 
         if out_units == "counts":
             np.divide(self.outsci, self.outexptime, self.outsci)
         elif out_units != "cps":
-            raise ValueError("Illegal value for wt_scl: %s" % out_units)
+            raise ValueError("Illegal value for out_units: %s" % out_units)
 
 
     def add_image(self, insci, inwcs, inwht=None,

--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -203,15 +203,6 @@ class ResampleData:
             output_model.meta.exposure.start_time = min(exposure_times['start'])
             output_model.meta.exposure.end_time = max(exposure_times['end'])
             output_model.meta.resample.product_exposure_time = texptime
-            output_model.meta.resample.product_data_extname = driz.sciext
-            output_model.meta.resample.product_context_extname = driz.conext
-            output_model.meta.resample.product_weight_extname = driz.whtext
-            output_model.meta.resample.drizzle_fill_value = str(driz.fillval)
-            output_model.meta.resample.drizzle_pixel_fraction = driz.pixfrac
-            output_model.meta.resample.drizzle_kernel = driz.kernel
-            output_model.meta.resample.drizzle_output_units = driz.out_units
-            output_model.meta.resample.drizzle_weight_scale = driz.wt_scl
-            output_model.meta.resample.resample_bits = self.drizpars['good_bits']
             output_model.meta.resample.weight_type = self.drizpars['wht_type']
             output_model.meta.resample.pointings = pointings
 

--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -170,11 +170,6 @@ class ResampleData:
                 self.blend_output_metadata(output_model)
                 output_model.meta.model_type = saved_model_type
 
-            # Following 2 lines can probably be removed once ASN dicts
-            # are handled properly
-            output_model.meta.asn.pool_name = self.input_models.meta.pool_name
-            output_model.meta.asn.table_name = self.input_models.meta.table_name
-
             exposure_times = {'start': [], 'end': []}
 
             # Initialize the output with the wcs

--- a/jwst/resample/resample_spec.py
+++ b/jwst/resample/resample_spec.py
@@ -389,15 +389,6 @@ class ResampleSpecData:
             output_model.meta.exposure.start_time = min(exposure_times['start'])
             output_model.meta.exposure.end_time = max(exposure_times['end'])
             output_model.meta.resample.product_exposure_time = texptime
-            output_model.meta.resample.product_data_extname = driz.sciext
-            output_model.meta.resample.product_context_extname = driz.conext
-            output_model.meta.resample.product_weight_extname = driz.whtext
-            output_model.meta.resample.drizzle_fill_value = str(driz.fillval)
-            output_model.meta.resample.drizzle_pixel_fraction = driz.pixfrac
-            output_model.meta.resample.drizzle_kernel = driz.kernel
-            output_model.meta.resample.drizzle_output_units = driz.out_units
-            output_model.meta.resample.drizzle_weight_scale = driz.wt_scl
-            output_model.meta.resample.resample_bits = self.drizpars['good_bits']
             output_model.meta.resample.weight_type = self.drizpars['wht_type']
             output_model.meta.resample.pointings = pointings
 

--- a/jwst/resample/resample_spec.py
+++ b/jwst/resample/resample_spec.py
@@ -355,9 +355,6 @@ class ResampleSpecData:
             output_model.meta.wcs.bounding_box = bb
             output_model.meta.filename = obs_product
 
-            output_model.meta.asn.pool_name = self.input_models.meta.pool_name
-            output_model.meta.asn.table_name = self.input_models.meta.table_name
-
             exposure_times = {'start': [], 'end': []}
 
             outwcs = output_model.meta.wcs

--- a/jwst/resample/resample_spec_step.py
+++ b/jwst/resample/resample_spec_step.py
@@ -2,6 +2,7 @@ from ..stpipe import Step, cmdline
 from .. import datamodels
 from . import resample_spec
 from ..exp_to_source import multislit_to_container
+from ..assign_wcs.util import update_s_region
 
 
 class ResampleSpecStep(Step):
@@ -43,8 +44,8 @@ class ResampleSpecStep(Step):
         # Multislits get converted to a ModelContainer per slit
         if all([isinstance(i, datamodels.MultiSlitModel) for i in input_models]):
             container_dict = multislit_to_container(input_models)
-            output_product = datamodels.MultiProductModel()
-            output_product.update(input_models[0])
+            output = datamodels.MultiProductModel()
+            output.update(input_models[0])
             for k, v in container_dict.items():
                 input_models = v
 
@@ -56,13 +57,20 @@ class ResampleSpecStep(Step):
                     good_bits=self.good_bits)
                 # Do the resampling
                 resamp.do_drizzle()
+
+                for model in resamp.output_models:
+                    update_s_region(model)
+
                 if len(resamp.output_models) == 1:
                     out_slit = resamp.output_models[0]
-                    output_product.products.append(out_slit)
-                    output_product.products[-1].bunit_data = input_models[0].meta.bunit_data
+                    output.products.append(out_slit)
+                    output.products[-1].bunit_data = input_models[0].meta.bunit_data
                 else:
                     out_slit = resamp.output_models
-            result = output_product
+            result = output
+            result.meta.cal_step.resample = "COMPLETE"
+            result.meta.asn.pool_name = input_models.meta.pool_name
+            result.meta.asn.table_name = input_models.meta.table_name
         else:
             # Set up the resampling object as part of this step
             resamp = resample_spec.ResampleSpecData(input_models,
@@ -72,14 +80,18 @@ class ResampleSpecStep(Step):
             # Do the resampling
             resamp.do_drizzle()
 
+            for model in resamp.output_models:
+                model.meta.cal_step.resample = "COMPLETE"
+                update_s_region(model)
+                model.meta.asn.pool_name = input_models.meta.pool_name
+                model.meta.asn.table_name = input_models.meta.table_name
+
             # Return either the single resampled datamodel, or the container
             # of datamodels.
             if len(resamp.output_models) == 1:
                 result = resamp.output_models[0]
             else:
                 result = resamp.output_models
-
-        result.meta.cal_step.resample = 'COMPLETE'
 
         return result
 

--- a/jwst/resample/resample_step.py
+++ b/jwst/resample/resample_step.py
@@ -48,13 +48,16 @@ class ResampleStep(Step):
             blendheaders=self.blendheaders)
         resamp.do_drizzle()
 
+        for model in resamp.output_models:
+            model.meta.cal_step.resample = "COMPLETE"
+            update_s_region(model)
+            model.meta.asn.pool_name = input_models.meta.pool_name
+            model.meta.asn.table_name = input_models.meta.table_name
+
+
         if len(resamp.output_models) == 1:
             result = resamp.output_models[0]
-            result.meta.cal_step.resample = "COMPLETE"
-            update_s_region(result)
         else:
             result = resamp.output_models
-            for model in result:
-                model.meta.cal_step.resample = "COMPLETE"
-                update_s_region(model)
+
         return result

--- a/jwst/resample/resample_step.py
+++ b/jwst/resample/resample_step.py
@@ -1,7 +1,7 @@
 from ..stpipe import Step
 from .. import datamodels
 from . import resample
-from .. assign_wcs.util import update_s_region
+from ..assign_wcs.util import update_s_region
 
 
 class ResampleStep(Step):

--- a/jwst/tests_nightly/general/pipelines/test_nrs_fs_brightobj_spec2.py
+++ b/jwst/tests_nightly/general/pipelines/test_nrs_fs_brightobj_spec2.py
@@ -11,12 +11,9 @@ pytestmark = [
 
 def test_nrs_fs_brightobj_spec2(_bigdata):
     """
-
     Regression test of calwebb_spec2 pipeline performed on NIRSpec fixed-slit data
     that uses the NRS_BRIGHTOBJ mode (S1600A1 slit).
-
     """
-
     step = Spec2Pipeline()
     step.save_bsub = True
     step.save_results = True
@@ -25,16 +22,16 @@ def test_nrs_fs_brightobj_spec2(_bigdata):
     step.extract_1d.save_results = True
     step.run(_bigdata+'/pipelines/jw84600042001_02101_00001_nrs2_rateints.fits')
 
+    ignore_keywords = ['DATE','CAL_VER','CAL_VCS','CRDS_VER','CRDS_CTX']
+
     na = 'jw84600042001_02101_00001_nrs2_calints.fits'
     nb = _bigdata+'/pipelines/jw84600042001_02101_00001_nrs2_calints_ref.fits'
     h = pf.open(na)
     href = pf.open(nb)
-    newh = pf.HDUList([h['primary'],h['sci',1],h['err',1],h['dq',1],h['relsens',1],
-                                    h['wavelength',1]])
-    newhref = pf.HDUList([href['primary'],href['sci',1],href['err',1],href['dq',1],href['relsens',1],
-                                          href['wavelength',1]])
-    result = pf.diff.FITSDiff(newh, newhref,
-                              ignore_keywords = ['DATE','CAL_VER','CAL_VCS','CRDS_VER','CRDS_CTX'],
+    result = pf.diff.FITSDiff(h,
+                              href,
+                              ignore_hdus=['ASDF'],
+                              ignore_keywords=ignore_keywords,
                               rtol = 0.00001)
     assert result.identical, result.report()
 
@@ -42,9 +39,9 @@ def test_nrs_fs_brightobj_spec2(_bigdata):
     nb = _bigdata+'/pipelines/jw84600042001_02101_00001_nrs2_x1dints_ref.fits'
     h = pf.open(na)
     href = pf.open(nb)
-    newh = pf.HDUList([h['primary'],h['extract1d',1],h['extract1d',2],h['extract1d',3]])
-    newhref = pf.HDUList([href['primary'],href['extract1d',1],href['extract1d',2],href['extract1d',3]])
-    result = pf.diff.FITSDiff(newh, newhref,
-                              ignore_keywords = ['DATE','CAL_VER','CAL_VCS','CRDS_VER','CRDS_CTX'],
+    result = pf.diff.FITSDiff(h,
+                              href,
+                              ignore_hdus=['ASDF'],
+                              ignore_keywords=ignore_keywords,
                               rtol = 0.00001)
     assert result.identical, result.report()

--- a/jwst/tests_nightly/general/pipelines/test_nrs_fs_multi_spec2_1.py
+++ b/jwst/tests_nightly/general/pipelines/test_nrs_fs_multi_spec2_1.py
@@ -11,9 +11,7 @@ pytestmark = [
 
 def test_nrs_fs_multi_spec2_1(_bigdata):
     """
-
     Regression test of calwebb_spec2 pipeline performed on NIRSpec fixed-slit data.
-
     """
     step = Spec2Pipeline()
     step.save_bsub = True
@@ -23,38 +21,16 @@ def test_nrs_fs_multi_spec2_1(_bigdata):
     step.extract_1d.save_results = True
     step.run(_bigdata+'/pipelines/jw00023001001_01101_00001_NRS1_rate.fits')
 
+    ignore_keywords = ['DATE','CAL_VER','CAL_VCS','CRDS_VER','CRDS_CTX']
+
     na = 'jw00023001001_01101_00001_NRS1_cal.fits'
     nb = _bigdata+'/pipelines/jw00023001001_01101_00001_NRS1_cal_ref.fits'
     h = pf.open(na)
     href = pf.open(nb)
-    newh = pf.HDUList([h['primary'],h['sci',1],h['err',1],h['dq',1],h['relsens',1],h['wavelength',1],
-                                    h['pathloss_pointsource',1],h['wavelength_pointsource',1],
-                                    h['pathloss_uniformsource',1],h['wavelength_uniformsource',1],
-                                    h['sci',2],h['err',2],h['dq',2],h['relsens',2],h['wavelength',2],
-                                    h['pathloss_pointsource',2],h['wavelength_pointsource',2],
-                                    h['pathloss_uniformsource',2],h['wavelength_uniformsource',2],
-                                    h['sci',3],h['err',3],h['dq',3],h['relsens',3],h['wavelength',3],
-                                    h['sci',4],h['err',4],h['dq',4],h['relsens',4],h['wavelength',4],
-                                    h['pathloss_pointsource',4],h['wavelength_pointsource',4],
-                                    h['pathloss_uniformsource',4],h['wavelength_uniformsource',4],
-                                    h['sci',5],h['err',5],h['dq',5],h['relsens',5],h['wavelength',5],
-                                    h['pathloss_pointsource',5],h['wavelength_pointsource',5],
-                                    h['pathloss_uniformsource',5],h['wavelength_uniformsource',5]])
-    newhref = pf.HDUList([href['primary'],href['sci',1],href['err',1],href['dq',1],href['relsens',1],href['wavelength',1],
-                                          href['pathloss_pointsource',1],href['wavelength_pointsource',1],
-                                          href['pathloss_uniformsource',1],href['wavelength_uniformsource',1],
-                                          href['sci',2],href['err',2],href['dq',2],href['relsens',2],href['wavelength',2],
-                                          href['pathloss_pointsource',2],href['wavelength_pointsource',2],
-                                          href['pathloss_uniformsource',2],href['wavelength_uniformsource',2],
-                                          href['sci',3],href['err',3],href['dq',3],href['relsens',3],href['wavelength',3],
-                                          href['sci',4],href['err',4],href['dq',4],href['relsens',4],href['wavelength',4],
-                                          href['pathloss_pointsource',4],href['wavelength_pointsource',4],
-                                          href['pathloss_uniformsource',4],href['wavelength_uniformsource',4],
-                                          href['sci',5],href['err',5],href['dq',5],href['relsens',5],href['wavelength',5],
-                                          href['pathloss_pointsource',5],href['wavelength_pointsource',5],
-                                          href['pathloss_uniformsource',5],href['wavelength_uniformsource',5]])
-    result = pf.diff.FITSDiff(newh, newhref,
-                              ignore_keywords = ['DATE','CAL_VER','CAL_VCS','CRDS_VER','CRDS_CTX'],
+    result = pf.diff.FITSDiff(h,
+                              href,
+                              ignore_hdus=['ASDF'],
+                              ignore_keywords=ignore_keywords,
                               rtol = 0.00001)
     assert result.identical, result.report()
 
@@ -62,18 +38,10 @@ def test_nrs_fs_multi_spec2_1(_bigdata):
     nb = _bigdata+'/pipelines/jw00023001001_01101_00001_NRS1_s2d_ref.fits'
     h = pf.open(na)
     href = pf.open(nb)
-    newh = pf.HDUList([h['primary'],h['sci',1],h['wht',1],h['con',1],h['relsens',1],
-                                    h['sci',2],h['wht',2],h['con',2],h['relsens',2],
-                                    h['sci',3],h['wht',3],h['con',3],h['relsens',3],
-                                    h['sci',4],h['wht',4],h['con',4],h['relsens',4],
-                                    h['sci',5],h['wht',5],h['con',5],h['relsens',5]])
-    newhref = pf.HDUList([href['primary'],href['sci',1],href['wht',1],href['con',1],href['relsens',1],
-                                          href['sci',2],href['wht',2],href['con',2],href['relsens',2],
-                                          href['sci',3],href['wht',3],href['con',3],href['relsens',3],
-                                          href['sci',4],href['wht',4],href['con',4],href['relsens',4],
-                                          href['sci',5],href['wht',5],href['con',5],href['relsens',5]])
-    result = pf.diff.FITSDiff(newh, newhref,
-                              ignore_keywords = ['DATE','CAL_VER','CAL_VCS','CRDS_VER','CRDS_CTX'],
+    result = pf.diff.FITSDiff(h,
+                              href,
+                              ignore_hdus=['ASDF'],
+                              ignore_keywords=ignore_keywords,
                               rtol = 0.00001)
     assert result.identical, result.report()
 
@@ -81,10 +49,10 @@ def test_nrs_fs_multi_spec2_1(_bigdata):
     nb = _bigdata+'/pipelines/jw00023001001_01101_00001_NRS1_x1d_ref.fits'
     h = pf.open(na)
     href = pf.open(nb)
-    newh = pf.HDUList([h['primary'],h['extract1d',1],h['extract1d',2],h['extract1d',3],h['extract1d',4],h['extract1d',5]])
-    newhref = pf.HDUList([href['primary'],href['extract1d',1],href['extract1d',2],href['extract1d',3],href['extract1d',4],href['extract1d',5]])
-    result = pf.diff.FITSDiff(newh, newhref,
-                              ignore_keywords = ['DATE','CAL_VER','CAL_VCS','CRDS_VER','CRDS_CTX'],
+    result = pf.diff.FITSDiff(h,
+                              href,
+                              ignore_hdus=['ASDF'],
+                              ignore_keywords=ignore_keywords,
                               rtol = 0.00001)
     assert result.identical, result.report()
 

--- a/jwst/tests_nightly/general/pipelines/test_nrs_fs_multi_spec2_2.py
+++ b/jwst/tests_nightly/general/pipelines/test_nrs_fs_multi_spec2_2.py
@@ -11,9 +11,7 @@ pytestmark = [
 
 def test_nrs_fs_multi_spec2_2(_bigdata):
     """
-
     Regression test of calwebb_spec2 pipeline performed on NIRSpec fixed-slit data.
-
     """
     step = Spec2Pipeline()
     step.save_bsub = True
@@ -23,32 +21,16 @@ def test_nrs_fs_multi_spec2_2(_bigdata):
     step.extract_1d.save_results = True
     step.run(_bigdata+'/pipelines/jwtest1013001_01101_00001_NRS1_rate.fits')
 
+    ignore_keywords = ['DATE','CAL_VER','CAL_VCS','CRDS_VER','CRDS_CTX']
+
     na = 'jwtest1013001_01101_00001_NRS1_cal.fits'
     nb = _bigdata+'/pipelines/jwtest1013001_01101_00001_NRS1_cal_ref.fits'
     h = pf.open(na)
     href = pf.open(nb)
-    newh = pf.HDUList([h['primary'],h['sci',1],h['err',1],h['dq',1],h['relsens',1],h['wavelength',1],
-                                    h['pathloss_pointsource',1],h['wavelength_pointsource',1],
-                                    h['pathloss_uniformsource',1],h['wavelength_uniformsource',1],
-                                    h['sci',2],h['err',2],h['dq',2],h['relsens',2],h['wavelength',2],
-                                    h['pathloss_pointsource',2],h['wavelength_pointsource',2],
-                                    h['pathloss_uniformsource',2],h['wavelength_uniformsource',2],
-                                    h['sci',3],h['err',3],h['dq',3],h['relsens',3],h['wavelength',3],
-                                    h['sci',4],h['err',4],h['dq',4],h['relsens',4],h['wavelength',4],
-                                    h['pathloss_pointsource',4],h['wavelength_pointsource',4],
-                                    h['pathloss_uniformsource',4],h['wavelength_uniformsource',4]])
-    newhref = pf.HDUList([href['primary'],href['sci',1],href['err',1],href['dq',1],href['relsens',1],href['wavelength',1],
-                                          href['pathloss_pointsource',1],href['wavelength_pointsource',1],
-                                          href['pathloss_uniformsource',1],href['wavelength_uniformsource',1],
-                                          href['sci',2],href['err',2],href['dq',2],href['relsens',2],href['wavelength',2],
-                                          href['pathloss_pointsource',2],href['wavelength_pointsource',2],
-                                          href['pathloss_uniformsource',2],href['wavelength_uniformsource',2],
-                                          href['sci',3],href['err',3],href['dq',3],href['relsens',3],href['wavelength',3],
-                                          href['sci',4],href['err',4],href['dq',4],href['relsens',4],href['wavelength',4],
-                                          href['pathloss_pointsource',4],href['wavelength_pointsource',4],
-                                          href['pathloss_uniformsource',4],href['wavelength_uniformsource',4]])
-    result = pf.diff.FITSDiff(newh, newhref,
-                              ignore_keywords = ['DATE','CAL_VER','CAL_VCS','CRDS_VER','CRDS_CTX'],
+    result = pf.diff.FITSDiff(h,
+                              href,
+                              ignore_hdus=['ASDF'],
+                              ignore_keywords=ignore_keywords,
                               rtol = 0.00001)
     assert result.identical, result.report()
 
@@ -56,16 +38,10 @@ def test_nrs_fs_multi_spec2_2(_bigdata):
     nb = _bigdata+'/pipelines/jwtest1013001_01101_00001_NRS1_s2d_ref.fits'
     h = pf.open(na)
     href = pf.open(nb)
-    newh = pf.HDUList([h['primary'],h['sci',1],h['wht',1],h['con',1],h['relsens',1],
-                                    h['sci',2],h['wht',2],h['con',2],h['relsens',2],
-                                    h['sci',3],h['wht',3],h['con',3],h['relsens',3],
-                                    h['sci',4],h['wht',4],h['con',4],h['relsens',4]])
-    newhref = pf.HDUList([href['primary'],href['sci',1],href['wht',1],href['con',1],href['relsens',1],
-                                          href['sci',2],href['wht',2],href['con',2],href['relsens',2],
-                                          href['sci',3],href['wht',3],href['con',3],href['relsens',3],
-                                          href['sci',4],href['wht',4],href['con',4],href['relsens',4]])
-    result = pf.diff.FITSDiff(newh, newhref,
-                              ignore_keywords = ['DATE','CAL_VER','CAL_VCS','CRDS_VER','CRDS_CTX'],
+    result = pf.diff.FITSDiff(h,
+                              href,
+                              ignore_hdus=['ASDF'],
+                              ignore_keywords=ignore_keywords,
                               rtol = 0.00001)
     assert result.identical, result.report()
 
@@ -73,9 +49,9 @@ def test_nrs_fs_multi_spec2_2(_bigdata):
     nb = _bigdata+'/pipelines/jwtest1013001_01101_00001_NRS1_x1d_ref.fits'
     h = pf.open(na)
     href = pf.open(nb)
-    newh = pf.HDUList([h['primary'],h['extract1d',1],h['extract1d',2],h['extract1d',3],h['extract1d',4]])
-    newhref = pf.HDUList([href['primary'],href['extract1d',1],href['extract1d',2],href['extract1d',3],href['extract1d',4]])
-    result = pf.diff.FITSDiff(newh, newhref,
-                              ignore_keywords = ['DATE','CAL_VER','CAL_VCS','CRDS_VER','CRDS_CTX'],
+    result = pf.diff.FITSDiff(h,
+                              href,
+                              ignore_hdus=['ASDF'],
+                              ignore_keywords=ignore_keywords,
                               rtol = 0.00001)
     assert result.identical, result.report()

--- a/jwst/tests_nightly/general/pipelines/test_nrs_fs_multi_spec2_3.py
+++ b/jwst/tests_nightly/general/pipelines/test_nrs_fs_multi_spec2_3.py
@@ -11,10 +11,8 @@ pytestmark = [
 
 def test_nrs_fs_multi_spec2_3(_bigdata):
     """
-
     Regression test of calwebb_spec2 pipeline performed on NIRSpec fixed-slit data
     using the ALLSLITS subarray and detector NRS2.
-
     """
     step = Spec2Pipeline()
     step.save_bsub = True
@@ -24,18 +22,16 @@ def test_nrs_fs_multi_spec2_3(_bigdata):
     step.extract_1d.save_results = True
     step.run(_bigdata+'/pipelines/jw84600002001_02101_00001_nrs2_rate.fits')
 
+    ignore_keywords = ['DATE','CAL_VER','CAL_VCS','CRDS_VER','CRDS_CTX']
+
     na = 'jw84600002001_02101_00001_nrs2_cal.fits'
     nb = _bigdata+'/pipelines/jw84600002001_02101_00001_nrs2_cal_ref.fits'
     h = pf.open(na)
     href = pf.open(nb)
-    newh = pf.HDUList([h['primary'],h['sci',1],h['err',1],h['dq',1],h['relsens',1],h['wavelength',1],
-                                    h['pathloss_pointsource',1],h['wavelength_pointsource',1],
-                                    h['pathloss_uniformsource',1],h['wavelength_uniformsource',1]])
-    newhref = pf.HDUList([href['primary'],href['sci',1],href['err',1],href['dq',1],href['relsens',1],href['wavelength',1],
-                                          href['pathloss_pointsource',1],href['wavelength_pointsource',1],
-                                          href['pathloss_uniformsource',1],href['wavelength_uniformsource',1]])
-    result = pf.diff.FITSDiff(newh, newhref,
-                              ignore_keywords = ['DATE','CAL_VER','CAL_VCS','CRDS_VER','CRDS_CTX'],
+    result = pf.diff.FITSDiff(h,
+                              href,
+                              ignore_hdus=['ASDF'],
+                              ignore_keywords=ignore_keywords,
                               rtol = 0.00001)
     assert result.identical, result.report()
 
@@ -43,10 +39,10 @@ def test_nrs_fs_multi_spec2_3(_bigdata):
     nb = _bigdata+'/pipelines/jw84600002001_02101_00001_nrs2_s2d_ref.fits'
     h = pf.open(na)
     href = pf.open(nb)
-    newh = pf.HDUList([h['primary'],h['sci',1],h['wht',1],h['con',1],h['relsens',1]])
-    newhref = pf.HDUList([href['primary'],href['sci',1],href['wht',1],href['con',1],href['relsens',1]])
-    result = pf.diff.FITSDiff(newh, newhref,
-                              ignore_keywords = ['DATE','CAL_VER','CAL_VCS','CRDS_VER','CRDS_CTX'],
+    result = pf.diff.FITSDiff(h,
+                              href,
+                              ignore_hdus=['ASDF'],
+                              ignore_keywords=ignore_keywords,
                               rtol = 0.00001)
     assert result.identical, result.report()
 
@@ -54,9 +50,9 @@ def test_nrs_fs_multi_spec2_3(_bigdata):
     nb = _bigdata+'/pipelines/jw84600002001_02101_00001_nrs2_x1d_ref.fits'
     h = pf.open(na)
     href = pf.open(nb)
-    newh = pf.HDUList([h['primary'],h['extract1d',1]])
-    newhref = pf.HDUList([href['primary'],href['extract1d',1]])
-    result = pf.diff.FITSDiff(newh, newhref,
-                              ignore_keywords = ['DATE','CAL_VER','CAL_VCS','CRDS_VER','CRDS_CTX'],
+    result = pf.diff.FITSDiff(h,
+                              href,
+                              ignore_hdus=['ASDF'],
+                              ignore_keywords=ignore_keywords,
                               rtol = 0.00001)
     assert result.identical, result.report()

--- a/jwst/tests_nightly/general/pipelines/test_nrs_fs_single_spec2.py
+++ b/jwst/tests_nightly/general/pipelines/test_nrs_fs_single_spec2.py
@@ -11,10 +11,8 @@ pytestmark = [
 
 def test_nrs_fs_single_spec2(_bigdata):
     """
-
     Regression test of calwebb_spec2 pipeline performed on NIRSpec fixed-slit data
     that uses a single-slit subarray (S200B1).
-
     """
     step = Spec2Pipeline()
     step.save_bsub = True
@@ -24,18 +22,16 @@ def test_nrs_fs_single_spec2(_bigdata):
     step.extract_1d.save_results = True
     step.run(_bigdata+'/pipelines/jw84600002001_02101_00001_nrs2_rate.fits')
 
+    ignore_keywords = ['DATE','CAL_VER','CAL_VCS','CRDS_VER','CRDS_CTX']
+
     na = 'jw84600002001_02101_00001_nrs2_cal.fits'
     nb = _bigdata+'/pipelines/jw84600002001_02101_00001_nrs2_cal_ref.fits'
     h = pf.open(na)
     href = pf.open(nb)
-    newh = pf.HDUList([h['primary'],h['sci',1],h['err',1],h['dq',1],h['relsens',1],h['wavelength',1],
-                                    h['pathloss_pointsource',1],h['wavelength_pointsource',1],
-                                    h['pathloss_uniformsource',1],h['wavelength_uniformsource',1]])
-    newhref = pf.HDUList([href['primary'],href['sci',1],href['err',1],href['dq',1],href['relsens',1],href['wavelength',1],
-                                          href['pathloss_pointsource',1],href['wavelength_pointsource',1],
-                                          href['pathloss_uniformsource',1],href['wavelength_uniformsource',1]])
-    result = pf.diff.FITSDiff(newh, newhref,
-                              ignore_keywords = ['DATE','CAL_VER','CAL_VCS','CRDS_VER','CRDS_CTX'],
+    result = pf.diff.FITSDiff(h,
+                              href,
+                              ignore_hdus=['ASDF'],
+                              ignore_keywords=ignore_keywords,
                               rtol = 0.00001)
     assert result.identical, result.report()
 
@@ -43,10 +39,10 @@ def test_nrs_fs_single_spec2(_bigdata):
     nb = _bigdata+'/pipelines/jw84600002001_02101_00001_nrs2_s2d_ref.fits'
     h = pf.open(na)
     href = pf.open(nb)
-    newh = pf.HDUList([h['primary'],h['sci',1],h['wht',1],h['con',1],h['relsens',1]])
-    newhref = pf.HDUList([href['primary'],href['sci',1],href['wht',1],href['con',1],href['relsens',1]])
-    result = pf.diff.FITSDiff(newh, newhref,
-                              ignore_keywords = ['DATE','CAL_VER','CAL_VCS','CRDS_VER','CRDS_CTX'],
+    result = pf.diff.FITSDiff(h,
+                              href,
+                              ignore_hdus=['ASDF'],
+                              ignore_keywords=ignore_keywords,
                               rtol = 0.00001)
     assert result.identical, result.report()
 
@@ -54,9 +50,9 @@ def test_nrs_fs_single_spec2(_bigdata):
     nb = _bigdata+'/pipelines/jw84600002001_02101_00001_nrs2_x1d_ref.fits'
     h = pf.open(na)
     href = pf.open(nb)
-    newh = pf.HDUList([h['primary'],h['extract1d',1]])
-    newhref = pf.HDUList([href['primary'],href['extract1d',1]])
-    result = pf.diff.FITSDiff(newh, newhref,
-                              ignore_keywords = ['DATE','CAL_VER','CAL_VCS','CRDS_VER','CRDS_CTX'],
+    result = pf.diff.FITSDiff(h,
+                              href,
+                              ignore_hdus=['ASDF'],
+                              ignore_keywords=ignore_keywords,
                               rtol = 0.00001)
     assert result.identical, result.report()

--- a/jwst/tests_nightly/general/pipelines/test_nrs_msa_spec2.py
+++ b/jwst/tests_nightly/general/pipelines/test_nrs_msa_spec2.py
@@ -12,9 +12,7 @@ pytestmark = [
 
 def test_nrs_msa_spec2(_bigdata):
     """
-
     Regression test of calwebb_spec2 pipeline performed on NIRSpec MSA data.
-
     """
     input = 'F170LP-G235M_MOS_observation-6-c0e0_001_DN_NRS1_mod.fits'
 
@@ -29,16 +27,18 @@ def test_nrs_msa_spec2(_bigdata):
     step.extract_1d.bkg_order = 0
     step.run(os.path.join(_bigdata, 'pipelines', input))
 
+    ignore_keywords = ['DATE','CAL_VER','CAL_VCS','CRDS_VER','CRDS_CTX']
+
     # compare _cal files
     output = 'F170LP-G235M_MOS_observation-6-c0e0_001_DN_NRS1_mod_cal.fits'
     nbname = 'f170lp-g235m_mos_observation-6-c0e0_001_dn_nrs1_mod_cal_ref.fits'
     nb = os.path.join(_bigdata,'pipelines', nbname)
     h = pf.open(output)
     href = pf.open(nb)
-    h = h[:-1]
-    href = href[:-1]
-    result = pf.diff.FITSDiff(h, href,
-                              ignore_keywords = ['DATE','CAL_VER','CAL_VCS','CRDS_VER','CRDS_CTX','FILENAME'],
+    result = pf.diff.FITSDiff(h,
+                              href,
+                              ignore_hdus=['ASDF'],
+                              ignore_keywords=ignore_keywords,
                               rtol = 0.00001)
     assert result.identical, result.report()
 
@@ -48,9 +48,9 @@ def test_nrs_msa_spec2(_bigdata):
     nb = os.path.join(_bigdata, 'pipelines', nbname)
     h = pf.open(output2)
     href = pf.open(nb)
-    h = h[:-1]
-    href = href[:-1]
-    result = pf.diff.FITSDiff(h, href,
-                              ignore_keywords = ['DATE','CAL_VER','CAL_VCS','CRDS_VER','CRDS_CTX','FILENAME'],
+    result = pf.diff.FITSDiff(h,
+                              href,
+                              ignore_hdus=['ASDF'],
+                              ignore_keywords=ignore_keywords,
                               rtol = 0.00001)
     assert result.identical, result.report()

--- a/jwst/tests_nightly/general/pipelines/test_nrs_msa_spec2b.py
+++ b/jwst/tests_nightly/general/pipelines/test_nrs_msa_spec2b.py
@@ -13,10 +13,8 @@ pytestmark = [
 
 def test_nrs_msa_spec2b(_bigdata):
     """
-
     Regression test of calwebb_spec2 pipeline performed on NIRSpec MSA data,
     including barshadow correction.
-
     """
     file_in = os.path.join(_bigdata, 'pipelines',
                        'jw95065_nrs_msaspec_barshadow.fits')
@@ -31,36 +29,30 @@ def test_nrs_msa_spec2b(_bigdata):
     step.extract_1d.save_results = True
     step.run(file_in)
 
+    ignore_keywords = ['DATE','CAL_VER','CAL_VCS','CRDS_VER','CRDS_CTX']
+
     # compare _cal file
     na = 'jw95065_nrs_msaspec_barshadow_cal.fits'
     nb = os.path.join(_bigdata,'pipelines',
                       'jw95065_nrs_msaspec_barshadow_cal_ref.fits')
     h = pf.open(na)
     href = pf.open(nb)
-    h = h[:-1]
-    href = href[:-1]
-    result = pf.diff.FITSDiff(h, href,
-                              ignore_keywords = ['DATE','CAL_VER','CAL_VCS','CRDS_VER','CRDS_CTX'],
+    result = pf.diff.FITSDiff(h,
+                              href,
+                              ignore_hdus=['ASDF'],
+                              ignore_keywords=ignore_keywords,
                               rtol = 0.00001)
     assert result.identical, result.report()
 
-    #na = 'f170lp-g235m_mos_observation-6-c0e0_001_dn_nrs1_mod_s2d.fits'
-    #nb = _bigdata+'/pipelines/F170LP-G235M_MOS_observation-6-c0e0_001_DN_NRS1_s2d_ref.fits'
-    #h = pf.open(na)
-    #href = pf.open(nb)
-    #newh = pf.HDUList([h['primary'],h['sci',1],h['wht',1],h['con',1],h['relsens',1],
-    #                                h['sci',2],h['wht',2],h['con',2],h['relsens',2],
-    #                                h['sci',3],h['wht',3],h['con',3],h['relsens',3],
-    #                                h['sci',4],h['wht',4],h['con',4],h['relsens',4],
-    #                                h['sci',5],h['wht',5],h['con',5],h['relsens',5]])
-    #newhref = pf.HDUList([href['primary'],href['sci',1],href['wht',1],href['con',1],href['relsens',1],
-    #                                      href['sci',2],href['wht',2],href['con',2],href['relsens',2],
-    #                                      href['sci',3],href['wht',3],href['con',3],href['relsens',3],
-    #                                      href['sci',4],href['wht',4],href['con',4],href['relsens',4],
-    #                                      href['sci',5],href['wht',5],href['con',5],href['relsens',5]])
-    #result = pf.diff.FITSDiff(newh, newhref,
-    #                          ignore_keywords = ['DATE','CAL_VER','CAL_VCS','CRDS_VER','CRDS_CTX'],
-    #                          rtol = 0.00001)
+    na = 'f170lp-g235m_mos_observation-6-c0e0_001_dn_nrs1_mod_s2d.fits'
+    nb = _bigdata+'/pipelines/F170LP-G235M_MOS_observation-6-c0e0_001_DN_NRS1_s2d_ref.fits'
+    h = pf.open(na)
+    href = pf.open(nb)
+    result = pf.diff.FITSDiff(h,
+                              href,
+                              ignore_hdus=['ASDF'],
+                              ignore_keywords=ignore_keywords,
+                              rtol = 0.00001)
     assert result.identical, result.report()
 
     # compare _x1d file
@@ -69,9 +61,9 @@ def test_nrs_msa_spec2b(_bigdata):
                       'jw95065_nrs_msaspec_barshadow_x1d_ref.fits')
     h = pf.open(na)
     href = pf.open(nb)
-    h = h[:-1]
-    href = href[:-1]
-    result = pf.diff.FITSDiff(h, href,
-                              ignore_keywords = ['DATE','CAL_VER','CAL_VCS','CRDS_VER','CRDS_CTX'],
+    result = pf.diff.FITSDiff(h,
+                              href,
+                              ignore_hdus=['ASDF'],
+                              ignore_keywords=ignore_keywords,
                               rtol = 0.00001)
     assert result.identical, result.report()


### PR DESCRIPTION
- Remove unnecessary, unused metadata from `ModelContainer` schema
- Remove unnecessary, unused metadata from level 3 product schema
- move population of association metadata up into the `ResampleStep` classes
- update S_REGION correctly for `ResampleSpecStep` outputs