### PR TITLE
Fix AssociationPool.write to be compatible with jsviewer

### DIFF
--- a/jwst/associations/__init__.py
+++ b/jwst/associations/__init__.py
@@ -4,7 +4,7 @@ from os.path import (
     join
 )
 
-__version__ = '0.9.20'
+__version__ = '0.9.19'
 
 
 # Utility

--- a/jwst/associations/__init__.py
+++ b/jwst/associations/__init__.py
@@ -4,7 +4,7 @@ from os.path import (
     join
 )
 
-__version__ = '0.9.18'
+__version__ = '0.9.20'
 
 
 # Utility

--- a/jwst/associations/pool.py
+++ b/jwst/associations/pool.py
@@ -55,9 +55,18 @@ class AssociationPool(Table):
         """
         delimiter = kwargs.pop('delimiter', DEFAULT_DELIMITER)
         format = kwargs.pop('format', DEFAULT_FORMAT)
-        super(AssociationPool, self).write(
-            *args, delimiter=delimiter, format=format, **kwargs
-        )
+        try:
+            super(AssociationPool, self).write(
+                *args, delimiter=delimiter, format=format, **kwargs
+            )
+        except TypeError:
+            # Most likely caused by the actual `write` called
+            # does not handle `delimiter`. `jsviewer` is one
+            # such format.
+            # So, try again without a delimiter.
+            super(AssociationPool, self).write(
+                *args, format=format, **kwargs
+            )
 
 
 class _ConvertToStr(dict):


### PR DESCRIPTION
`jsviewer` does not take delimiters as keyword arguments, which `AssociationPool` forces. Allow this case to occur cleanly.